### PR TITLE
Refactor `AppendOperator`

### DIFF
--- a/example_dags/example_snowflake_partial_table_with_append.py
+++ b/example_dags/example_snowflake_partial_table_with_append.py
@@ -119,9 +119,14 @@ def example_snowflake_partial_table_with_append():
     # Append transformed & filtered data to reporting table
     # Dependency is inferred by passing the previous `filtered_data` task to `append_table` param
     record_results = append(
-        append_table=filtered_data,
-        columns=["sell", "list", "variable", "value"],
-        main_table=Table(name="homes_reporting"),
+        source_table=filtered_data,
+        target_table=Table(name="homes_reporting", conn_id=SNOWFLAKE_CONN_ID),
+        source_to_target_columns_map={
+            "sell": "sell",
+            "list": "list",
+            "variable": "variable",
+            "value": "value",
+        },
     )
     record_results.set_upstream(create_results_table)
 

--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -61,5 +61,4 @@ LoadExistStrategy = Literal["replace", "append"]
 ExportExistsStrategy = Literal["replace", "exception"]
 
 # TODO: check how snowflake names these
-AppendConflictStrategy = Literal["append", "replace", "exception"]
 MergeConflictStrategy = Literal["ignore", "update", "exception"]

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -4,10 +4,11 @@ from typing import Dict, List, Optional, Tuple
 import pandas as pd
 import sqlalchemy
 from airflow.hooks.base import BaseHook
+from sqlalchemy import column, insert, select
+from sqlalchemy.sql.schema import Table as SqlaTable
 
 from astro.constants import (
     DEFAULT_CHUNK_SIZE,
-    AppendConflictStrategy,
     ExportExistsStrategy,
     LoadExistStrategy,
     MergeConflictStrategy,
@@ -248,7 +249,6 @@ class BaseDatabase(ABC):
         source_table: Table,
         target_table: Table,
         source_to_target_columns_map: Dict[str, str],
-        if_conflicts: AppendConflictStrategy = "exception",
     ) -> None:
         """
         Append the source table rows into a destination table.
@@ -256,10 +256,25 @@ class BaseDatabase(ABC):
 
         :param source_table: Contains the rows to be appended to the target_table
         :param target_table: Contains the destination table in which the rows will be appended
-        :param source_to_target_columns_map: Dict of target_table columns names to source_table columns names
-        :param if_conflicts: The strategy to be applied if there are conflicts.
+        :param source_to_target_columns_map: Dict of source_table columns names to target_table columns names
         """
