### PR TITLE
Tests: Fix evaluate_load_file to load file with connection id

### DIFF
--- a/tests/benchmark/dags/evaluate_load_file.py
+++ b/tests/benchmark/dags/evaluate_load_file.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from airflow import DAG
 
 from astro import sql as aql
+from astro.constants import DEFAULT_CHUNK_SIZE
 from astro.files import File
 from astro.sql.table import Metadata, Table
 
@@ -38,18 +39,19 @@ def count_columns(input_table: Table):
 def create_dag(database_name, table_args, dataset):
     dataset_name = dataset["name"]
     dataset_path = dataset["path"]
+    dataset_conn_id = dataset.get("conn_id")
     # dataset_rows = dataset["rows"]
 
     dag_name = f"load_file_{dataset_name}_into_{database_name}"
     table_name = Path(dataset_path).stem
 
     with DAG(dag_name, schedule_interval=None, start_date=START_DATE) as dag:
-        chunk_size = int(os.environ["ASTRO_CHUNKSIZE"])
+        chunk_size = int(os.getenv("ASTRO_CHUNK_SIZE", DEFAULT_CHUNK_SIZE))
 
         metadata = Metadata(**table_args.pop("metadata"))
         table_metadata = Table(name=table_name, metadata=metadata, **table_args)
         table_xcom = aql.load_file(  # noqa: F841
-            input_file=File(path=dataset_path),
+            input_file=File(path=dataset_path, conn_id=dataset_conn_id),
             task_id="load_csv",
             output_table=table_metadata,
             chunk_size=chunk_size,


### PR DESCRIPTION
- Add `conn_id` while loading the file in evaluate_load_file.py for benchmarking.
- load default chunk size


Part of: #437 