### PR TITLE
Add `flake8` check for logging in Pre-commit Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
           - flake8-colors
           - flake8-assertive
           - flake8-typing-imports
+          - flake8-logging-format
 
   - repo: https://github.com/timothycrosley/isort
     rev: 5.10.1


### PR DESCRIPTION
This commit adds flake8 plugin for logging - https://github.com/globality-corp/flake8-logging-format in pre-commit Hooks so that we always use Lazy loading of args in logs.