### PR TITLE
Support table.name correct sizing after setting table.schema

### DIFF
--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -1,14 +1,14 @@
 import random
 import string
 from dataclasses import dataclass, field, fields
-from typing import List, Optional, Union
+from typing import List, Union
 
 from airflow.models import DagRun, TaskInstance
 from sqlalchemy import Column, MetaData
 
 from astro.constants import UNIQUE_TABLE_NAME_LENGTH
 
-MAX_TABLE_NAME_LENGTH = 45
+MAX_TABLE_NAME_LENGTH = 62
 
 
 @dataclass
@@ -45,17 +45,14 @@ class Table:
     # SQL table itself
     # Some ideas: TableRef, TableMetadata, TableData, TableDataset
     conn_id: str = ""
-    name: str = ""
+    name: Union[str, property] = ""
+    _name: str = field(init=False, repr=False, default="")
     metadata: Metadata = field(default_factory=Metadata)
-    columns: Optional[List[Column]] = None
+    columns: List[Column] = field(default_factory=list)
     temp: bool = False
 
     def __post_init__(self):
-        if self.columns is None:
-            self.columns = []
-
-        if not self.name:
-            self.name = self._create_unique_table_name()
+        if not self._name:
             self.temp = True
 
     def _create_unique_table_name(self) -> str:
@@ -78,6 +75,18 @@ class Table:
         else:
             alchemy_metadata = MetaData()
         return alchemy_metadata
+
+    @property  # type: ignore
+    def name(self) -> str:
+        if self.temp and not self._name:
+            self._name = self._create_unique_table_name()
+        return self._name
+
+    @name.setter
+    def name(self, value: Union[str, property]) -> None:
+        if not isinstance(value, property):
+            self._name = value
+            self.temp = False
 
 
 # TODO: deprecate by the end of the refactoring

--- a/tests/sql/test_table.py
+++ b/tests/sql/test_table.py
@@ -1,0 +1,39 @@
+from astro.sql.table import Table
+
+
+def test_table_with_explicit_name():
+    """Check that we respect the name of table when it's named an we set it to non-temp"""
+    table = Table(conn_id="some_connection", name="some_name")
+    assert table.conn_id == "some_connection"
+    assert table.name == "some_name"
+    assert not table.temp
+
+
+def test_table_without_name():
+    """Check that we create a name, that it is always the same name, and that we set temp name to True"""
+    table = Table(conn_id="some_connection")
+    assert table.conn_id == "some_connection"
+    name1 = table.name
+    name2 = table.name
+    assert name1
+    assert isinstance(name1, str)
+    assert len(table.name) == 62
+    assert name1 == name2
+    assert table.temp
+
+
+def test_table_without_name_and_schema():
+    """Check that the table name is smaller when there is metadata associated to the table."""
+    table = Table(conn_id="some_connection")
+    table.metadata.schema = "abc"
+    assert isinstance(table.name, str)
+    assert len(table.name) == 59  # max length limit - len("abc")
+    assert table.temp
+
+
+def test_table_name_set_after_initialization():
+    """Check that the table is no longer considered temp when the name is set after initialization."""
+    table = Table(conn_id="some_connection")
+    assert table.temp
+    table.name = "something"
+    assert not table.temp


### PR DESCRIPTION
@dimberman identified a scenario where the table name was being created incorrectly.

There are situations in the code when we want to associate metadata (e.g., schema) to a temporary table after it was created. When this happens, the previous implementation of `table.name` would auto-generate the name during initialization without considering the schema (which had not been set yet).

This PR introduces test cases and adjusts the implementation to generate only the `table.name` once it is needed (when trying to access the attribute).