### PR TITLE
add repr to all classes #283

### DIFF
--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -46,6 +46,9 @@ class BaseDatabase(ABC):
     def __init__(self, conn_id: str):
         self.conn_id = conn_id
 
+    def __repr__(self):
+        return f'{self.__class__.__name__}(conn_id="{self.conn_id})'
+
     @property
     def hook(self) -> BaseHook:
         """Return an instance of the database-specific Airflow hook."""

--- a/src/astro/files/types/base.py
+++ b/src/astro/files/types/base.py
@@ -38,3 +38,6 @@ class FileType(ABC):
     def __str__(self):
         """String representation of type"""
         return self.name.value
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}(path="{self.path}",conn_id="{self.normalize_config}")'

--- a/src/astro/files/types/base.py
+++ b/src/astro/files/types/base.py
@@ -40,4 +40,4 @@ class FileType(ABC):
         return self.name.value
 
     def __repr__(self):
-        return f'{self.__class__.__name__}(path="{self.path}",conn_id="{self.normalize_config}")'
+        return f'{self.__class__.__name__}(path="{self.path}")'

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -23,9 +23,6 @@ class Metadata:
     schema: Optional[str] = None
     database: Optional[str] = None
 
-    def __repr__(self):
-        return f'{self.__class__.__name__}(schema="{self.schema}", database="{self.database}")'
-
     def is_empty(self):
         """Check if all the fields are None."""
         values = [getattr(self, field.name) for field in fields(self)]
@@ -57,16 +54,6 @@ class Table:
     def __post_init__(self):
         if not self._name:
             self.temp = True
-
-    def __repr__(self):
-        return (
-            f"{self.__class__.__name__}("
-            f'conn_id="{self.conn_id}", '
-            f'name="{self.name}", '
-            f"temp={self.temp}, "
-            f"metadata={self.metadata}, "
-            f"columns={self.columns})"
-        )
 
     def _create_unique_table_name(self, prefix: str = "") -> str:
         """

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -23,6 +23,9 @@ class Metadata:
     schema: Optional[str] = None
     database: Optional[str] = None
 
+    def __repr__(self):
+        return f'{self.__class__.__name__}(schema="{self.schema}", database="{self.database}")'
+
     def is_empty(self):
         """Check if all the fields are None."""
         values = [getattr(self, field.name) for field in fields(self)]
@@ -54,6 +57,16 @@ class Table:
     def __post_init__(self):
         if not self._name:
             self.temp = True
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f'conn_id="{self.conn_id}", '
+            f'name="{self.name}", '
+            f"temp={self.temp}, "
+            f"metadata={self.metadata}, "
+            f"columns={self.columns})"
+        )
 
     def _create_unique_table_name(self, prefix: str = "") -> str:
         """


### PR DESCRIPTION
**Reference**:
- https://stackoverflow.com/questions/1436703/what-is-the-difference-between-str-and-repr

Currently, without `__repr__`, if you create an instance of a Database class and print it out, it will give the memory address as shown below.
```python
>>> from astro.databases.snowflake import SnowflakeDatabase
>>> SnowflakeDatabase("d")
<astro.databases.snowflake.SnowflakeDatabase object at 0x7ff3c80afe80>
```

As part of this GitHub issue, we should evaluate all of custom classes (`FileType`, `FileLocation` etc) and add `__repr__` methods wherever they are missing.

Example:

https://github.com/astronomer/astro-sdk/blob/5a511d265c6aed10248a1e36fd986518eaec0875/src/astro/files/base.py#L87-L93

closes #283 