### PR TITLE
Fix the test for BigQuery with constraint

### DIFF
--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -7,6 +7,7 @@ from airflow.utils import timezone
 
 from astro import sql as aql
 from astro.databases import create_database
+from astro.databases.google.bigquery import BigqueryDatabase
 from astro.databases.sqlite import SqliteDatabase
 from astro.files import File
 from astro.sql.table import Table
@@ -74,6 +75,8 @@ def add_constraint(table: Table):
     db = create_database(table.conn_id)
     if isinstance(db, SqliteDatabase):
         return "CREATE UNIQUE INDEX unique_index ON {{table}}(list,sell)"
+    if isinstance(db, BigqueryDatabase):
+        return "RETURN"
     return "ALTER TABLE {{table}} ADD CONSTRAINT airflow UNIQUE (list,sell)"
 
 

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -75,6 +75,8 @@ def add_constraint(table: Table):
     db = create_database(table.conn_id)
     if isinstance(db, SqliteDatabase):
         return "CREATE UNIQUE INDEX unique_index ON {{table}}(list,sell)"
+    # The only constraint that BigQuery supports is NOT NULL
+    # Hence, skipping the constraint for Bigquery.
     if isinstance(db, BigqueryDatabase):
         return "RETURN"
     return "ALTER TABLE {{table}} ADD CONSTRAINT airflow UNIQUE (list,sell)"


### PR DESCRIPTION
- `RETURN` in case of BigQuery without any constraints. The only constraint that BigQuery supports is `NOT NULL`.

closes: #415 