### PR TITLE
Read default config if airflow's isn't defined

### DIFF
--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -1,4 +1,4 @@
 from airflow.configuration import conf
 
 DEFAULT_SCHEMA = "tmp_astro"
-SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=None) or DEFAULT_SCHEMA
+SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -1,4 +1,4 @@
 from airflow.configuration import conf
 
 DEFAULT_SCHEMA = "tmp_astro"
-SCHEMA = conf.get("astro_sdk", "sql_schema") or DEFAULT_SCHEMA
+SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=None) or DEFAULT_SCHEMA


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, the code for reading default `sql_schema` in setting.py errors out if the config is not defined in airflow's config.

related: #503 


## What is the new behavior?
Added a default value of not `None` so that the default value gets picked up.


## Does this introduce a breaking change?
Nope.

### Checklist
- [X] Created tests that fail without the change (if possible)
