### PR TITLE
Add CI job to check for dead links

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: '.github/workflows/mlc_config.json'
 
   Type-Check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,12 @@ jobs:
           key: ${{ hashFiles('pyproject.toml') }}
       - uses: pre-commit/action@v2.0.3
 
+  Markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+
   Type-Check:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost:"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ How to Train Your Dragon 2 (2014)|7.9
 
 ## Available operations
 
-A summary of the currently available operations in **Astro SDK Python**. More details are available in the [reference guide](REFERENCE.md).
+A summary of the currently available operations in **Astro SDK Python**.
 * `load_file`: load a given file into a SQL table
 * `transform`: applies a SQL select statement to a source table and saves the result to a destination table
 * `truncate`: remove all records from a SQL table
@@ -169,15 +169,15 @@ We follow Semantic Versioning for releases. Check the [changelog](docs/CHANGELOG
 
 ## Release Managements
 
-To learn more about our release philosophy and steps, check [here](docs/RELEASE.md)
+To learn more about our release philosophy and steps, check [here](docs/development/RELEASE.md)
 
 ## Contribution Guidelines
 
 All contributions, bug reports, bug fixes, documentation improvements, enhancements, and ideas are welcome.
 
-Read the [Contribution Guideline](docs/CONTRIBUTING.md) for a detailed overview on how to contribute.
+Read the [Contribution Guideline](docs/development/CONTRIBUTING.md) for a detailed overview on how to contribute.
 
-As contributors and maintainers to this project, you should abide by the [Contributor Code of Conduct](docs/CODE_OF_CONDUCT.md).
+As contributors and maintainers to this project, you should abide by the [Contributor Code of Conduct](docs/development/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/docs/development/RELEASE.md
+++ b/docs/development/RELEASE.md
@@ -64,8 +64,11 @@ Once your release branch is ready to go there are a few simple steps to actually
 The first step is to go to [the base level \_\_init\_\_.py](../../src/astro/__init__.py) and change the `__version__` variable to the new version. You can then
 push this change to main or create a PR depending on your level of permission within the project.
 
+<!-- markdown-link-check-disable -->
+<!-- The following GitHub link for some reason give 403 in CI, hence ignore it in markdown-link -->
 The second step is to [create a release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
 in GitHub. Please take extra care to ensure that you a) create a tag with the new release version (e.g. `0.7.0`) and that you
 target the release branch (e.g. `release-0.7`). Failure to do these steps properly could result in a release we will later need to yank.
+<!-- markdown-link-check-enable -->
 
 Once you've created your release, that's it! The rest of the steps should be handled by the CI system.

--- a/tests/benchmark/datasets.md
+++ b/tests/benchmark/datasets.md
@@ -26,18 +26,20 @@ Within `gs://astro-sdk/benchmark/`, there are two paths:
 ## Origin of these datasets
 
 ### UK COVID overview
+<!-- markdown-link-check-disable -->
+
 Subset of the data available in the government website
 * Source: https://coronavirus.data.gov.uk/api/v2/data?areaType=overview&metric=covidOccupiedMVBeds&metric=cumCasesByPublishDate&metric=newOnsDeathsByRegistrationDate&metric=hospitalCases&format=csv
 * Download date: 8 February 2022
 * Original size: 45 KB
 * Dataset URI: `gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.parquet`
-* Processing details: [download_datasets.sh](tests/benchmark/download_datasets.sh)
+* Processing details: [download_datasets.sh](download_datasets.sh)
+<!-- markdown-link-check-enable -->
 
 ```commandline
 $ sed -n '1,160 p' covid_overview.csv > covid_overview_160rows.csv
 $python -c 'import pandas; df = pandas.read_csv("covid_overview_160rows.csv").to_parquet("covid_overview_10kb.parquet")'
 ```
-
 
 
 ### Tate Britain
@@ -46,7 +48,7 @@ Subset of artists of pieces exposed at the Tate Britain museum
 * Download date: 1 February 2022
 * Original size: 45 KB
 * Dataset URI: `gs://astro-sdk/benchmark/trimmed/tate/*`
-* Processing details: [download_datasets.sh](tests/benchmark/download_datasets.sh)
+* Processing details: [download_datasets.sh](download_datasets.sh)
 
 ### IMDB
 Subset of the Internet Movies Database:
@@ -54,7 +56,7 @@ Subset of the Internet Movies Database:
 * Download date: 11 February 2022
 * Original size: 20 MB
 * Dataset URI: `gs://astro-sdk/benchmark/trimmed/imdb/*`
-* Processing details: [download_datasets.sh](tests/benchmark/download_datasets.sh)
+* Processing details: [download_datasets.sh](download_datasets.sh)
 
 ### Github timeline
 Subset of the Github git repository records
@@ -62,7 +64,7 @@ Subset of the Github git repository records
 * Download date: 11 February 2022
 * Original size: 20 MB
 * Dataset URI: `gs://astro-sdk/benchmark/trimmed/github/github_timeline_100mb.csv`
-* Processing details: [download_datasets.sh](tests/benchmark/download_datasets.sh)
+* Processing details: [download_datasets.sh](download_datasets.sh)
 
 ### Stack Overflow
 Subset of the archives of Stack Overflow:

--- a/tests/benchmark/results.md
+++ b/tests/benchmark/results.md
@@ -49,7 +49,7 @@ For Machine types: n2-standard-4
 |github/github-archive/*                    |10GB |0:01:09        |
 
 
-#### Baseline using `GCSToBigQueryOperator` using [benchmark_gcs_to_bigquery.py](tests/benchmark/dags/benchmark_gcs_to_big_query.py)
+#### Baseline using `GCSToBigQueryOperator` using [benchmark_gcs_to_bigquery.py](dags/benchmark_gcs_to_big_query.py)
 
 |Dataset                                    |Size | Duration(seconds)  |
 |-------------------------------------------|-----|--------------------|


### PR DESCRIPTION
This will allow avoiding situations like https://github.com/astronomer/astro-sdk/pull/526 where the links return 404

