### PR TITLE
Fail `LoadFile` operator when `input_file` does not exist

### DIFF
--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -45,3 +45,5 @@ ExportExistsStrategy = Literal["replace", "exception"]
 
 # TODO: check how snowflake names these
 MergeConflictStrategy = Literal["ignore", "update", "exception"]
+
+FileNotFoundStrategy = Literal["suppress", "exception"]

--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -45,5 +45,3 @@ ExportExistsStrategy = Literal["replace", "exception"]
 
 # TODO: check how snowflake names these
 MergeConflictStrategy = Literal["ignore", "update", "exception"]
-
-FileNotFoundStrategy = Literal["suppress", "exception"]

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -1,9 +1,9 @@
-from typing import Any, List, Optional, Union, cast
+from typing import List, Optional, Union
 
 import pandas as pd
 import smart_open
 
-from astro.constants import FileNotFoundStrategy, FileType
+from astro.constants import FileType
 from astro.files.locations import create_file_location
 from astro.files.types import create_file_type
 
@@ -35,12 +35,12 @@ class File:
         )
 
     @property
-    def path(self) -> Union[List[str], str]:
-        return cast(list, self.location.path)
+    def path(self) -> str:
+        return self.location.path
 
     @property
     def conn_id(self) -> Optional[str]:
-        return cast(str, self.location.conn_id)
+        return self.location.conn_id
 
     @property
     def size(self) -> int:
@@ -89,9 +89,7 @@ class File:
             f'{self.__class__.__name__}(location="{self.location}",type="{self.type}")'
         )
 
-    # To Do: path property can resolve into lists of path(list[str]) or single path(str).
-    # Right now code is assuming value of string which is wrong need to make changes all across code.
-    def __str__(self) -> Any:
+    def __str__(self) -> str:
         return self.location.path
 
 
@@ -100,7 +98,6 @@ def get_files(
     conn_id: Optional[str] = None,
     filetype: Union[FileType, None] = None,
     normalize_config: Optional[dict] = None,
-    if_file_doesnt_exist: FileNotFoundStrategy = "exception",
 ) -> List[File]:
     """get file objects by resolving path_pattern from local/object stores
     path_pattern can be
@@ -112,7 +109,6 @@ def get_files(
     :param conn_id: Airflow connection ID
     :param filetype: constant to provide an explicit file type
     :param normalize_config: parameters in dict format of pandas json_normalize() function
-    :param if_file_doesnt_exist: determines the strategy in case the file path/pattern doesn't result in existing files
     """
     location = create_file_location(path_pattern, conn_id)
     files = [
@@ -124,7 +120,7 @@ def get_files(
         )
         for path in location.paths
     ]
-    if len(files) == 0 and if_file_doesnt_exist == "exception":
+    if len(files) == 0:
         raise ValueError(f"File(s) not found for path/pattern '{path_pattern}'")
 
     return files

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -34,11 +34,9 @@ class File:
             path=path, filetype=filetype, normalize_config=normalize_config
         )
 
-    # ToDo: path property can resolve into lists of path(list[str]) or single path(str).
-    # Right now code is assuming value of string which is wrong need to make changes all across code.
     @property
-    def path(self) -> Any:
-        return self.location.path
+    def path(self) -> Union[List[str], str]:
+        return cast(list, self.location.path)
 
     @property
     def conn_id(self) -> Optional[str]:

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -42,7 +42,7 @@ class File:
 
     @property
     def conn_id(self) -> Optional[str]:
-        return cast(Optional[str], self.location.conn_id)
+        return cast(str, self.location.conn_id)
 
     @property
     def size(self) -> int:

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -34,7 +34,7 @@ class File:
             path=path, filetype=filetype, normalize_config=normalize_config
         )
 
-    # To Do: path property can resolve into lists of path(list[str]) or single path(str).
+    # ToDo: path property can resolve into lists of path(list[str]) or single path(str).
     # Right now code is assuming value of string which is wrong need to make changes all across code.
     @property
     def path(self) -> Any:

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, cast
 
 import pandas as pd
 import smart_open
