### PR TITLE
CI: Split the Airflow version matrix to separate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,12 +97,11 @@ jobs:
       AIRFLOW__CORE__ENABLE_XCOM_PICKLING: True
       AIRFLOW_VAR_FOO: templated_file_name
       FORCE_COLOR: "true"
-  Run-Unit-tests:
+  Run-Unit-tests-Airflow-2-3:
     strategy:
       fail-fast: false
       matrix:
         group: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 ]
-        airflow: ["2.2.5", "2.3"]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -129,12 +128,12 @@ jobs:
           path: |
             ~/.cache/pip
             .nox
-          key: ${{ runner.os }}-${{ matrix.airflow }}-${{ hashFiles('pyproject.toml') }}
+          key: ${{ runner.os }}-2.3-${{ hashFiles('pyproject.toml') }}
       - run: cat .github/ci-test-connections.yaml > test-connections.yaml
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='${{ matrix.airflow }}')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:
@@ -163,9 +162,67 @@ jobs:
       AIRFLOW__CORE__ENABLE_XCOM_PICKLING: True
       AIRFLOW_VAR_FOO: templated_file_name
 
+  Run-Unit-tests-Airflow-2-2-5:
+    runs-on: ubuntu-latest
+    needs:
+      - Run-Unit-tests-Airflow-2-3
+    services:
+      postgres:
+        # Docker Hub image
+        image: dimberman/pagila-test
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          architecture: 'x64'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .nox
+          key: ${{ runner.os }}-2.2.5-${{ hashFiles('pyproject.toml') }}
+      - run: cat .github/ci-test-connections.yaml > test-connections.yaml
+      - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
+      - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
+      - run: pip3 install nox
+      - run: nox -s "test-3.8(airflow='2.2.5')" -- "tests/test_example_dags.py" "integration_test_dag.py"
+    env:
+      AWS_BUCKET: tmp9
+      GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
+      GOOGLE_BUCKET: dag-authoring
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AIRFLOW__ASTRO__SQL_SCHEMA: astroflow_ci
+      SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
+      SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+      SNOWFLAKE_SCHEMA: ASTROFLOW_CI
+      SNOWFLAKE_DATABASE: SANDBOX
+      SNOWFLAKE_WAREHOUSE: DEMO
+      SNOWFLAKE_HOST: https://gp21411.us-east-1.snowflakecomputing.com
+      SNOWFLAKE_ACCOUNT: gp21411
+      SNOWFLAKE_REGION: us-east-1
+      SNOWFLAKE_ROLE: AIRFLOW_TEST_USER
+      AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: True
+      AIRFLOW__CORE__ENABLE_XCOM_PICKLING: True
+      AIRFLOW_VAR_FOO: templated_file_name
+
   Code-Coverage:
     needs:
-      - Run-Unit-tests
+      - Run-Unit-tests-Airflow-2-3
       - Run-Optional-Packages-tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The CI is failing intermittently as I initially suspected in https://github.com/astronomer/astro-sdk/pull/370

Example: https://github.com/astronomer/astro-sdk/runs/6601723455?check_suite_focus=true

This PR runs 2.2.5 tests after 2.3 tests are complete and also only runs a subset of the tests (Example DAGs and one of the integration tests) for 2.2.5 which should be enough for 2.2.5