### PR TITLE
Fix failing test for 2.2.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,7 +196,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.2.5')" -- "tests/test_example_dags.py" "integration_test_dag.py"
+      - run: nox -s "test-3.8(airflow='2.2.5')" -- "tests/test_example_dags.py" "tests/integration_test_dag.py"
     env:
       AWS_BUCKET: tmp9
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,7 +196,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.2.5')" -- "tests/test_example_dags.py" "tests/integration_test_dag.py"
+      - run: nox -s "test-3.8(airflow='2.2.5')" -- "tests/test_example_dags.py"
     env:
       AWS_BUCKET: tmp9
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -125,7 +125,6 @@ def run_merge(output_specs: Table, merge_keys):
         "snowflake",
         "postgres",
         "bigquery",
-        # pytest.param("bigquery", marks=pytest.mark.xfail(reason="some bug")),
         "sqlite",
     ],
     indirect=True,
@@ -143,7 +142,7 @@ def test_full_dag(sql_server, sample_dag, test_table):
         run_merge(output_table, merge_keys(sql_server))
         aql.export_file(
             input_data=tranformed_table,
-            output_file_path="/tmp/out_agg.csv",
-            overwrite=True,
+            output_file=File(path="/tmp/out_agg.csv"),
+            if_exists="replace",
         )
     test_utils.run_dag(sample_dag)


### PR DESCRIPTION
There was a typo in the file to include for 2.2.5 testing

```
============================ no tests ran in 0.01s =============================
ERROR: file or directory not found: integration_test_dag.py

```