### PR TITLE
CI: Get list of the slowest 30 test durations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ provider_info = "astro.__init__:get_provider_info"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["--durations=30 --durations-min=1.0"]
+addopts = ["--durations=30", "--durations-min=1.0"]
 env_files = [".env"]
 testpaths = ["tests"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ provider_info = "astro.__init__:get_provider_info"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = ["--durations=30", "--durations-min=1.0"]
+addopts = "--durations=30 --durations-min=1.0"
 env_files = [".env"]
 testpaths = ["tests"]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ provider_info = "astro.__init__:get_provider_info"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
+addopts = ["--durations=30 --durations-min=1.0"]
 env_files = [".env"]
 testpaths = ["tests"]
 markers = [


### PR DESCRIPTION
Uses https://docs.pytest.org/en/latest/how-to/usage.html#profiling-test-execution-duration to get a list of slowest 30 tests for which the durations is over 1.0s long.

This is a small change but will help identify if a test takes too long. Found a need to do that while working on https://github.com/astro-projects/astro/pull/367 and https://github.com/astro-projects/astro/pull/370