### PR TITLE
Enable table to have Airflow templated names

### DIFF
--- a/src/astro/sql/operators/transform.py
+++ b/src/astro/sql/operators/transform.py
@@ -169,7 +169,6 @@ class TransformOperator(DecoratedOperator):
         # convert Jinja templating to SQLAlchemy SQL templating, safely converting table identifiers
         for k, v in self.parameters.items():
             if isinstance(v, Table):
-                # v = self.render_template(v, context)
                 (
                     jinja_table_identifier,
                     jinja_table_parameter_value,

--- a/src/astro/sql/operators/transform.py
+++ b/src/astro/sql/operators/transform.py
@@ -68,6 +68,8 @@ class TransformOperator(DecoratedOperator):
             target_table=self.output_table.create_similar_table(),
         )
 
+        self.output_table = self.render_template(self.output_table, context)
+
         # Get SQL from function and render templates in the SQL String
         self.read_sql_from_function()
         self.move_function_params_into_sql_params(context)
@@ -165,6 +167,7 @@ class TransformOperator(DecoratedOperator):
         # convert Jinja templating to SQLAlchemy SQL templating, safely converting table identifiers
         for k, v in self.parameters.items():
             if isinstance(v, Table):
+                v = self.render_template(v, context)
                 (
                     jinja_table_identifier,
                     jinja_table_parameter_value,

--- a/src/astro/sql/operators/transform.py
+++ b/src/astro/sql/operators/transform.py
@@ -68,6 +68,8 @@ class TransformOperator(DecoratedOperator):
             target_table=self.output_table.create_similar_table(),
         )
 
+        # The transform decorator doesn't explicitly pass output_table as a
+        # parameter. Hence, it's not covered in templated fields of class Table.
         self.output_table = self.render_template(self.output_table, context)
 
         # Get SQL from function and render templates in the SQL String
@@ -167,7 +169,7 @@ class TransformOperator(DecoratedOperator):
         # convert Jinja templating to SQLAlchemy SQL templating, safely converting table identifiers
         for k, v in self.parameters.items():
             if isinstance(v, Table):
-                v = self.render_template(v, context)
+                # v = self.render_template(v, context)
                 (
                     jinja_table_identifier,
                     jinja_table_parameter_value,

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -39,6 +39,8 @@ class Table:
     Temporary tables are prefixed with the prefix TEMP_PREFIX.
     """
 
+    template_fields = ("name",)
+
     # TODO: discuss alternative names to this class, since it contains metadata as opposed to be the
     # SQL table itself
     # Some ideas: TableRef, TableMetadata, TableData, TableDataset

--- a/tests/sql/operators/transform/test_transform.py
+++ b/tests/sql/operators/transform/test_transform.py
@@ -150,12 +150,12 @@ def test_transform_with_templated_table_name(database_table_fixture, sample_dag)
 
     with sample_dag:
 
-        target_table = Table(name="test-is-{{ test_mode }}", conn_id="sqlite_default")
+        target_table = Table(name="test_is_{{ ds_nodash }}", conn_id="sqlite_default")
 
         top_five_animations(input_table=imdb_table, output_table=target_table)
     test_utils.run_dag(sample_dag)
 
     expected_target_table = target_table.create_similar_table()
-    expected_target_table.name = "test-is-True"
+    expected_target_table.name = "test_is_True"
     database.drop_table(expected_target_table)
     assert not database.table_exists(expected_target_table)

--- a/tests/sql/operators/transform/test_transform.py
+++ b/tests/sql/operators/transform/test_transform.py
@@ -139,7 +139,7 @@ def test_transform_with_templated_table_name(database_table_fixture, sample_dag)
     database, imdb_table = database_table_fixture
 
     @aql.transform
-    def top_five_animations(input_table: Table) -> Table:
+    def top_five_animations(input_table: Table) -> str:
         return """
             SELECT Title, Rating
             FROM {{ input_table }}

--- a/tests/sql/operators/transform/test_transform.py
+++ b/tests/sql/operators/transform/test_transform.py
@@ -5,6 +5,7 @@ import pytest
 from airflow.decorators import task
 
 from astro import sql as aql
+from astro.constants import Database
 from astro.files import File
 from astro.sql.table import Table
 from tests.sql.operators import utils as test_utils
@@ -116,3 +117,45 @@ def test_raw_sql(sql_server, sample_dag, test_table):
         )
         validate_raw_sql(raw_sql_result)
     test_utils.run_dag(sample_dag)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.SQLITE,
+            "file": File(
+                "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb.csv"
+            ),
+            "table": Table(name="imdb", conn_id="sqlite_default"),
+        }
+    ],
+    indirect=True,
+    ids=["sqlite"],
+)
+def test_transform_with_templated_table_name(database_table_fixture, sample_dag):
+    """Test table creation via select statement when the output table uses an Airflow template in its name"""
+    database, imdb_table = database_table_fixture
+
+    @aql.transform
+    def top_five_animations(input_table: Table) -> Table:
+        return """
+            SELECT Title, Rating
+            FROM {{ input_table }}
+            WHERE Genre1=='Animation'
+            ORDER BY Rating desc
+            LIMIT 5;
+        """
+
+    with sample_dag:
+
+        target_table = Table(name="test-is-{{ test_mode }}", conn_id="sqlite_default")
+
+        top_five_animations(input_table=imdb_table, output_table=target_table)
+    test_utils.run_dag(sample_dag)
+
+    expected_target_table = target_table.create_similar_table()
+    expected_target_table.name = "test-is-True"
+    database.drop_table(expected_target_table)
+    assert not database.table_exists(expected_target_table)


### PR DESCRIPTION
- Add template field - `name` to `Table` class.
- Render template for all the Tables in op_args and op_kwargs.

closes: #413 