-        raise NotImplementedError
+        target_table_sqla = self.get_sqla_table(target_table)
+        source_table_sqla = self.get_sqla_table(source_table)
+        if not source_to_target_columns_map:
+            source_columns = target_columns = [
+                column(col) for col in target_table_sqla.c.keys()
+            ]
+        else:
+            target_columns = [
+                column(col) for col in source_to_target_columns_map.values()
+            ]
+            source_columns = [
+                column(col) for col in source_to_target_columns_map.keys()
+            ]
+
+        sel = select(source_columns).select_from(source_table_sqla)
+        sql = insert(target_table_sqla).from_select(target_columns, sel)
+        self.run_sql(sql_statement=sql)
 
     def merge_table(
         self,
@@ -280,6 +295,16 @@ class BaseDatabase(ABC):
         :param if_conflicts: The strategy to be applied if there are conflicts.
         """
         raise NotImplementedError
+
+    def get_sqla_table(self, table: Table) -> SqlaTable:
+        """
+        Return SQLAlchemy table instance
+
+        :param table: Astro Table to be converted to SQLAlchemy table instance
+        """
+        return SqlaTable(
+            table.name, table.sqlalchemy_metadata, autoload_with=self.sqlalchemy_engine
+        )
 
     # ---------------------------------------------------------
     # Extract methods

--- a/src/astro/databases/sqlite.py
+++ b/src/astro/databases/sqlite.py
@@ -1,8 +1,10 @@
 from typing import Dict, List, Optional, Tuple
 
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+from sqlalchemy import MetaData as SqlaMetaData
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
+from sqlalchemy.sql.schema import Table as SqlaTable
 
 from astro.constants import MergeConflictStrategy
 from astro.databases.base import BaseDatabase
@@ -114,3 +116,13 @@ class SqliteDatabase(BaseDatabase):
             merge_keys=",".join(list(target_conflict_columns)),
         )
         self.run_sql(sql_statement=query)
+
+    def get_sqla_table(self, table: Table) -> SqlaTable:
+        """
+        Return SQLAlchemy table instance
+
+        :param table: Astro Table to be converted to SQLAlchemy table instance
+        """
+        return SqlaTable(
+            table.name, SqlaMetaData(), autoload_with=self.sqlalchemy_engine
+        )

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -72,21 +72,23 @@ def run_raw_sql(
 
 
 def append(
-    append_table: Table,
-    main_table: Table,
-    columns: Optional[List[str]] = None,
-    casted_columns: Optional[dict] = None,
+    *,
+    source_table: Table,
+    target_table: Table,
+    source_to_target_columns_map: Optional[Dict[str, str]] = None,
     **kwargs,
 ):
-    if columns is None:
-        columns = []
-    if casted_columns is None:
-        casted_columns = {}
+    """
+    Append the source table rows into a destination table.
+
+    :param source_table: Contains the rows to be appended to the target_table (templated)
+    :param target_table: Contains the destination table in which the rows will be appended (templated)
+    :param source_to_target_columns_map: Dict of source_table columns names to target_table columns names
+    """
     return AppendOperator(
-        main_table=main_table,
-        append_table=append_table,
-        columns=columns,
-        casted_columns=casted_columns,
+        target_table=target_table,
+        source_table=source_table,
+        source_to_target_columns_map=source_to_target_columns_map,
         **kwargs,
     ).output
 
@@ -116,6 +118,7 @@ def merge(
         source_to_target_columns_map=source_to_target_columns_map,
         target_conflict_columns=target_conflict_columns,
         if_conflicts=if_conflicts,
+        **kwargs,
     ).output
 
 

--- a/src/astro/sql/operators/append.py
+++ b/src/astro/sql/operators/append.py
@@ -1,110 +1,46 @@
-import importlib
-from typing import List, Optional, Union
+from typing import Dict, Optional
 
-from sqlalchemy import MetaData, cast, column, insert, select
-from sqlalchemy.sql.elements import Cast, ColumnClause
-from sqlalchemy.sql.schema import Table as SqlaTable
+from airflow.models.baseoperator import BaseOperator
 
-from astro.constants import Database
-from astro.sql.operators.sql_decorator_legacy import SqlDecoratedOperator
+from astro.databases import create_database
 from astro.sql.table import Table
-from astro.utils.database import get_database_name
-from astro.utils.schema_util import (
-    get_error_string_for_multiple_dbs,
-    tables_from_same_db,
-)
-from astro.utils.table_handler import TableHandler
 from astro.utils.task_id_helper import get_unique_task_id
 
 
-class AppendOperator(SqlDecoratedOperator, TableHandler):
-    template_fields = ("main_table", "append_table")
+class AppendOperator(BaseOperator):
+    """
+    Append the source table rows into a destination table.
+
+    :param source_table: Contains the rows to be appended to the target_table (templated)
+    :param target_table: Contains the destination table in which the rows will be appended (templated)
+    :param source_to_target_columns_map: Dict of source_table columns names to target_table columns names
+    """
+
+    template_fields = ("source_table", "target_table")
 
     def __init__(
         self,
-        append_table: Table,
-        main_table: Table,
-        columns: Optional[List[str]] = None,
-        casted_columns: Optional[dict] = None,
+        source_table: Table,
+        target_table: Table,
+        source_to_target_columns_map: Optional[Dict[str, str]] = None,
+        task_id: str = "",
         **kwargs,
     ) -> None:
-        if columns is None:
-            columns = []
-        if casted_columns is None:
-            casted_columns = {}
-        self.append_table = append_table
-        self.main_table = main_table
-        self.sql = ""
+        self.source_table = source_table
+        self.target_table = target_table
+        self.source_to_target_columns_map = source_to_target_columns_map or {}
 
-        self.columns = columns
-        self.casted_columns = casted_columns
-        task_id = get_unique_task_id("append_table")
+        task_id = task_id or get_unique_task_id("append_table")
 
-        def null_function():
-            pass
+        super().__init__(task_id=task_id, **kwargs)
 
-        super().__init__(
-            raw_sql=True,
-            parameters={},
-            task_id=kwargs.get("task_id") or task_id,
-            op_args=(),
-            python_callable=null_function,
-            handler=lambda x: None,
-            **kwargs,
+    def execute(self, context: dict) -> Table:  # skipcq: PYL-W0613
+        db = create_database(self.target_table.conn_id)
+        self.source_table = db.populate_table_metadata(self.source_table)
+        self.target_table = db.populate_table_metadata(self.target_table)
+        db.append_table(
+            source_table=self.source_table,
+            target_table=self.target_table,
+            source_to_target_columns_map=self.source_to_target_columns_map,
         )
-
-    def execute(self, context: dict) -> Table:
-        if not tables_from_same_db([self.append_table, self.main_table]):
-            raise ValueError(
-                get_error_string_for_multiple_dbs([self.append_table, self.main_table])
-            )
-
-        self.main_table.conn_id = self.main_table.conn_id or self.append_table.conn_id
-        self.conn_id = self.main_table.conn_id or self.append_table.conn_id
-        self.database = (
-            self.main_table.metadata.database or self.append_table.metadata.database
-        )
-        self.schema = (
-            self.append_table.metadata.schema or self.append_table.metadata.schema
-        )
-
-        self.sql = self.append(
-            main_table=self.main_table,
-            append_table=self.append_table,
-            columns=self.columns,
-            casted_columns=self.casted_columns,
-        )
-        super().execute(context)
-        return self.main_table
-
-    def append(
-        self,
-        main_table: Table,
-        columns: List[str],
-        casted_columns: dict,
-        append_table: Table,
-    ):
-        engine = self.get_sql_alchemy_engine()
-        if self.schema and get_database_name(engine) != Database.SQLITE:
-            metadata = MetaData(schema=self.schema)
-        else:
-            metadata = MetaData()
-        # TO Do - fix bigquery and postgres reflection table issue.
-        main_table_sqla = SqlaTable(main_table.name, metadata, autoload_with=engine)
-        append_table_sqla = SqlaTable(append_table.name, metadata, autoload_with=engine)
-
-        column_names: List[Union[ColumnClause, Cast]] = [column(c) for c in columns]
-        sqlalchemy = importlib.import_module("sqlalchemy")
-        casted_fields = [
-            cast(column(k), getattr(sqlalchemy, v)) for k, v in casted_columns.items()
-        ]
-        main_columns = [k for k, v in casted_columns.items()]
-        main_columns.extend(list(columns))
-
-        if len(column_names) + len(casted_fields) == 0:
-            column_names = [column(c) for c in append_table_sqla.c.keys()]
-            main_columns = column_names
-
-        column_names.extend(casted_fields)
-        sel = select(column_names).select_from(append_table_sqla)
-        return insert(main_table_sqla).from_select(main_columns, sel)
+        return self.target_table

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -75,9 +75,9 @@ def run_append(output_specs: List):
     )
 
     aql.append(
-        columns=["sell", "living"],
-        main_table=load_main,
-        append_table=load_append,
+        source_to_target_columns_map={"sell": "sell", "living": "living"},
+        target_table=load_main,
+        source_table=load_append,
     )
 
 

--- a/tests/sql/operators/test_append.py
+++ b/tests/sql/operators/test_append.py
@@ -39,22 +39,15 @@ def append_params(request):
     mode = request.param
     if mode == "basic":
         return {
-            "columns": ["sell", "living"],
+            "source_to_target_columns_map": {"sell": "sell", "living": "living"},
         }, validate_basic
     if mode == "all_fields":
         return {}, validate_append_all
-    if mode == "with_caste":
-        return {
-            "columns": ["sell", "living"],
-            "casted_columns": {"age": "INTEGER"},
-        }, validate_basic
-    if mode == "caste_only":
-        return {"casted_columns": {"age": "INTEGER"}}, validate_caste_only
 
 
 @pytest.mark.parametrize(
     "append_params",
-    ["basic", "all_fields", "with_caste"],
+    ["basic", "all_fields"],
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -94,8 +87,8 @@ def test_append(sql_server, sample_dag, test_table, append_params):
     with sample_dag:
         appended_table = aql.append(
             **app_param,
-            main_table=test_table[0],
-            append_table=test_table[1],
+            target_table=test_table[0],
+            source_table=test_table[1],
         )
         validate_append(appended_table)
     test_utils.run_dag(sample_dag)
@@ -122,7 +115,7 @@ def test_append_on_tables_on_different_db(sample_dag, sql_server):
                 output_table=test_table_2,
             )
             aql.append(
-                main_table=load_main,
-                append_table=load_append,
+                target_table=load_main,
+                source_table=load_append,
             )
         test_utils.run_dag(sample_dag)


### PR DESCRIPTION
This PR refactors the Append operator to use the new interfaces.

Breaking Changes that I would love to get some feedback on:
- Removed casting functionality
- changed the interface from which uses `source_to_target_columns_map` instead of `columns`:

```python
    def append(
        self,
        main_table: Table,
        columns: List[str],
        casted_columns: dict,
        append_table: Table,
    ):
```

to

```python
def append(
    source_table: Table,
    target_table: Table,
    source_to_target_columns_map: Optional[Dict[str, str]] = None,
    **kwargs,
):
```

This PR intends to keep the same logic as now and just use new interfaces so we can delete all the old files from old interfaces. The scope to whether or not we should have a single function or not is kept for https://github.com/astronomer/astro-sdk/pull/383

closes #343
closes https://github.com/astronomer/astro-sdk/issues/335

Co-Authored-By: Utkarsh Sharma <utkarsharma2@gmail.com>