### PR TITLE
Use native path for S3 to Bigquery in load_file operator

### DIFF
--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -52,3 +52,5 @@ connections:
     conn_type: aws
     description: null
     extra: null
+    login: $AWS_ACCESS_KEY_ID
+    password: $AWS_SECRET_ACCESS_KEY

--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -52,5 +52,3 @@ connections:
     conn_type: aws
     description: null
     extra: null
-    login: $AWS_ACCESS_KEY_ID
-    password: $AWS_SECRET_ACCESS_KEY

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -207,7 +207,7 @@ class BaseDatabase(ABC):
         """
         Remove all rows from a given table.
 
-        :param table: The table to be deleted.
+        :param table: Table from which all rows will be deleted.
         """
         statement = self._truncate_table_statement.format(
             self.get_table_qualified_name(table)

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from typing import Dict, List, Optional, Tuple, Union
 
-import pandas
 import pandas as pd
 import sqlalchemy
 from airflow.hooks.dbapi import DbApiHook

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -205,7 +205,7 @@ class BaseDatabase(ABC):
 
     def truncate_table(self, table: Table) -> None:
         """
-        Delete a SQL table, if it exists.
+        Remove all rows from a given table.
 
         :param table: The table to be deleted.
         """

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -37,7 +37,7 @@ class BaseDatabase(ABC):
     _create_schema_statement: str = "CREATE SCHEMA IF NOT EXISTS {}"
     _drop_table_statement: str = "DROP TABLE IF EXISTS {}"
     _create_table_statement: str = "CREATE TABLE IF NOT EXISTS {} AS {}"
-
+    _truncate_table_statement: str = "TRUNCATE TABLE {}"
     # Used to normalize the ndjson when appending fields in nested fields.
     # Example -
     #   ndjson - {'a': {'b': 'val'}}
@@ -199,6 +199,17 @@ class BaseDatabase(ABC):
         :param table: The table to be deleted.
         """
         statement = self._drop_table_statement.format(
+            self.get_table_qualified_name(table)
+        )
+        self.run_sql(statement)
+
+    def truncate_table(self, table: Table) -> None:
+        """
+        Delete a SQL table, if it exists.
+
+        :param table: The table to be deleted.
+        """
+        statement = self._truncate_table_statement.format(
             self.get_table_qualified_name(table)
         )
         self.run_sql(statement)

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -485,7 +485,7 @@ class BaseDatabase(ABC):
         :param source_file: File from which we need to transfer data
         :param target_table: Table that needs to be populated with file data
         :param if_exists: Overwrite file if exists. Default False
-        :param native_support_kwargs: kwargs to be used by method involved in native support flow
+        :param native_support_kwargs: kwargs to be used by native loading command
         """
         raise NotImplementedError
 

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from typing import Dict, List, Optional, Tuple, Union
 
+import pandas
 import pandas as pd
 import sqlalchemy
 from airflow.hooks.dbapi import DbApiHook
@@ -479,19 +480,16 @@ class BaseDatabase(ABC):
         raise NotImplementedError
 
     def create_empty_table(
-        self, source_file: File, target_table: Table, chunksize: int = 1000
+        self, source_file: File, target_table: Table, nrows: int = 1000
     ):
         """
         Infer schema from source file and create and empty table in database
 
         :param source_file: File from which we need to transfer data
         :param target_table: Table that needs to be populated with file data
-        :param chunksize: No. of rows to use to infer schema
+        :param nrows: No. of rows to use to infer schema
         """
-        df = source_file.export_to_dataframe(chunksize=chunksize)
-        # When we pass chunksize we get reference to data and not the data.
-        # We need to use read() to get the 1st chunk.
-        df = df.read()
+        df = source_file.export_to_dataframe(nrows=nrows)
         schema_statement = get_schema(
             df, self.get_table_qualified_name(target_table), con=self.sqlalchemy_engine
         )

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -226,6 +226,7 @@ class BaseDatabase(ABC):
         if_exists: LoadExistStrategy = "replace",
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         use_native_support: bool = True,
+        native_support_kwargs: Optional[Dict] = None,
         **kwargs,
     ):
         """
@@ -237,7 +238,8 @@ class BaseDatabase(ABC):
         :param if_exists: Overwrite file if exists
         :param chunk_size: Specify the number of records in each batch to be written at a time
         :param use_native_support: Use native support for data transfer if available on the destination
-        :param normalize_config: pandas json_normalize params config.
+        :param normalize_config: pandas json_normalize params config
+        :param native_support_kwargs: kwargs to be used by method involved in native support flow
         """
         input_files = resolve_file_path_pattern(
             input_file.path,
@@ -252,6 +254,7 @@ class BaseDatabase(ABC):
                     source_file=file,
                     target_table=output_table,
                     if_exists=if_exists,
+                    native_support_kwargs=native_support_kwargs,
                     **kwargs,
                 )
             else:
@@ -472,11 +475,17 @@ class BaseDatabase(ABC):
         source_file: File,
         target_table: Table,
         if_exists: LoadExistStrategy = "replace",
+        native_support_kwargs: Optional[Dict] = None,
         **kwargs,
     ):
         """
         Checks if optimised path for transfer between File location to database exists
-        and if it does, it transfers it and returns true else false.
+        and if it does, it transfers it and returns true else false
+
+        :param source_file: File from which we need to transfer data
+        :param target_table: Table that needs to be populated with file data
+        :param if_exists: Overwrite file if exists. Default False
+        :param native_support_kwargs: kwargs to be used by method involved in native support flow
         """
         raise NotImplementedError
 
@@ -494,6 +503,7 @@ class BaseDatabase(ABC):
         # When we pass chunksize we get reference to data and not the data.
         # We need to use read() to get the 1st chunk.
         df = df.read()
+
         self.load_pandas_dataframe_to_table(
             source_dataframe=df,
             target_table=target_table,

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -10,8 +10,8 @@ from airflow.providers.google.cloud.hooks.bigquery_dts import (
 from google.api_core.exceptions import NotFound as GoogleNotFound
 from google.cloud import bigquery_datatransfer
 from google.cloud.bigquery_datatransfer_v1.types import (
+    StartManualTransferRunsResponse,
     TransferConfig,
-    TransferRun,
     TransferState,
 )
 from google.protobuf import timestamp_pb2  # type: ignore
@@ -377,19 +377,19 @@ class S3ToBigqueryDataTransfer:
         Extract transfer_config_id from TransferConfig object
         """
         # ToDo: Look for a native way to extract 'transfer_config_id'
-        # name - "projects/103191871648/locations/us/transferConfigs/6302bf19-0000-26cf-a568-94eb2c0a61ee'.
+        # name - 'projects/103191871648/locations/us/transferConfigs/6302bf19-0000-26cf-a568-94eb2c0a61ee'
         # We need extract transferConfigs which is at the end of string.
         tokens = config.name.split("transferConfigs/")
         return str(tokens[-1])
 
     @staticmethod
-    def get_run_id(config: TransferRun) -> str:
+    def get_run_id(config: StartManualTransferRunsResponse) -> str:
         """
-        Extract run_id from TransferRun object
+        Extract run_id from StartManualTransferRunsResponse object
         """
         # ToDo: Look for a native way to extract 'run_id'
         # config.runs[0].name - "projects/103191871648/locations/us/
-        # transferConfigs/62d38894-0000-239c-a4d8-089e08325b54/runs/62d6a4df-0000-2fad-8752-d4f547e68ef4'.
+        # transferConfigs/62d38894-0000-239c-a4d8-089e08325b54/runs/62d6a4df-0000-2fad-8752-d4f547e68ef4'
         # We need extract transferConfigs which is at the end of string.
         tokens = config.runs[0].name.split("runs/")
         return str(tokens[-1])

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -266,10 +266,10 @@ class BigqueryDatabase(BaseDatabase):
         **kwargs,
     ):
         """
-         Load content of multiple files in S3 to output_table in Bigquery by using a datatransfer job
+        Load content of multiple files in S3 to output_table in Bigquery by using a datatransfer job
         Note - To use this function we need
-            1. Enable API on Bigquery
-            2. Enable Data transfer service on Bigquery, which is a chargeable service
+        1. Enable API on Bigquery
+        2. Enable Data transfer service on Bigquery, which is a chargeable service
         for more information refer - https://cloud.google.com/bigquery-transfer/docs/enable-transfer-service
 
         :param source_file: Source file that is used as source of data
@@ -342,9 +342,7 @@ class S3ToBigqueryDataTransfer:
         self.kwargs = kwargs
 
     def run(self):
-        """
-        Algo to run S3 to Bigquery datatransfer
-        """
+        """Algo to run S3 to Bigquery datatransfer"""
         transfer_config_id = self.create_transfer_config()
         try:
             # Manually run a transfer job using previously created transfer config
@@ -373,9 +371,7 @@ class S3ToBigqueryDataTransfer:
 
     @staticmethod
     def get_transfer_config_id(config: TransferConfig) -> str:
-        """
-        Extract transfer_config_id from TransferConfig object
-        """
+        """Extract transfer_config_id from TransferConfig object"""
         # ToDo: Look for a native way to extract 'transfer_config_id'
         # name - 'projects/103191871648/locations/us/transferConfigs/6302bf19-0000-26cf-a568-94eb2c0a61ee'
         # We need extract transferConfigs which is at the end of string.
@@ -384,9 +380,7 @@ class S3ToBigqueryDataTransfer:
 
     @staticmethod
     def get_run_id(config: StartManualTransferRunsResponse) -> str:
-        """
-        Extract run_id from StartManualTransferRunsResponse object
-        """
+        """Extract run_id from StartManualTransferRunsResponse object"""
         # ToDo: Look for a native way to extract 'run_id'
         # config.runs[0].name - "projects/103191871648/locations/us/
         # transferConfigs/62d38894-0000-239c-a4d8-089e08325b54/runs/62d6a4df-0000-2fad-8752-d4f547e68ef4'

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -356,6 +356,8 @@ class S3ToBigqueryDataTransfer:
     def delete_transfer_config(self, run_id):
         """
         Delete transfer config created on Google cloud
+
+        :param run_id: job run id
         """
         req = bigquery_datatransfer.DeleteTransferConfigRequest(name=run_id)
         self.client.delete_transfer_config(req)
@@ -363,6 +365,8 @@ class S3ToBigqueryDataTransfer:
     def run_transfer_now(self, run_id):
         """
         Run transfer job on Google cloud
+
+        :param run_id: job run id
         """
         start_time = timestamp_pb2.Timestamp(seconds=int(time.time() + 10))
         run_req = bigquery_datatransfer.StartManualTransferRunsRequest(
@@ -372,6 +376,9 @@ class S3ToBigqueryDataTransfer:
         return run.runs[0].name
 
     def get_transfer_info(self, run_id):
-        """Get transfer job info"""
+        """Get transfer job info
+
+        :param run_id: job run id
+        """
         req = bigquery_datatransfer.GetTransferRunRequest(name=run_id)
         return self.client.get_transfer_run(req)

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -20,6 +20,7 @@ class LoadFile(BaseOperator):
     :param chunk_size: Specify the number of records in each batch to be written at a time.
     :param if_exists: Overwrite file if exists. Default False.
     :param use_native_support: Use native support for data transfer if available on the destination.
+    :param native_support_kwargs: kwargs to be used by method involved in native support flow
 
     :return: If ``output_table`` is passed this operator returns a Table object. If not
         passed, returns a dataframe.
@@ -35,6 +36,7 @@ class LoadFile(BaseOperator):
         if_exists: LoadExistStrategy = "replace",
         ndjson_normalize_sep: str = "_",
         use_native_support: bool = True,
+        native_support_kwargs: Optional[Dict] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -46,6 +48,7 @@ class LoadFile(BaseOperator):
         self.ndjson_normalize_sep = ndjson_normalize_sep
         self.normalize_config: Dict[str, str] = {}
         self.use_native_support = use_native_support
+        self.native_support_kwargs: Dict[str, Any] = native_support_kwargs or {}
 
     def execute(self, context: Any) -> Union[Table, pd.DataFrame]:  # skipcq: PYL-W0613
         """
@@ -86,6 +89,7 @@ class LoadFile(BaseOperator):
             if_exists=self.if_exists,
             chunk_size=self.chunk_size,
             use_native_support=self.use_native_support,
+            native_support_kwargs=self.native_support_kwargs,
         )
         self.log.info("Completed loading the data into %s.", self.output_table)
         return self.output_table
@@ -157,6 +161,7 @@ def load_file(
     if_exists: LoadExistStrategy = "replace",
     ndjson_normalize_sep: str = "_",
     use_native_support: bool = True,
+    native_support_kwargs: Optional[Dict] = None,
     **kwargs: Any,
 ) -> XComArg:
     """Load a file or bucket into either a SQL table or a pandas dataframe.
@@ -168,6 +173,7 @@ def load_file(
     :param ndjson_normalize_sep: separator used to normalize nested ndjson.
         ex - ``{"a": {"b":"c"}}`` will result in: ``column - "a_b"`` where ``ndjson_normalize_sep = "_"``
     :param use_native_support: Use native support for data transfer if available on the destination.
+    :param native_support_kwargs: kwargs to be used by method involved in native support flow
     """
 
     # Note - using path for task id is causing issues as it's a pattern and
@@ -181,5 +187,6 @@ def load_file(
         if_exists=if_exists,
         ndjson_normalize_sep=ndjson_normalize_sep,
         use_native_support=use_native_support,
+        native_support_kwargs=native_support_kwargs,
         **kwargs,
     ).output

--- a/tests/databases/test_base_database.py
+++ b/tests/databases/test_base_database.py
@@ -125,3 +125,32 @@ def test_load_file_to_table_natively(
         assert method.called
         assert is_dict_subset(superset=method.call_args.kwargs, subset=expected_kwargs)
         assert method.call_args.args == expected_args
+
+
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [{"database": Database.BIGQUERY, "table": Table(conn_id="bigquery")}],
+    indirect=True,
+    ids=["bigquery"],
+)
+def test_create_empty_table(database_table_fixture):
+    db, test_table = database_table_fixture
+    file = File(path="../data/homes_main.csv")
+
+    database = create_database(test_table.conn_id)
+    database.create_empty_table(source_file=file, target_table=test_table)
+
+    df = db.export_table_to_pandas_dataframe(test_table)
+    cols = list(df.columns)
+    cols.sort()
+    assert cols == [
+        "acres",
+        "age",
+        "baths",
+        "beds",
+        "list",
+        "living",
+        "rooms",
+        "sell",
+        "taxes",
+    ]

--- a/tests/databases/test_base_database.py
+++ b/tests/databases/test_base_database.py
@@ -1,3 +1,4 @@
+import pathlib
 from unittest import mock
 
 import pytest
@@ -8,6 +9,8 @@ from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.files import File
 from astro.sql.table import Table
+
+CWD = pathlib.Path(__file__).parent
 
 
 class DatabaseSubclass(BaseDatabase):
@@ -135,7 +138,7 @@ def test_load_file_to_table_natively(
 )
 def test_create_empty_table(database_table_fixture):
     db, test_table = database_table_fixture
-    file = File(path="../data/homes_main.csv")
+    file = File(path=str(CWD) + "/../data/homes_main.csv")
 
     database = create_database(test_table.conn_id)
     database.create_empty_table(source_file=file, target_table=test_table)

--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -6,6 +6,12 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 import sqlalchemy
+from databases.google.bigquery import S3ToBigqueryDataTransfer
+from google.cloud.bigquery_datatransfer_v1.types import (
+    StartManualTransferRunsResponse,
+    TransferConfig,
+    TransferRun,
+)
 
 from astro.constants import Database
 from astro.databases import create_database
@@ -355,3 +361,26 @@ def test_create_table_from_select_statement(database_table_fixture):
     expected = pd.DataFrame([{"id": 1, "name": "First"}])
     test_utils.assert_dataframes_are_equal(df, expected)
     database.drop_table(target_table)
+
+
+def test_get_transfer_config_id():
+    config = TransferConfig()
+    config.name = "projects/103191871648/locations/us/transferConfigs/6302bf19-0000-26cf-a568-94eb2c0a61ee"
+    assert (
+        S3ToBigqueryDataTransfer.get_transfer_config_id(config)
+        == "6302bf19-0000-26cf-a568-94eb2c0a61ee"
+    )
+
+
+def test_get_run_id():
+    config = StartManualTransferRunsResponse()
+    run = TransferRun()
+    run.name = (
+        "projects/103191871648/locations/us/transferConfigs/"
+        "62d38894-0000-239c-a4d8-089e08325b54/runs/62d6a4df-0000-2fad-8752-d4f547e68ef4"
+    )
+    config.runs.append(run)
+    assert (
+        S3ToBigqueryDataTransfer.get_run_id(config)
+        == "62d6a4df-0000-2fad-8752-d4f547e68ef4"
+    )

--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -6,7 +6,6 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 import sqlalchemy
-from databases.google.bigquery import S3ToBigqueryDataTransfer
 from google.cloud.bigquery_datatransfer_v1.types import (
     StartManualTransferRunsResponse,
     TransferConfig,
@@ -15,7 +14,7 @@ from google.cloud.bigquery_datatransfer_v1.types import (
 
 from astro.constants import Database
 from astro.databases import create_database
-from astro.databases.google.bigquery import BigqueryDatabase
+from astro.databases.google.bigquery import BigqueryDatabase, S3ToBigqueryDataTransfer
 from astro.exceptions import NonExistentTableException
 from astro.files import File
 from astro.settings import SCHEMA

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -836,19 +836,11 @@ def test_aql_load_file_optimized_path_method_is_not_called(
 
     with mock.patch(mock_path) as method:
         load_file(
-            input_file=File(file_uri),
-            output_table=test_table,
-            use_native_support=False,
+            input_file=File(file_uri), output_table=test_table, use_native_support=False
         ).operator.execute({})
         assert not method.called
 
 
-@pytest.mark.parametrize(
-    "remote_files_fixture",
-    [{"provider": "amazon"}],
-    indirect=True,
-    ids=["amazon_S3"],
-)
 @pytest.mark.parametrize(
     "database_table_fixture",
     [
@@ -860,16 +852,20 @@ def test_aql_load_file_optimized_path_method_is_not_called(
     ids=["Bigquery"],
 )
 def test_aql_load_file_optimized_path_method_is_not_called_1(
-    sample_dag, database_table_fixture, remote_files_fixture
+    sample_dag, database_table_fixture
 ):
     """
     Verify that the optimised path method is skipped in case use_native_support is set to False.
     """
     db, test_table = database_table_fixture
-    file_uri = remote_files_fixture[0]
 
     load_file(
-        input_file=File(file_uri),
+        input_file=File("s3://tmp9/homes_main.csv", conn_id="aws_1"),
         output_table=test_table,
         use_native_support=True,
+        native_support_kwargs={
+            "ignore_unknown_values": True,
+            "allow_jagged_rows": True,
+            "skip_leading_rows": "1",
+        },
     ).operator.execute({})

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -859,6 +859,9 @@ def test_aql_load_file_optimized_path_method_is_not_called_1(
     """
     db, test_table = database_table_fixture
 
+    # We are using a preexisting file for integration test, since the dynamically populating
+    # file on S3 results in file not found, since that file is not propagated to all the servers/clusters,
+    # and we might hit a server where the file in not yet populated, resulting in file not found issue.
     load_file(
         input_file=File("s3://tmp9/homes_main.csv", conn_id="aws_1"),
         output_table=test_table,
@@ -869,3 +872,6 @@ def test_aql_load_file_optimized_path_method_is_not_called_1(
             "skip_leading_rows": "1",
         },
     ).operator.execute({})
+
+    df = db.export_table_to_pandas_dataframe(test_table)
+    assert df.shape == (3, 9)

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -841,6 +841,7 @@ def test_aql_load_file_optimized_path_method_is_not_called(
         assert not method.called
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",
     [
@@ -863,7 +864,7 @@ def test_aql_load_file_optimized_path_method_is_not_called_1(
     # file on S3 results in file not found, since that file is not propagated to all the servers/clusters,
     # and we might hit a server where the file in not yet populated, resulting in file not found issue.
     load_file(
-        input_file=File("s3://tmp9/homes_main.csv", conn_id="aws_1"),
+        input_file=File("s3://tmp9/homes_main.csv", conn_id="aws_conn"),
         output_table=test_table,
         use_native_support=True,
         native_support_kwargs={

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -740,9 +740,9 @@ def is_dict_subset(superset: dict, subset: dict) -> bool:
 
 @pytest.mark.parametrize(
     "remote_files_fixture",
-    [{"provider": "google"}],
+    [{"provider": "google"}, {"provider": "amazon"}],
     indirect=True,
-    ids=["google_gcs"],
+    ids=["google_gcs", "amazon_s3"],
 )
 @pytest.mark.parametrize(
     "database_table_fixture",
@@ -768,13 +768,21 @@ def test_aql_load_file_optimized_path_method_called(
     file = File(file_uri)
     optimised_path_to_method = {
         ("gs", "bigquery",): {
-            "method_path": "astro.databases.google.bigquery.BigqueryDatabase.gs_to_bigquery",
+            "method_path": "astro.databases.google.bigquery.BigqueryDatabase.load_gs_file_to_bigquery",
             "expected_kwargs": {
                 "source_file": file,
                 "target_table": test_table,
             },
             "expected_args": (),
-        }
+        },
+        ("s3", "bigquery",): {
+            "method_path": "astro.databases.google.bigquery.BigqueryDatabase.load_s3_file_to_bigquery",
+            "expected_kwargs": {
+                "source_file": file,
+                "target_table": test_table,
+            },
+            "expected_args": (),
+        },
     }
 
     source = file_uri.split(":")[0]
@@ -795,9 +803,9 @@ def test_aql_load_file_optimized_path_method_called(
 
 @pytest.mark.parametrize(
     "remote_files_fixture",
-    [{"provider": "google"}],
+    [{"provider": "google"}, {"provider": "amazon"}],
     indirect=True,
-    ids=["google_gcs"],
+    ids=["google_gcs", "amazon_s3"],
 )
 @pytest.mark.parametrize(
     "database_table_fixture",
@@ -826,8 +834,11 @@ def test_aql_load_file_optimized_path_method_is_not_called(
     # }
     optimised_path_to_method = {
         ("gs", "bigquery",): {
-            "method_path": "astro.databases.google.bigquery.BigqueryDatabase.gs_to_bigquery",
-        }
+            "method_path": "astro.databases.google.bigquery.BigqueryDatabase.load_gs_file_to_bigquery",
+        },
+        ("s3", "bigquery",): {
+            "method_path": "astro.databases.google.bigquery.BigqueryDatabase.load_s3_file_to_bigquery",
+        },
     }
 
     source = file_uri.split(":")[0]

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -841,3 +841,35 @@ def test_aql_load_file_optimized_path_method_is_not_called(
             use_native_support=False,
         ).operator.execute({})
         assert not method.called
+
+
+@pytest.mark.parametrize(
+    "remote_files_fixture",
+    [{"provider": "amazon"}],
+    indirect=True,
+    ids=["amazon_S3"],
+)
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.BIGQUERY,
+        }
+    ],
+    indirect=True,
+    ids=["Bigquery"],
+)
+def test_aql_load_file_optimized_path_method_is_not_called_1(
+    sample_dag, database_table_fixture, remote_files_fixture
+):
+    """
+    Verify that the optimised path method is skipped in case use_native_support is set to False.
+    """
+    db, test_table = database_table_fixture
+    file_uri = remote_files_fixture[0]
+
+    load_file(
+        input_file=File(file_uri),
+        output_table=test_table,
+        use_native_support=True,
+    ).operator.execute({})


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, we are transferring the data between S3 to Bigquery vi GCS to local and then local to Bigquery.

related: #512 



## What is the new behavior?
We can request Bigquery via API to submit the job at bigquery to do the direct transfer, which can lot quicker.
https://cloud.google.com/bigquery-transfer/docs/s3-transfer#bq

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
