### PR TITLE
Run tests against multiple airflow versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+        group: [ 1, 2, 3, 4, 5, 6 ]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -133,7 +133,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s test -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s unit_test -- --splits 6 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:
@@ -161,6 +161,72 @@ jobs:
       AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: True
       AIRFLOW__CORE__ENABLE_XCOM_PICKLING: True
       AIRFLOW_VAR_FOO: templated_file_name
+
+  Run-Integration-tests:
+      strategy:
+        fail-fast: false
+        matrix:
+          group: [ 1, 2, 3, 4, 5, 6 ]
+          airflow: ["2.2.5", "2.3"]
+      runs-on: ubuntu-latest
+      services:
+        postgres:
+          # Docker Hub image
+          image: dimberman/pagila-test
+          env:
+            POSTGRES_PASSWORD: postgres
+          # Set health checks to wait until postgres has started
+          options: >-
+            --health-cmd pg_isready
+            --health-interval 10s
+            --health-timeout 5s
+            --health-retries 5
+          ports:
+            - 5432:5432
+      steps:
+        - uses: actions/checkout@v3
+        - uses: actions/setup-python@v3
+          with:
+            python-version: '3.8'
+            architecture: 'x64'
+        - uses: actions/cache@v3
+          with:
+            path: |
+              ~/.cache/pip
+              .nox
+            key: ${{ runner.os }}-${{ matrix.airflow }}-${{ hashFiles('pyproject.toml') }}
+        - run: cat .github/ci-test-connections.yaml > test-connections.yaml
+        - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+        - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
+        - run: pip3 install nox
+        - run: nox -s "integration_test-3.8(airflow='${{ matrix.airflow }}')" -- --splits 6 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+        - name: Upload coverage
+          uses: actions/upload-artifact@v2
+          with:
+            name: coverage${{ matrix.group }}
+            path: .coverage
+      env:
+        AWS_BUCKET: tmp9
+        GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
+        GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
+        GOOGLE_BUCKET: dag-authoring
+        POSTGRES_HOST: postgres
+        POSTGRES_PORT: 5432
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AIRFLOW__ASTRO__SQL_SCHEMA: astroflow_ci
+        SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
+        SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+        SNOWFLAKE_SCHEMA: ASTROFLOW_CI
+        SNOWFLAKE_DATABASE: SANDBOX
+        SNOWFLAKE_WAREHOUSE: DEMO
+        SNOWFLAKE_HOST: https://gp21411.us-east-1.snowflakecomputing.com
+        SNOWFLAKE_ACCOUNT: gp21411
+        SNOWFLAKE_REGION: us-east-1
+        SNOWFLAKE_ROLE: AIRFLOW_TEST_USER
+        AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: True
+        AIRFLOW__CORE__ENABLE_XCOM_PICKLING: True
+        AIRFLOW_VAR_FOO: templated_file_name
 
   Code-Coverage:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [ 1, 2, 3, 4, 5, 6 ]
+        group: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
+        airflow: ["2.2.5", "2.3"]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -128,12 +129,12 @@ jobs:
           path: |
             ~/.cache/pip
             .nox
-          key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-${{ matrix.airflow }}-${{ hashFiles('pyproject.toml') }}
       - run: cat .github/ci-test-connections.yaml > test-connections.yaml
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s unit_test -- --splits 6 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='${{ matrix.airflow }}')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:
@@ -161,72 +162,6 @@ jobs:
       AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: True
       AIRFLOW__CORE__ENABLE_XCOM_PICKLING: True
       AIRFLOW_VAR_FOO: templated_file_name
