### PR TITLE
Allow list and tuples as columns names in Append & Merge

### DIFF
--- a/example_dags/example_snowflake_partial_table_with_append.py
+++ b/example_dags/example_snowflake_partial_table_with_append.py
@@ -121,12 +121,7 @@ def example_snowflake_partial_table_with_append():
     record_results = append(
         source_table=filtered_data,
         target_table=Table(name="homes_reporting", conn_id=SNOWFLAKE_CONN_ID),
-        source_to_target_columns_map={
-            "sell": "sell",
-            "list": "list",
-            "variable": "variable",
-            "value": "value",
-        },
+        columns=["sell", "list", "variable", "value"],
     )
     record_results.set_upstream(create_results_table)
 

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Union
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
 
 import pandas as pd
 
@@ -9,11 +9,11 @@ except ImportError:
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
 from astro.constants import MergeConflictStrategy
-from astro.sql.operators.append import AppendOperator
+from astro.sql.operators.append import APPEND_COLUMN_TYPE, AppendOperator
 from astro.sql.operators.dataframe import DataframeOperator
 from astro.sql.operators.export_file import export_file  # noqa: F401
 from astro.sql.operators.load_file import load_file  # noqa: F401
-from astro.sql.operators.merge import MergeOperator
+from astro.sql.operators.merge import MERGE_COLUMN_TYPE, MergeOperator
 from astro.sql.operators.raw_sql import RawSQLOperator
 from astro.sql.operators.transform import TransformOperator  # noqa: F401
 from astro.sql.operators.truncate import TruncateOperator
@@ -80,7 +80,7 @@ def append(
     *,
     source_table: Table,
     target_table: Table,
-    source_to_target_columns_map: Optional[Dict[str, str]] = None,
+    columns: APPEND_COLUMN_TYPE = None,
     **kwargs: Any,
 ):
     """
@@ -88,12 +88,15 @@ def append(
 
     :param source_table: Contains the rows to be appended to the target_table (templated)
     :param target_table: Contains the destination table in which the rows will be appended (templated)
-    :param source_to_target_columns_map: Dict of source_table columns names to target_table columns names
+    :param columns: List/Tuple of columns if name of source and target tables are same.
+        If the column names in source and target tables are different pass a dictionary
+        of source_table columns names to target_table columns names.
+        Examples: ``["sell", "list"]`` or ``{"s_sell": "t_sell", "s_list": "t_list"}``
     """
     return AppendOperator(
         target_table=target_table,
         source_table=source_table,
-        source_to_target_columns_map=source_to_target_columns_map,
+        columns=columns,
         **kwargs,
     ).output
 