@@ -34,13 +34,15 @@ class File:
             path=path, filetype=filetype, normalize_config=normalize_config
         )
 
+    # To Do: path property can resolve into lists of path(list[str]) or single path(str).
+    # Right now code is assuming value of string which is wrong need to make changes all across code.
     @property
     def path(self) -> Any:
         return self.location.path
 
     @property
-    def conn_id(self) -> Any:
-        return self.location.conn_id
+    def conn_id(self) -> Optional[str]:
+        return cast(Optional[str], self.location.conn_id)
 
     @property
     def size(self) -> int:
@@ -89,6 +91,8 @@ class File:
             f'{self.__class__.__name__}(location="{self.location}",type="{self.type}")'
         )
 
+    # To Do: path property can resolve into lists of path(list[str]) or single path(str).
+    # Right now code is assuming value of string which is wrong need to make changes all across code.
     def __str__(self) -> Any:
         return self.location.path
 

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -4,7 +4,7 @@ import pandas as pd
 from airflow.models import BaseOperator
 from airflow.models.xcom_arg import XComArg
 
-from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy
+from astro.constants import DEFAULT_CHUNK_SIZE, FileNotFoundStrategy, LoadExistStrategy
 from astro.databases import BaseDatabase, create_database
 from astro.files import File, check_if_connection_exists, get_files
 from astro.sql.table import Table
@@ -22,6 +22,7 @@ class LoadFile(BaseOperator):
 
     :return: If ``output_table`` is passed this operator returns a Table object. If not
         passed, returns a dataframe.
+    :param if_file_doesnt_exist: determines the strategy in case the file path/pattern doesn't result in existing files
     """
 
     template_fields = ("output_table", "input_file")
@@ -33,6 +34,7 @@ class LoadFile(BaseOperator):
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         if_exists: LoadExistStrategy = "replace",
         ndjson_normalize_sep: str = "_",
+        if_file_doesnt_exist: FileNotFoundStrategy = "exception",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -43,6 +45,7 @@ class LoadFile(BaseOperator):
         self.if_exists = if_exists
         self.ndjson_normalize_sep = ndjson_normalize_sep
         self.normalize_config: Dict[str, str] = {}
+        self.if_file_doesnt_exist = if_file_doesnt_exist
 
     def execute(self, context: Any) -> Union[Table, pd.DataFrame]:  # skipcq: PYL-W0613
         """