-
-  Run-Integration-tests:
-      strategy:
-        fail-fast: false
-        matrix:
-          group: [ 1, 2, 3, 4, 5, 6 ]
-          airflow: ["2.2.5", "2.3"]
-      runs-on: ubuntu-latest
-      services:
-        postgres:
-          # Docker Hub image
-          image: dimberman/pagila-test
-          env:
-            POSTGRES_PASSWORD: postgres
-          # Set health checks to wait until postgres has started
-          options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
-          ports:
-            - 5432:5432
-      steps:
-        - uses: actions/checkout@v3
-        - uses: actions/setup-python@v3
-          with:
-            python-version: '3.8'
-            architecture: 'x64'
-        - uses: actions/cache@v3
-          with:
-            path: |
-              ~/.cache/pip
-              .nox
-            key: ${{ runner.os }}-${{ matrix.airflow }}-${{ hashFiles('pyproject.toml') }}
-        - run: cat .github/ci-test-connections.yaml > test-connections.yaml
-        - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
-        - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
-        - run: pip3 install nox
-        - run: nox -s "integration_test-3.8(airflow='${{ matrix.airflow }}')" -- --splits 6 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
-        - name: Upload coverage
-          uses: actions/upload-artifact@v2
-          with:
-            name: coverage${{ matrix.group }}
-            path: .coverage
-      env:
-        AWS_BUCKET: tmp9
-        GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
-        GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
-        GOOGLE_BUCKET: dag-authoring
-        POSTGRES_HOST: postgres
-        POSTGRES_PORT: 5432
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AIRFLOW__ASTRO__SQL_SCHEMA: astroflow_ci
-        SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
-        SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-        SNOWFLAKE_SCHEMA: ASTROFLOW_CI
-        SNOWFLAKE_DATABASE: SANDBOX
-        SNOWFLAKE_WAREHOUSE: DEMO
-        SNOWFLAKE_HOST: https://gp21411.us-east-1.snowflakecomputing.com
-        SNOWFLAKE_ACCOUNT: gp21411
-        SNOWFLAKE_REGION: us-east-1
-        SNOWFLAKE_ROLE: AIRFLOW_TEST_USER
-        AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: True
-        AIRFLOW__CORE__ENABLE_XCOM_PICKLING: True
-        AIRFLOW_VAR_FOO: templated_file_name
 
   Code-Coverage:
     needs:

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,33 +21,8 @@ def dev(session: nox.Session) -> None:
 
 
 @nox.session(python=["3.7", "3.8", "3.9"])
-def unit_test(session: nox.Session) -> None:
-    """Run unit tests."""
-    session.install("-e", ".[all]")
-    session.install("-e", ".[tests]")
-    # Log all the installed dependencies
-    session.log("Installed Dependencies:")
-    session.run("pip3", "freeze")
-    session.run("airflow", "db", "init")
-    session.run("pytest", "-k", "not integration", *session.posargs)
-
-
-@nox.session(python=["3.7", "3.8", "3.9"])
 @nox.parametrize("airflow", ["2.2.5", "2.3"])
-def integration_test(session: nox.Session, airflow) -> None:
-    """Run integration tests."""
-    session.install(f"apache-airflow=={airflow}")
-    session.install("-e", ".[all]")
-    session.install("-e", ".[tests]")
-    # Log all the installed dependencies
-    session.log("Installed Dependencies:")
-    session.run("pip3", "freeze")
-    session.run("airflow", "db", "init")
-    session.run("pytest", "-k", "integration", *session.posargs)
-
-
-@nox.session(python=["3.7", "3.8", "3.9"])
-def test(session: nox.Session) -> None:
+def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
     session.install("-e", ".[all]")
     session.install("-e", ".[tests]")

--- a/noxfile.py
+++ b/noxfile.py
@@ -21,8 +21,34 @@ def dev(session: nox.Session) -> None:
 
 
 @nox.session(python=["3.7", "3.8", "3.9"])
-def test(session: nox.Session) -> None:
+def unit_test(session: nox.Session) -> None:
     """Run unit tests."""
+    session.install("-e", ".[all]")
+    session.install("-e", ".[tests]")
+    # Log all the installed dependencies
+    session.log("Installed Dependencies:")
+    session.run("pip3", "freeze")
+    session.run("airflow", "db", "init")
+    session.run("pytest", "-k", "not integration", *session.posargs)
+
+
+@nox.session(python=["3.7", "3.8", "3.9"])
+@nox.parametrize("airflow", ["2.2.5", "2.3"])
+def integration_test(session: nox.Session, airflow) -> None:
+    """Run integration tests."""
+    session.install(f"apache-airflow=={airflow}")
+    session.install("-e", ".[all]")
+    session.install("-e", ".[tests]")
+    # Log all the installed dependencies
+    session.log("Installed Dependencies:")
+    session.run("pip3", "freeze")
+    session.run("airflow", "db", "init")
+    session.run("pytest", "-k", "integration", *session.posargs)
+
+
+@nox.session(python=["3.7", "3.8", "3.9"])
+def test(session: nox.Session) -> None:
+    """Run both unit and integration tests."""
     session.install("-e", ".[all]")
     session.install("-e", ".[tests]")
     # Log all the installed dependencies


### PR DESCRIPTION
We want to make sure that Astro SDK continues working with Airflow 2.2.5 and Airflow 2.3 - so this commit adds this capability in nox.

A problem I foresee is some tests failing intermittently as some of our "integration tests" don't have unique ids for tables, dataset which means there might be times when an integration test is running in 2.2.5 which deletes a resource that is being used by same test running for 2.3.

One "quick" solution is to run them sequentially but that will increase total test time. A better solution will be to fix the tests but that will take time.