### PR TITLE
Added feature to publish benchmark data to bigquery table.

### DIFF
--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -105,6 +105,9 @@ This is an example of the content of `/tmp/results-2022-02-10T14:36:09.ndjson`:
 {"duration": "1.2min", "rss": "157.17MB", "vms": "1.02GB", "shared": "41.9MB", "dag_id": "load_file_few_mb_into_postgres", "execution_date": "2022-02-12 00:34:03.794995+00:00", "revision": "e1fb164"}
 ```
 
+### Publishing Benchmark results
+
+To publish the results to bigquery table, we need to create an environment variable `ASTRO_PUBLISH_BENCHMARK_DATA` and set it to `True`. Once this is done the benchmarking data can be seen in bigquery table `astronomer-dag-authoring.Benchmark.load_files_to_database`.
 
 ## Analyze the results
 

--- a/tests/benchmark/dags/evaluate_load_file.py
+++ b/tests/benchmark/dags/evaluate_load_file.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from airflow import DAG
 
 from astro import sql as aql
+from astro.constants import DEFAULT_CHUNK_SIZE
 from astro.files import File
 from astro.sql.table import Metadata, Table
 
@@ -44,8 +45,7 @@ def create_dag(database_name, table_args, dataset):
     table_name = Path(dataset_path).stem
 
     with DAG(dag_name, schedule_interval=None, start_date=START_DATE) as dag:
-        chunk_size = int(os.environ["ASTRO_CHUNKSIZE"])
-
+        chunk_size = int(os.getenv("ASTRO_CHUNK_SIZE", DEFAULT_CHUNK_SIZE))
         metadata = Metadata(**table_args.pop("metadata"))
         table_metadata = Table(name=table_name, metadata=metadata, **table_args)
         table_xcom = aql.load_file(  # noqa: F841


### PR DESCRIPTION
Closes: #434 

Earlier we were storing benchmark data in `/tmp/<some-file>.ndjson` file locally, but now we need to perform the benchmarks in the CI pipeline and hence we need the data to be persisted. With this PR we are publishing the benchmark data in the Bigquery table - `astronomer-dag-authoring.Benchmark.load_files_to_database`

Publishing is not enabled by default, because developers can run benchmarks locally but this data may not be intended to be published. In order to allow the publishing of data, an environment variable needs to be created `ASTRO_PUBLISH_BENCHMARK_DATA`.

Note - We assume the existence of a table in the Bigquery, and the schema of the table is tightly coupled with profiling data to be stored. If we decide to change the profiling data in the future, we may need to alter the table schema.