### PR TITLE
Bump pre-commit Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-hooks-apply
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
@@ -29,7 +29,7 @@ repos:
       - id: python-check-mock-methods
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.13
+    rev: v1.2.0
     hooks:
       - id: forbid-crlf
       - id: remove-crlf
@@ -46,10 +46,10 @@ repos:
     hooks:
       - id: blacken-docs
         alias: black
-        additional_dependencies: [black==22.1.0]
+        additional_dependencies: [black>=22.1.0]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies:
@@ -76,13 +76,13 @@ repos:
         language: python
         types: [text]
   -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: 'v0.942'
+      rev: 'v0.961'
       hooks:
       -   id: mypy
           additional_dependencies: [types-PyYAML]
 
   -   repo: https://github.com/asottile/pyupgrade
-      rev: v2.31.1
+      rev: v2.34.0
       hooks:
       -   id: pyupgrade
           args: [--py37-plus]


### PR DESCRIPTION
Bumps versions of the pre-commit Hooks

```
Updating https://github.com/pre-commit/pre-commit-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
updating v4.1.0 -> v4.3.0.
Updating https://github.com/pre-commit/pygrep-hooks ... already up to date.
Updating https://github.com/Lucas-C/pre-commit-hooks ... updating v1.1.13 -> v1.2.0.
Updating https://github.com/psf/black ... already up to date.
Updating https://github.com/asottile/blacken-docs ... already up to date.
Updating https://github.com/PyCQA/flake8 ... updating 3.9.2 -> 4.0.1.
Updating https://github.com/timothycrosley/isort ... already up to date.
Updating https://github.com/codespell-project/codespell ... already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
updating v0.942 -> v0.961.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
updating v2.31.1 -> v2.34.0.
```