### PR TITLE
Fix the link for Astro SDK Github discussion

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 ---
 contact_links:
   - name: Ask a question or get support (Forum)
-    url: https://github.com/astronomer/astronomer-providers/discussions/
+    url: https://github.com/astronomer/astro-sdk/discussions/
     about: Ask a question or request support for using this package


### PR DESCRIPTION
Looks like this might have been a copy paste error in https://github.com/astronomer/astro-sdk/pull/200/files
