### PR TITLE
Added absolute path as base dir for benchmarking script because relat…

### DIFF
--- a/tests/benchmark/run.sh
+++ b/tests/benchmark/run.sh
@@ -7,7 +7,7 @@ set -e
 
 repeat=${1:-1}  # how many times we want to repeat each DAG run (default: 1)
 
-benchmark_dir=`dirname "$0"`
+benchmark_dir="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 config_path="${benchmark_dir}/config.json"
 runner_path="${benchmark_dir}/run.py"
 astro_dir="${benchmark_dir}/../../src"


### PR DESCRIPTION
Partially Closes: https://github.com/astronomer/astro-sdk/issues/460 

Airflow 2.2.5+ expects an absolute path for the $AIRFLOW_HOME env variable, updated the script to pass the absolute path. 

Fix error - 
Cannot use relative path: sqlite:///./unittests.db to connect to sqlite. Please use absolute path such as sqlite:////tmp/airflow.db.
