### PR TITLE
Fix benchmark permissions

### DIFF
--- a/tests/benchmark/dags/evaluate_load_file.py
+++ b/tests/benchmark/dags/evaluate_load_file.py
@@ -55,7 +55,6 @@ def create_dag(database_name, table_args, dataset):
 
         @task(trigger_rule="all_done")
         def delete_table(table_metadata):
-            print("table_metadata : ", table_metadata)
             db = create_database(table_metadata.conn_id)
             db.drop_table(table_metadata)
 

--- a/tests/benchmark/infrastructure/terraform/main.tf
+++ b/tests/benchmark/infrastructure/terraform/main.tf
@@ -24,13 +24,19 @@ resource "google_service_account" "benchmark" {
 
 resource "google_project_iam_member" "benchmark_gcs" {
   project = var.project
-  role    = "roles/storage.objectViewer"
+  role    = "roles/storage.objectAdmin"
   member  = "serviceAccount:${google_service_account.benchmark.email}"
 }
 
-resource "google_project_iam_member" "benchmark_bq" {
+resource "google_project_iam_member" "benchmark_bq_data_editor" {
   project = var.project
   role    = "roles/bigquery.dataEditor"
+  member  = "serviceAccount:${google_service_account.benchmark.email}"
+}
+
+resource "google_project_iam_member" "benchmark_bq_job_user" {
+  project = var.project
+  role    = "roles/bigquery.jobUser"
   member  = "serviceAccount:${google_service_account.benchmark.email}"
 }
 


### PR DESCRIPTION
# Description

## What is the current behaviour?

Developers fail to run the benchmark K8s job when running:
```
make gke_setup
```

The K8s pod, created by the K8s job, logs:
```
+ python3 -W ignore /opt/app/tests/benchmark/run.py --dataset=few_kb --database=bigquery --revision d5f30a1 --chunk-size=1000000
Traceback (most recent call last):
  File "/opt/app/tests/benchmark/run.py", line 147, in <module>
    run_dag(
  File "/opt/app/tests/benchmark/run.py", line 67, in wrapper
    dag = func(*args, **kwargs)
  File "/opt/app/tests/benchmark/run.py", line 104, in run_dag
    dag.run(
  File "/usr/local/lib/python3.9/dist-packages/airflow/models/dag.py", line 2247, in run
    job.run()
  File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/base_job.py", line 244, in run
    self._execute()
  File "/usr/local/lib/python3.9/dist-packages/airflow/utils/session.py", line 71, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/backfill_job.py", line 860, in _execute
    raise BackfillUnfinished(err, ti_status)
airflow.exceptions.BackfillUnfinished: Some task instances failed
```

In order to get further details about the issue, it is possible to create a K8s pod with the container image using:
```
apiVersion: v1
kind: Pod
metadata:
  name: troubleshoot
  namespace: benchmark
spec:
  containers:
  - name: troubleshoot-benchmark
    image: gcr.io/astronomer-dag-authoring/benchmark
    # Just spin & wait forever
    command: [ "/bin/bash", "-c", "--" ]
    args: [ "while true; do sleep 30; done;" ]
```

This pod logs:
```
google.api_core.exceptions.Forbidden: 403 POST https://bigquery.googleapis.com/bigquery/v2/projects/astronomer-dag-authoring/jobs?prettyPrint=false: Access Denied: Project astronomer-dag-authoring: User does not have bigquery.jobs.create permission in project astronomer-dag-authoring.
```

## What is the new behaviour?

Developers can run successfully, from `tests/benchmark`:
```
make gke_setup
```

And the K8s job/pod are successful.

More information about the permissions to BigQuery and Cloud Storage can be found at:
https://cloud.google.com/storage/docs/access-control/iam-roles
https://cloud.google.com/bigquery/docs/access-control

## Does this introduce a breaking change?

No

### Checklist
- [x] The command `make run_job` successfully runs a K8s job without errors
- [x]  The command generated files to `gs://dag-authoring/benchmark/results/`