@@ -78,7 +81,10 @@ class LoadFile(BaseOperator):
         )
         if_exists = self.if_exists
         for file in get_files(
-            input_file.path, input_file.conn_id, normalize_config=self.normalize_config
+            input_file.path,
+            input_file.conn_id,
+            normalize_config=self.normalize_config,
+            if_file_doesnt_exist=self.if_file_doesnt_exist,
         ):
             database.load_pandas_dataframe_to_table(
                 source_dataframe=file.export_to_dataframe(),
@@ -96,7 +102,11 @@ class LoadFile(BaseOperator):
         SQL table was specified
         """
         df = None
-        for file in get_files(input_file.path, input_file.conn_id):
+        for file in get_files(
+            input_file.path,
+            input_file.conn_id,
+            if_file_doesnt_exist=self.if_file_doesnt_exist,
+        ):
             if isinstance(df, pd.DataFrame):
                 df = pd.concat([df, file.export_to_dataframe()])
             else:
@@ -153,6 +163,7 @@ def load_file(
     task_id: Optional[str] = None,
     if_exists: LoadExistStrategy = "replace",
     ndjson_normalize_sep: str = "_",
+    if_file_doesnt_exist: FileNotFoundStrategy = "exception",
     **kwargs: Any,
 ) -> XComArg:
     """Load a file or bucket into either a SQL table or a pandas dataframe.
@@ -164,6 +175,7 @@ def load_file(
         ex - {"a": {"b":"c"}} will result in
             column - "a_b"
             where ndjson_normalize_sep = "_"
+    :param if_file_doesnt_exist: determines the strategy in case the file path/pattern doesn't result in existing files
     """
 
     # Note - using path for task id is causing issues as it's a pattern and
@@ -176,5 +188,6 @@ def load_file(
         output_table=output_table,
         if_exists=if_exists,
         ndjson_normalize_sep=ndjson_normalize_sep,
+        if_file_doesnt_exist=if_file_doesnt_exist,
         **kwargs,
     ).output

--- a/tests/files/test_file.py
+++ b/tests/files/test_file.py
@@ -226,3 +226,19 @@ def test_get_files(file_type, file_location, locations_method_map_fixture):
         for file in files:
             assert file.location.location_type.value == file_location
             assert file.type.name.value == file_type
+
+
+@pytest.mark.parametrize(
+    "invalid_path",
+    [
+        "/tmp/cklcdklscdksl.csv",
+        "/tmp/cklcdklscdksl/*.csv",
+    ],
+)
+def test_get_files_raise_exception(invalid_path, caplog):
+    """get_files expected to fail with default 'if_file_doesnt_exist' exception strategy"""
+
+    with pytest.raises(ValueError) as e:
+        _ = get_files(path_pattern=invalid_path)
+    expected_error = f"File(s) not found for path/pattern '{invalid_path}'"
+    assert expected_error in str(e.value)

--- a/tests/files/test_file.py
+++ b/tests/files/test_file.py
@@ -6,12 +6,7 @@ import pytest
 from botocore.client import BaseClient
 from google.cloud.storage import Client
 
-from astro.constants import (
-    SUPPORTED_FILE_LOCATIONS,
-    SUPPORTED_FILE_TYPES,
-    FileLocation,
-    FileType,
-)
+from astro.constants import SUPPORTED_FILE_TYPES, FileType
 from astro.files import File, get_files
 
 sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent, "data/sample.csv")
@@ -206,26 +201,6 @@ def test_read_with_explicit_valid_type(
             )
         assert path == args[0]
         mocked_read.assert_called()
-
-
-@pytest.mark.parametrize(
-    "locations_method_map_fixture", [{"method": "paths"}], indirect=True
-)
-@pytest.mark.parametrize("file_location", SUPPORTED_FILE_LOCATIONS)
-@pytest.mark.parametrize("file_type", SUPPORTED_FILE_TYPES)
-def test_get_files(file_type, file_location, locations_method_map_fixture):
-    """Test get_files to resolve the patterns within paths"""
-    path = f"{file_location}://tmp/sample.{file_type}"
-    if file_location == FileLocation.LOCAL.value:
-        path = f"/tmp/sample.{file_type}"
-
-    patch_module = locations_method_map_fixture[FileLocation(file_location)]
-
-    with patch(patch_module):
-        files = get_files(path)
-        for file in files:
-            assert file.location.location_type.value == file_location
-            assert file.type.name.value == file_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes: #476 
 
**Describe the bug**
When we use the load_file operator and pass a local file and the file doesn't exist, the operator does nothing and fails silently. 

**Version**
* Astro: [e.g. 0.9.2]

**To Reproduce**
Steps to reproduce the behavior:
1. Use the load_file operator:
    ```
     aql.load_file(  # noqa: F841
            input_file=File(
                path='/tmp/non_existing_file.csv',
            ),
            task_id="load_csv",
            output_table=table_metadata,
            chunk_size=chunk_size,
     )
    ```
2. Now the operator will run without any warning or failure making the user think that the operator ran successfully.

**Expected behavior**
**Case 1 (default)**

> The operator should fail with an error if param `if_file_doesnt_exist`  is set to `exception` saying that the file doesn't exist.

**Case 2**

> if the `if_file_doesnt_exist` is set to `suppress` the operator should not raise an exception.

To accommodate this behaviour added a parameter `if_file_doesnt_exist`  to `load_file()` operator and `get_file()` function.
