### PR TITLE
Update the Repo URL after transfer to Astronomer org

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,7 +23,7 @@ Add any other context about the feature request here.
 **Acceptance Criteria**
 
 - [ ] All checks and tests in the CI should pass
-- [ ] Unit tests (90% code coverage or more, [once available](https://github.com/astro-projects/astro/issues/191))
+- [ ] Unit tests (90% code coverage or more, [once available](https://github.com/astronomer/astro-sdk/issues/191))
 - [ ] Integration tests (if the feature relates to a new database or external service)
 - [ ] Example DAG
 - [ ] Docstrings in [reStructuredText](https://peps.python.org/pep-0287/) for each of  methods, classes, functions and module-level attributes (including Example DAG on how it should be used)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 [![License](https://img.shields.io/pypi/l/astro-sdk-python.svg)](https://pypi.org/pypi/astro-sdk-python)
 [![Development Status](https://img.shields.io/pypi/status/astro-sdk-python.svg)](https://pypi.org/pypi/astro-sdk-python)
 [![PyPI downloads](https://img.shields.io/pypi/dm/astro-sdk-python.svg)](https://pypistats.org/packages/astro-sdk-python)
-[![Contributors](https://img.shields.io/github/contributors/astro-projects/astro)](https://github.com/astro-projects/astro)
-[![Commit activity](https://img.shields.io/github/commit-activity/m/astro-projects/astro)](https://github.com/astro-projects/astro)
-[![CI](https://github.com/astro-projects/astro/actions/workflows/ci.yaml/badge.svg)](https://github.com/astro-projects/astro)
+[![Contributors](https://img.shields.io/github/contributors/astro-projects/astro)](https://github.com/astronomer/astro-sdk)
+[![Commit activity](https://img.shields.io/github/commit-activity/m/astro-projects/astro)](https://github.com/astronomer/astro-sdk)
+[![CI](https://github.com/astronomer/astro-sdk/actions/workflows/ci.yaml/badge.svg)](https://github.com/astronomer/astro-sdk)
 [![codecov](https://codecov.io/gh/astro-projects/astro/branch/main/graph/badge.svg?token=MI4SSE50Q6)](https://codecov.io/gh/astro-projects/astro)
 
 **astro** allows rapid and clean development of {Extract, Load, Transform} workflows using Python.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,92 +3,92 @@
 ## 0.8.2
 
 Bug fix:
-* Support dataframes from different databases in dataframe operator [#325](https://github.com/astro-projects/astro/pull/325)
+* Support dataframes from different databases in dataframe operator [#325](https://github.com/astronomer/astro-sdk/pull/325)
 
 Enhancements:
-* Add integration testcase for `SqlDecoratedOperator` to test execution of Raw SQL [#316](https://github.com/astro-projects/astro/pull/316)
+* Add integration testcase for `SqlDecoratedOperator` to test execution of Raw SQL [#316](https://github.com/astronomer/astro-sdk/pull/316)
 
 ## 0.8.1
 
 Bug fix:
-* Snowflake transform without `input_table` [#319](https://github.com/astro-projects/astro/issues/319)
+* Snowflake transform without `input_table` [#319](https://github.com/astronomer/astro-sdk/issues/319)
 
 
 ## 0.8.0
 
 Feature:
 
-*`load_file` support for nested NDJSON files [#257](https://github.com/astro-projects/astro/issues/257)
+*`load_file` support for nested NDJSON files [#257](https://github.com/astronomer/astro-sdk/issues/257)
 
 Breaking change:
-* `aql.dataframe` switches the capitalization to lowercase by default. This behaviour can be changed by using `identifiers_as_lower` [#154](https://github.com/astro-projects/astro/issues/154)
+* `aql.dataframe` switches the capitalization to lowercase by default. This behaviour can be changed by using `identifiers_as_lower` [#154](https://github.com/astronomer/astro-sdk/issues/154)
 
 Documentation:
-* Fix commands in README.md [#242](https://github.com/astro-projects/astro/issues/242)
+* Fix commands in README.md [#242](https://github.com/astronomer/astro-sdk/issues/242)
 * Add scripts to auto-generate Sphinx documentation
 
 Enhancements:
 * Improve type hints coverage
-* Improve Amazon S3 example DAG, so it does not rely on pre-populated data [#293](https://github.com/astro-projects/astro/issues/293)
-* Add example DAG to load/export from BigQuery [#265](https://github.com/astro-projects/astro/issues/265)
-* Fix usages of mutable default args [#267](https://github.com/astro-projects/astro/issues/267)
-* Enable DeepSource validation [#299](https://github.com/astro-projects/astro/issues/299)
+* Improve Amazon S3 example DAG, so it does not rely on pre-populated data [#293](https://github.com/astronomer/astro-sdk/issues/293)
+* Add example DAG to load/export from BigQuery [#265](https://github.com/astronomer/astro-sdk/issues/265)
+* Fix usages of mutable default args [#267](https://github.com/astronomer/astro-sdk/issues/267)
+* Enable DeepSource validation [#299](https://github.com/astronomer/astro-sdk/issues/299)
 * Improve code quality and coverage
 
 Bug fixes:
-* Support `gcpbigquery` connections [#294](https://github.com/astro-projects/astro/issues/294)
-* Support `params` argument in `aql.render` to override SQL Jinja template values [#254](https://github.com/astro-projects/astro/issues/254)
-* Fix `aql.dataframe` when table arg is absent [#259](https://github.com/astro-projects/astro/issues/259)
+* Support `gcpbigquery` connections [#294](https://github.com/astronomer/astro-sdk/issues/294)
+* Support `params` argument in `aql.render` to override SQL Jinja template values [#254](https://github.com/astronomer/astro-sdk/issues/254)
+* Fix `aql.dataframe` when table arg is absent [#259](https://github.com/astronomer/astro-sdk/issues/259)
 
 Others:
-* Refactor integration tests, so they can run across all supported databases [#229](https://github.com/astro-projects/astro/issues/229), [#234](https://github.com/astro-projects/astro/issues/234), [#235](https://github.com/astro-projects/astro/issues/235), [#236](https://github.com/astro-projects/astro/issues/236), [#206](https://github.com/astro-projects/astro/issues/206), [#217](https://github.com/astro-projects/astro/issues/217)
+* Refactor integration tests, so they can run across all supported databases [#229](https://github.com/astronomer/astro-sdk/issues/229), [#234](https://github.com/astronomer/astro-sdk/issues/234), [#235](https://github.com/astronomer/astro-sdk/issues/235), [#236](https://github.com/astronomer/astro-sdk/issues/236), [#206](https://github.com/astronomer/astro-sdk/issues/206), [#217](https://github.com/astronomer/astro-sdk/issues/217)
 
 
 ## 0.7.0
 
 Feature:
-* `load_file` to a Pandas dataframe, without SQL database dependencies [#77](https://github.com/astro-projects/astro/issues/77)
+* `load_file` to a Pandas dataframe, without SQL database dependencies [#77](https://github.com/astronomer/astro-sdk/issues/77)
 
 Documentation:
-* Simplify README [#101](https://github.com/astro-projects/astro/issues/101)
-* Add Release Guidelines [#160](https://github.com/astro-projects/astro/pull/160)
-* Add Code of Conduct [#101](https://github.com/astro-projects/astro/pull/101)
-* Add Contribution Guidelines [#101](https://github.com/astro-projects/astro/pull/101)
+* Simplify README [#101](https://github.com/astronomer/astro-sdk/issues/101)
+* Add Release Guidelines [#160](https://github.com/astronomer/astro-sdk/pull/160)
+* Add Code of Conduct [#101](https://github.com/astronomer/astro-sdk/pull/101)
+* Add Contribution Guidelines [#101](https://github.com/astronomer/astro-sdk/pull/101)
 
 Enhancements:
-* Add SQLite example [#149](https://github.com/astro-projects/astro/issues/149)
-* Allow customization of `task_id` when using `dataframe` [#126](https://github.com/astro-projects/astro/issues/126)
-* Use standard AWS environment variables, as opposed to `AIRFLOW__ASTRO__CONN_AWS_DEFAULT` [#175](https://github.com/astro-projects/astro/issues/175)
+* Add SQLite example [#149](https://github.com/astronomer/astro-sdk/issues/149)
+* Allow customization of `task_id` when using `dataframe` [#126](https://github.com/astronomer/astro-sdk/issues/126)
+* Use standard AWS environment variables, as opposed to `AIRFLOW__ASTRO__CONN_AWS_DEFAULT` [#175](https://github.com/astronomer/astro-sdk/issues/175)
 
 Bug fixes:
-* Fix `merge` `XComArg` support [#183](https://github.com/astro-projects/astro/issues/183)
+* Fix `merge` `XComArg` support [#183](https://github.com/astronomer/astro-sdk/issues/183)
 * Fixes to `load_file`:
-   * `file_conn_id` support [#137](https://github.com/astro-projects/astro/issues/137)
-   * `sqlite_default` connection support [#158](https://github.com/astro-projects/astro/issues/158)
+   * `file_conn_id` support [#137](https://github.com/astronomer/astro-sdk/issues/137)
+   * `sqlite_default` connection support [#158](https://github.com/astronomer/astro-sdk/issues/158)
 * Fixes to `render`:
-   * `conn_id` are optional in SQL files [#117](https://github.com/astro-projects/astro/issues/117)
-   * `database` and `schema` are optional in SQL files [#124](https://github.com/astro-projects/astro/issues/124)
-* Fix `transform`, so it works with SQLite [#159](https://github.com/astro-projects/astro/issues/159)
+   * `conn_id` are optional in SQL files [#117](https://github.com/astronomer/astro-sdk/issues/117)
+   * `database` and `schema` are optional in SQL files [#124](https://github.com/astronomer/astro-sdk/issues/124)
+* Fix `transform`, so it works with SQLite [#159](https://github.com/astronomer/astro-sdk/issues/159)
 
 Others:
-* Remove `transform_file` [#162](https://github.com/astro-projects/astro/pull/162)
-* Improve integration tests coverage [#174](https://github.com/astro-projects/astro/pull/174)
+* Remove `transform_file` [#162](https://github.com/astronomer/astro-sdk/pull/162)
+* Improve integration tests coverage [#174](https://github.com/astronomer/astro-sdk/pull/174)
 
 ## 0.6.0
 
 Features:
-* Support SQLite [#86](https://github.com/astro-projects/astro/issues/86)
-* Support users who can't create schemas [#121](https://github.com/astro-projects/astro/issues/121)
-* Ability to install optional dependencies (amazon, google, snowflake) [#82](https://github.com/astro-projects/astro/issues/82)
+* Support SQLite [#86](https://github.com/astronomer/astro-sdk/issues/86)
+* Support users who can't create schemas [#121](https://github.com/astronomer/astro-sdk/issues/121)
+* Ability to install optional dependencies (amazon, google, snowflake) [#82](https://github.com/astronomer/astro-sdk/issues/82)
 
 Enhancements:
-* Change `render` so it creates a DAG as opposed to a TaskGroup [#143](https://github.com/astro-projects/astro/issues/143)
-* Allow users to specify a custom version of `snowflake_sqlalchemy` [#127](https://github.com/astro-projects/astro/issues/127)
+* Change `render` so it creates a DAG as opposed to a TaskGroup [#143](https://github.com/astronomer/astro-sdk/issues/143)
+* Allow users to specify a custom version of `snowflake_sqlalchemy` [#127](https://github.com/astronomer/astro-sdk/issues/127)
 
 Bug fixes:
-* Fix tasks created with `dataframe` so they inherit connection id [#134](https://github.com/astro-projects/astro/issues/134)
-* Fix snowflake URI issues [#102](https://github.com/astro-projects/astro/issues/102)
+* Fix tasks created with `dataframe` so they inherit connection id [#134](https://github.com/astronomer/astro-sdk/issues/134)
+* Fix snowflake URI issues [#102](https://github.com/astronomer/astro-sdk/issues/102)
 
 Others:
-* Run example DAGs as part of the CI [#114](https://github.com/astro-projects/astro/issues/114)
-* Benchmark tooling to validate performance of `load_file` [#105](https://github.com/astro-projects/astro/issues/105)
+* Run example DAGs as part of the CI [#114](https://github.com/astronomer/astro-sdk/issues/114)
+* Benchmark tooling to validate performance of `load_file` [#105](https://github.com/astronomer/astro-sdk/issues/105)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,7 +30,7 @@ report a bug, open an issue! We'd love all and any contributions. If you have qu
 We'd also love PRs. If you're thinking of a large PR, we advise opening up an issue first to talk about it,
 though! Look at the links below if you're not sure how to open a PR.
 
-If you have other questions, use [Github Discussions](https://github.com/astro-projects/astro/discussions).
+If you have other questions, use [Github Discussions](https://github.com/astronomer/astro-sdk/discussions).
 
 
 # Creating a local development
@@ -43,7 +43,7 @@ Follow the steps described in [development](DEVELOPMENT.md).
 1. Update the local sources to address the issue you are working on.
 
    * Create a local branch for your development. Make sure to use latest
-     [astro-projects/astro/main](https://github.com/astro-projects/astro) as base for the branch. This allows you to easily compare
+     [astro-projects/astro/main](https://github.com/astronomer/astro-sdk) as base for the branch. This allows you to easily compare
      changes, have several changes that you work on at the same time and many more.
 
    * Add necessary code and (unit) tests.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,7 +16,7 @@ strictly for bug fixes, and they can easily upgrade to it.
 
 When looking through the branches on the main repo, you will notice a series of `release` branches labeled
 `release-<major version>.<minor version>`. So if we are currently working on the 0.6 release, the branch should be labeled
-`release-0.6`. Before creating a minor release please check the [milestones](https://github.com/astro-projects/astro/milestones)
+`release-0.6`. Before creating a minor release please check the [milestones](https://github.com/astronomer/astro-sdk/milestones)
 page to ensure that all relevant bug fixes have been PRed and merged.
 
 Once you merge all expected fixes, the next step is to ensure that all fixes have been cherry-picked to the release

--- a/docs/aep/README.md
+++ b/docs/aep/README.md
@@ -27,7 +27,7 @@ Examples of life cycles:
 
 ### Draft
 
-Most proposals start with an idea. If you have an idea of how Astro could improve, create a [Github Issue](https://github.com/astro-projects/astro/issues/new) and, label it with `enhancement`.
+Most proposals start with an idea. If you have an idea of how Astro could improve, create a [Github Issue](https://github.com/astronomer/astro-sdk/issues/new) and, label it with `enhancement`.
 
 We encourage you to start a Draft document in the [aep](.) folder an make a pull request, so others can discuss it. Please, follow the [AEP template](./AEP-template.md).
 
@@ -43,7 +43,7 @@ This is done by encouraging people to add the reactions "+1" or "-1" in the Gith
 
 Congratulations! Your proposal has been accepted.
 
-Next up is breaking down tasks using the [Github Issues page](https://github.com/astro-projects/astro/issues/new).
+Next up is breaking down tasks using the [Github Issues page](https://github.com/astronomer/astro-sdk/issues/new).
 
 Ask a committer to create a label for your AEP, and link all your issues with it for easier maintainability.
 
@@ -72,4 +72,4 @@ AEPs may be moved to abandoned in the following two cases:
 
 | ID         | Title                     | Github Issue                                       |
 | ---------- | ------------------------- | -------------------------------------------------- |
-| AEP-01     | Support API retrieval     | https://github.com/astro-projects/astro/issues/20  |
+| AEP-01     | Support API retrieval     | https://github.com/astronomer/astro-sdk/issues/20  |

--- a/example_dags/example_sqlite_load_transform.py
+++ b/example_dags/example_sqlite_load_transform.py
@@ -27,7 +27,7 @@ with DAG(
 ) as dag:
 
     imdb_movies = aql.load_file(
-        path="https://raw.githubusercontent.com/astro-projects/astro/main/tests/data/imdb.csv",
+        path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb.csv",
         task_id="load_csv",
         output_table=Table(name="imdb_movies", conn_id="sqlite_default"),
     )


### PR DESCRIPTION
depends on https://github.com/astronomer/astro-sdk/pull/374

We moved this repo from astro-projects to astronomer org. This commit updates the URL in the docs and code.
