### PR TITLE
Bump Google Provider for `google` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ tests = [
     "sqlalchemy-stubs"  # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
 ]
 google = [
-    "apache-airflow-providers-google",
+    "apache-airflow-providers-google>=6.4.0",
     "sqlalchemy-bigquery>=1.3.0",
     "smart-open[gcs]>=5.2.1",
 ]


### PR DESCRIPTION
I updated it in https://github.com/astronomer/astro-sdk/pull/294 but missed the google extra.