@@ -102,7 +105,7 @@ def merge(
     *,
     target_table: Table,
     source_table: Table,
-    source_to_target_columns_map: Dict[str, str],
+    columns: MERGE_COLUMN_TYPE,
     target_conflict_columns: List[str],
     if_conflicts: MergeConflictStrategy,
     **kwargs: Any,
@@ -112,7 +115,10 @@ def merge(
 
     :param source_table: Contains the rows to be merged to the target_table (templated)
     :param target_table: Contains the destination table in which the rows will be merged (templated)
-    :param source_to_target_columns_map: Dict of target_table columns names to source_table columns names
+    :param columns: List/Tuple of columns if name of source and target tables are same.
+        If the column names in source and target tables are different pass a dictionary
+        of source_table columns names to target_table columns names.
+        Examples: ``["sell", "list"]`` or ``{"s_sell": "t_sell", "s_list": "t_list"}``
     :param target_conflict_columns: List of cols where we expect to have a conflict while combining
     :param if_conflicts: The strategy to be applied if there are conflicts.
     """
@@ -120,7 +126,7 @@ def merge(
     return MergeOperator(
         target_table=target_table,
         source_table=source_table,
-        source_to_target_columns_map=source_to_target_columns_map,
+        columns=columns,
         target_conflict_columns=target_conflict_columns,
         if_conflicts=if_conflicts,
         **kwargs,

--- a/src/astro/sql/operators/append.py
+++ b/src/astro/sql/operators/append.py
@@ -1,10 +1,12 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from airflow.models.baseoperator import BaseOperator
 
 from astro.databases import create_database
 from astro.sql.table import Table
 from astro.utils.task_id_helper import get_unique_task_id
+
+APPEND_COLUMN_TYPE = Optional[Union[List[str], Tuple[str], Dict[str, str]]]
 
 
 class AppendOperator(BaseOperator):
@@ -13,7 +15,10 @@ class AppendOperator(BaseOperator):
 
     :param source_table: Contains the rows to be appended to the target_table (templated)
     :param target_table: Contains the destination table in which the rows will be appended (templated)
-    :param source_to_target_columns_map: Dict of source_table columns names to target_table columns names
+    :param columns: List/Tuple of columns if name of source and target tables are same.
+        If the column names in source and target tables are different pass a dictionary
+        of source_table columns names to target_table columns names.
+        Examples: ``["sell", "list"]`` or ``{"s_sell": "t_sell", "s_list": "t_list"}``
     """
 
     template_fields = ("source_table", "target_table")
@@ -22,14 +27,19 @@ class AppendOperator(BaseOperator):
         self,
         source_table: Table,
         target_table: Table,
-        source_to_target_columns_map: Optional[Dict[str, str]] = None,
+        columns: APPEND_COLUMN_TYPE = None,
         task_id: str = "",
         **kwargs: Any,
     ) -> None:
         self.source_table = source_table
         self.target_table = target_table
-        self.source_to_target_columns_map = source_to_target_columns_map or {}
-
+        if isinstance(columns, (list, tuple)):
+            columns = dict(zip(columns, columns))
+        if columns and not isinstance(columns, dict):
+            raise ValueError(
+                f"columns is not a valid type. Valid types: [tuple, list, dict], Passed: {type(columns)}"
+            )
+        self.columns = columns or {}
         task_id = task_id or get_unique_task_id("append_table")
 
         super().__init__(task_id=task_id, **kwargs)
@@ -41,6 +51,6 @@ class AppendOperator(BaseOperator):
         db.append_table(
             source_table=self.source_table,
             target_table=self.target_table,
-            source_to_target_columns_map=self.source_to_target_columns_map,
+            source_to_target_columns_map=self.columns,
         )
         return self.target_table

--- a/src/astro/sql/operators/merge.py
+++ b/src/astro/sql/operators/merge.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.baseoperator import BaseOperator
@@ -7,6 +7,8 @@ from astro.constants import MergeConflictStrategy
 from astro.databases import create_database
 from astro.sql.table import Table
 
+MERGE_COLUMN_TYPE = Union[List[str], Tuple[str], Dict[str, str]]
+
 
 class MergeOperator(BaseOperator):
     """
@@ -14,7 +16,10 @@ class MergeOperator(BaseOperator):
 
     :param source_table: Contains the rows to be merged to the target_table (templated)
     :param target_table: Contains the destination table in which the rows will be merged (templated)
-    :param source_to_target_columns_map: Dict of target_table columns names to source_table columns names
+    :param columns: List/Tuple of columns if name of source and target tables are same.
+        If the column names in source and target tables are different pass a dictionary
+        of source_table columns names to target_table columns names.
+        Examples: ``["sell", "list"]`` or ``{"s_sell": "t_sell", "s_list": "t_list"}``
     :param target_conflict_columns: List of cols where we expect to have a conflict while combining
     :param if_conflicts: The strategy to be applied if there are conflicts.
     """
@@ -26,7 +31,7 @@ class MergeOperator(BaseOperator):
         *,
         target_table: Table,
         source_table: Table,
-        source_to_target_columns_map: Dict[str, str],
+        columns: MERGE_COLUMN_TYPE,
         if_conflicts: MergeConflictStrategy,
         target_conflict_columns: List[str],
         task_id: str = "",
@@ -35,7 +40,13 @@ class MergeOperator(BaseOperator):
         self.target_table = target_table
         self.source_table = source_table
         self.target_conflict_columns = target_conflict_columns
-        self.source_to_target_columns_map = source_to_target_columns_map
+        if isinstance(columns, (list, tuple)):
+            columns = dict(zip(columns, columns))
+        if columns and not isinstance(columns, dict):
+            raise ValueError(
+                f"columns is not a valid type. Valid types: [tuple, list, dict], Passed: {type(columns)}"
+            )
+        self.columns = columns or {}
         self.if_conflicts = if_conflicts
         task_id = task_id or get_unique_task_id("_merge")
 
@@ -45,11 +56,12 @@ class MergeOperator(BaseOperator):
         db = create_database(self.target_table.conn_id)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
+
         db.merge_table(
             source_table=self.source_table,
             target_table=self.target_table,
             if_conflicts=self.if_conflicts,
             target_conflict_columns=self.target_conflict_columns,
-            source_to_target_columns_map=self.source_to_target_columns_map,
+            source_to_target_columns_map=self.columns,
         )
         return self.target_table

--- a/tests/integration_test_dag.py
+++ b/tests/integration_test_dag.py
@@ -74,7 +74,7 @@ def run_append(output_table: Table):
     )
 
     aql.append(
-        source_to_target_columns_map={"sell": "sell", "living": "living"},
+        columns={"sell": "sell", "living": "living"},
         target_table=load_main,
         source_table=load_append,
     )
@@ -97,7 +97,7 @@ def run_merge(output_table: Table):
         target_table=main_table,
         source_table=merge_table,
         target_conflict_columns=["list", "sell"],
-        source_to_target_columns_map={"list": "list", "sell": "sell"},
+        columns={"list": "list", "sell": "sell"},
         if_conflicts="ignore",
     )
     con1 >> merged_table


### PR DESCRIPTION
addresses https://github.com/astronomer/astro-sdk/pull/439#discussion_r892181788

Tt feels tedious and probably most of the times the col names would be the same. This commit renames `source_to_target_columns_map` param in Append and Merge operator to `columns` and allows passing either a) list or tuples containing col names b) dict containing source to target mapping.

**Before**:

```python
append(
    source_table=filtered_data,
    target_table=Table(name="homes_reporting", conn_id=SNOWFLAKE_CONN_ID),
    source_to_target_columns_map={
        "sell": "sell",
        "list": "list",
        "variable": "variable",
        "value": "value",
    },
)
```

**After**:

```python
append(
    source_table=filtered_data,
    target_table=Table(name="homes_reporting", conn_id=SNOWFLAKE_CONN_ID),
    columns=["sell", "list", "variable", "value"]
)
```

**ToDo**:
- [x] Add unit tests for passing different types and verify that it is converted to dict
- [ ] Probably a separate task to update docs and add a task in example DAGs with one of list and dict as col names before we release 0.10.0 - https://github.com/astronomer/astro-sdk/issues/466