### PR TITLE
Create Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,30 @@
+# Description
+## What is the current behavior?
+<!-- Please describe the current behavior that you are modifying. -->
+
+
+<!-- Issues are required for both bug fixes and features. -->
+Issue URL:
+
+
+## What is the new behavior?
+<!-- Please describe the behavior or changes that are being added by this PR. -->
+
+-
+-
+-
+
+## Does this introduce a breaking change?
+
+- [ ] Yes
+- [ ] No
+
+<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
+
+
+### Checklist
+- [ ] Code compiles correctly
+- [ ] Created tests which fail without the change (if possible)
+- [ ] All tests passing
+- [ ] Extended the README / documentation, if necessary
+- [ ] Added myself / the copyright holder to the AUTHORS file

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -3,7 +3,7 @@
 <!-- Please describe the current behavior that you are modifying. -->
 
 
-<!-- 
+<!--
 Issues are required for both bug fixes and features.
 Reference it using one of the following:
 
@@ -20,9 +20,6 @@ related: #ISSUE
 -
 
 ## Does this introduce a breaking change?
-
-- [ ] Yes
-- [ ] No
 
 <!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -23,7 +23,7 @@ Issue URL:
 
 
 ### Checklist
-- [ ] Code compiles correctly
+- [ ] Code passes all static checks
 - [ ] Created tests which fail without the change (if possible)
 - [ ] All tests passing
 - [ ] Extended the README / documentation, if necessary

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -21,11 +21,7 @@ related: #ISSUE
 
 ## Does this introduce a breaking change?
 
-<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
-
 
 ### Checklist
-- [ ] Code passes all static checks
 - [ ] Created tests which fail without the change (if possible)
-- [ ] All tests passing
 - [ ] Extended the README / documentation, if necessary

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -32,4 +32,3 @@ related: #ISSUE
 - [ ] Created tests which fail without the change (if possible)
 - [ ] All tests passing
 - [ ] Extended the README / documentation, if necessary
-- [ ] Added myself / the copyright holder to the AUTHORS file

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -3,8 +3,13 @@
 <!-- Please describe the current behavior that you are modifying. -->
 
 
-<!-- Issues are required for both bug fixes and features. -->
-Issue URL:
+<!-- 
+Issues are required for both bug fixes and features.
+Reference it using one of the following:
+
+closes: #ISSUE
+related: #ISSUE
+-->
 
 
 ## What is the new behavior?


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently there is no pull request template so users need to create their own PR descriptions from scratch. This leads to under-descriptive PRs and a lack of consistency.

<!-- Issues are required for both bug fixes and features. -->
closes:  https://github.com/astronomer/astro-sdk/issues/205
related:


## What is the new behavior?

Now when users create a PR, they will get this description automatically to help them fill in relevant details

## Does this introduce a breaking change? No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary

closes https://github.com/astronomer/astro-sdk/issues/205