### PR TITLE
Optimize postgres performance

### DIFF
--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from typing import Dict, List, Optional, Tuple, Union
 
+import pandas
 import pandas as pd
 import sqlalchemy
 from airflow.hooks.dbapi import DbApiHook
@@ -177,21 +178,28 @@ class BaseDatabase(ABC):
         metadata.create_all(self.sqlalchemy_engine, tables=[sqlalchemy_table])
 
     def create_table_using_schema_autodetection(
-        self, table: Table, file: Optional[File] = None
+        self,
+        table: Table,
+        file: Optional[File] = None,
+        dataframe: Optional[pandas.DataFrame] = None,
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file.
 
         :param table: The table to be created.
         :param file: File used to infer the new table columns.
+        :param dataframe: Dataframe used to infer the new table columns if there is no file
         """
         if file is None:
-            raise ValueError(
-                "File is required for creating table using schema autodetection"
+            if dataframe is None:
+                raise ValueError(
+                    "File or Dataframe is required for creating table using schema autodetection"
+                )
+            source_dataframe = dataframe
+        else:
+            source_dataframe = file.export_to_dataframe(
+                nrows=LOAD_TABLE_AUTODETECT_ROWS_COUNT
             )
-        source_dataframe = file.export_to_dataframe(
-            nrows=LOAD_TABLE_AUTODETECT_ROWS_COUNT
-        )
         db = SQLDatabase(engine=self.sqlalchemy_engine)
         db.prep_table(
             source_dataframe,
@@ -201,18 +209,25 @@ class BaseDatabase(ABC):
             index=False,
         )
 
-    def create_table(self, table: Table, file: Optional[File] = None) -> None:
+    def create_table(
+        self,
+        table: Table,
+        file: Optional[File] = None,
+        dataframe: Optional[pandas.DataFrame] = None,
+    ) -> None:
         """
         Create a table either using its explicitly defined columns or inferring
         it's columns from a given file.
 
         :param table: The table to be created
         :param file: (optional) File used to infer the table columns.
+        :param dataframe: (optional) Dataframe used to infer the new table columns if there is no file
+
         """
         if table.columns:
             self.create_table_using_columns(table)
         else:
-            self.create_table_using_schema_autodetection(table, file)
+            self.create_table_using_schema_autodetection(table, file, dataframe)
 
     def create_table_from_select_statement(
         self,
@@ -301,7 +316,7 @@ class BaseDatabase(ABC):
                     dataframe,
                     output_table,
                     chunk_size=chunk_size,
-                    if_exists=if_exists,
+                    if_exists="append",  # We've already created a new table in this case
                 )
 
     def load_pandas_dataframe_to_table(

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from typing import Dict, List, Optional, Tuple, Union
 
-import pandas
 import pandas as pd
 import sqlalchemy
 from airflow.hooks.dbapi import DbApiHook
@@ -181,7 +180,7 @@ class BaseDatabase(ABC):
         self,
         table: Table,
         file: Optional[File] = None,
-        dataframe: Optional[pandas.DataFrame] = None,
+        dataframe: Optional[pd.DataFrame] = None,
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file.
@@ -213,7 +212,7 @@ class BaseDatabase(ABC):
         self,
         table: Table,
         file: Optional[File] = None,
-        dataframe: Optional[pandas.DataFrame] = None,
+        dataframe: Optional[pd.DataFrame] = None,
     ) -> None:
         """
         Create a table either using its explicitly defined columns or inferring

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -1,9 +1,12 @@
 """Postgres database implementation."""
+import io
+from contextlib import closing
 from typing import Dict, List
 
 import pandas as pd
 import sqlalchemy
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from pandas.io.sql import SQLDatabase
 from psycopg2 import sql as postgres_sql
 
 from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy, MergeConflictStrategy
@@ -74,15 +77,29 @@ class PostgresDatabase(BaseDatabase):
         if target_table.metadata and target_table.metadata.schema:
             self.create_schema_if_needed(target_table.metadata.schema)
             schema = target_table.metadata.schema.lower()
-        source_dataframe.to_sql(
-            target_table.name,
-            schema=schema,  # type: ignore
-            con=self.sqlalchemy_engine,
+        db = SQLDatabase(engine=self.sqlalchemy_engine)
+        # within prep_table() we use pandas drop() function which is used when we pass 'if_exists=replace'.
+        # There is an issue where has_table() works with uppercase table names but the function meta.reflect() don't.
+        # To prevent the issue we are passing table name in lowercase.
+        db.prep_table(
+            source_dataframe,
+            target_table.name.lower(),
+            schema=schema,
             if_exists=if_exists,
-            chunksize=chunk_size,
-            method="multi",
             index=False,
         )
+
+        output = io.StringIO()
+        source_dataframe.to_csv(output, sep=",", header=True, index=False)
+        output.seek(0)
+        table = self.get_table_qualified_name(target_table)
+        con = self.hook.get_conn()
+        with closing(con) as conn:
+            with closing(conn.cursor()) as cur:
+                cur.copy_expert(
+                    f"COPY {table} FROM STDIN DELIMITER ',' CSV HEADER;", output
+                )
+                conn.commit()
 
     @staticmethod
     def get_table_qualified_name(table: Table) -> str:  # skipcq: PYL-R0201

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -6,7 +6,6 @@ from typing import Dict, List
 import pandas as pd
 import sqlalchemy
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from pandas.io.sql import SQLDatabase
 from psycopg2 import sql as postgres_sql
 
 from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy, MergeConflictStrategy
@@ -73,18 +72,6 @@ class PostgresDatabase(BaseDatabase):
         :param if_exists: Strategy to be used in case the target table already exists.
         :param chunk_size: Specify the number of rows in each batch to be written at a time.
         """
-        if target_table.metadata and target_table.metadata.schema:
-            self.create_schema_if_needed(target_table.metadata.schema)
-
-        # create an empty table
-        db = SQLDatabase(engine=self.sqlalchemy_engine)
-        db.prep_table(
-            source_dataframe,
-            target_table.name.lower(),
-            schema=target_table.metadata.schema,
-            if_exists=if_exists,
-            index=False,
-        )
 
         output_buffer = io.StringIO()
         source_dataframe.to_csv(output_buffer, sep=",", header=True, index=False)

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -83,15 +83,16 @@ class PostgresDatabase(BaseDatabase):
             if_exists=if_exists,
             index=False,
         )
-        output = io.StringIO()
-        source_dataframe.to_csv(output, sep=",", header=True, index=False)
-        output.seek(0)
-        table = self.get_table_qualified_name(target_table)
-        con = self.hook.get_conn()
-        with closing(con) as conn:
+        output_buffer = io.StringIO()
+        source_dataframe.to_csv(output_buffer, sep=",", header=True, index=False)
+        output_buffer.seek(0)
+        table_name = self.get_table_qualified_name(target_table)
+        postgres_conn = self.hook.get_conn()
+        with closing(postgres_conn) as conn:
             with closing(conn.cursor()) as cur:
                 cur.copy_expert(
-                    f"COPY {table} FROM STDIN DELIMITER ',' CSV HEADER;", output
+                    f"COPY {table_name} FROM STDIN DELIMITER ',' CSV HEADER;",
+                    output_buffer,
                 )
                 conn.commit()
 

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -73,6 +73,10 @@ class PostgresDatabase(BaseDatabase):
         :param chunk_size: Specify the number of rows in each batch to be written at a time.
         """
 
+        self.create_schema_if_needed(target_table.metadata.schema)
+        if not self.table_exists(table=target_table) or if_exists == "replace":
+            self.create_table(table=target_table, dataframe=source_dataframe)
+
         output_buffer = io.StringIO()
         source_dataframe.to_csv(output_buffer, sep=",", header=True, index=False)
         output_buffer.seek(0)

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -91,13 +91,12 @@ class PostgresDatabase(BaseDatabase):
         output_buffer.seek(0)
         table_name = self.get_table_qualified_name(target_table)
         postgres_conn = self.hook.get_conn()
-        with closing(postgres_conn) as conn:
-            with closing(conn.cursor()) as cur:
-                cur.copy_expert(
-                    f"COPY {table_name} FROM STDIN DELIMITER ',' CSV HEADER;",
-                    output_buffer,
-                )
-                conn.commit()
+        with closing(postgres_conn) as conn, closing(conn.cursor()) as cur:
+            cur.copy_expert(
+                f"COPY {table_name} FROM STDIN DELIMITER ',' CSV HEADER;",
+                output_buffer,
+            )
+            conn.commit()
 
     @staticmethod
     def get_table_qualified_name(table: Table) -> str:  # skipcq: PYL-R0201

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -72,6 +72,27 @@ class File:
         ) as stream:
             self.type.create_from_dataframe(stream=stream, df=df)
 
+    def _convert_remote_file_to_byte_stream(self) -> io.IOBase:
+        """
+        Read file from all supported location and convert them into a buffer that can be streamed into other data
+        structures.
+
+        Due to noted issues with using smart_open with pandas (like
+        https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
+        before exporting to a dataframe. We've found a sizable speed improvement with this optimizat
+
+        Returns: an io object that can be streamed into a dataframe (or other object)
+
+        """
+        mode = "rb" if self.is_binary() else "r"
+        remote_obj_buffer = io.BytesIO() if self.is_binary() else io.StringIO()
+        with smart_open.open(
+            self.path, mode=mode, transport_params=self.location.transport_params
+        ) as stream:
+            remote_obj_buffer.write(stream.read())
+        remote_obj_buffer.seek(0)
+        return remote_obj_buffer
+
     def export_to_dataframe(self, **kwargs) -> pd.DataFrame:
         """Read file from all supported location and convert them into dataframes.
 
@@ -80,14 +101,9 @@ class File:
         before exporting to a dataframe. We've found a sizable speed improvement with this optimization.
         """
 
-        mode = "rb" if self.is_binary() else "r"
-        remote_obj_buffer = io.BytesIO() if self.is_binary() else io.StringIO()
-        with smart_open.open(
-            self.path, mode=mode, transport_params=self.location.transport_params
-        ) as stream:
-            remote_obj_buffer.write(stream.read())
-        remote_obj_buffer.seek(0)
-        return self.type.export_to_dataframe(remote_obj_buffer, **kwargs)
+        return self.type.export_to_dataframe(
+            self._convert_remote_file_to_byte_stream(), **kwargs
+        )
 
     def exists(self) -> bool:
         """Check if the file exists or not"""

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -73,7 +73,12 @@ class File:
             self.type.create_from_dataframe(stream=stream, df=df)
 
     def export_to_dataframe(self, **kwargs) -> pd.DataFrame:
-        """Read file from all supported location and convert them into dataframes"""
+        """Read file from all supported location and convert them into dataframes.
+
+        Due to noted issues with using smart_open with pandas (like
+        https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
+        before exporting to a dataframe. We've found a sizable speed improvement with this optimization.
+        """
 
         mode = "rb" if self.is_binary() else "r"
         remote_obj_buffer = io.BytesIO() if self.is_binary() else io.StringIO()

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -1,3 +1,4 @@
+import io
 from typing import List, Optional, Union
 
 import pandas as pd
@@ -73,16 +74,15 @@ class File:
 
     def export_to_dataframe(self, **kwargs) -> pd.DataFrame:
         """Read file from all supported location and convert them into dataframes"""
-        import io
 
         mode = "rb" if self.is_binary() else "r"
-        io_obj = io.BytesIO() if self.is_binary() else io.StringIO()
+        remote_obj_buffer = io.BytesIO() if self.is_binary() else io.StringIO()
         with smart_open.open(
             self.path, mode=mode, transport_params=self.location.transport_params
         ) as stream:
-            io_obj.write(stream.read())
-        io_obj.seek(0)
-        return self.type.export_to_dataframe(io_obj, **kwargs)
+            remote_obj_buffer.write(stream.read())
+        remote_obj_buffer.seek(0)
+        return self.type.export_to_dataframe(remote_obj_buffer, **kwargs)
 
     def exists(self) -> bool:
         """Check if the file exists or not"""

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -73,11 +73,16 @@ class File:
 
     def export_to_dataframe(self, **kwargs) -> pd.DataFrame:
         """Read file from all supported location and convert them into dataframes"""
+        import io
+
         mode = "rb" if self.is_binary() else "r"
+        io_obj = io.BytesIO() if self.is_binary() else io.StringIO()
         with smart_open.open(
             self.path, mode=mode, transport_params=self.location.transport_params
         ) as stream:
-            return self.type.export_to_dataframe(stream, **kwargs)
+            io_obj.write(stream.read())
+        io_obj.seek(0)
+        return self.type.export_to_dataframe(io_obj, **kwargs)
 
     def exists(self) -> bool:
         """Check if the file exists or not"""

--- a/tests/benchmark/dags/evaluate_load_file.py
+++ b/tests/benchmark/dags/evaluate_load_file.py
@@ -63,7 +63,7 @@ def create_dag(database_name, table_args, dataset):
             output_table=table,
             chunk_size=chunk_size,
         )
-        aql.truncate(my_table)
+        aql.cleanup([my_table])
 
         # Todo: Check is broken so the following code is commented out, uncomment when fixed
         # aggregate_check(

--- a/tests/benchmark/dags/evaluate_load_file.py
+++ b/tests/benchmark/dags/evaluate_load_file.py
@@ -46,7 +46,7 @@ def create_dag(database_name, table_args, dataset):
     dag_name = f"load_file_{dataset_name}_into_{database_name}"
 
     with DAG(dag_name, schedule_interval=None, start_date=START_DATE) as dag:
-        chunk_size = int(os.getenv("ASTRO_CHUNK_SIZE", DEFAULT_CHUNK_SIZE))
+        chunk_size = int(os.getenv("ASTRO_CHUNK_SIZE", str(DEFAULT_CHUNK_SIZE)))
         table_metadata = table_args.pop("metadata", {})
         if table_metadata:
             table = Table(metadata=Metadata(**table_metadata), **table_args)

--- a/tests/databases/test_sqlite.py
+++ b/tests/databases/test_sqlite.py
@@ -162,7 +162,7 @@ def test_sqlite_create_table_autodetection_without_file(database_table_fixture):
     with pytest.raises(ValueError) as exc_info:
         database.create_table(table)
     assert exc_info.match(
-        "File is required for creating table using schema autodetection"
+        "File or Dataframe is required for creating table using schema autodetection"
     )
 
 

--- a/tests/files/test_file.py
+++ b/tests/files/test_file.py
@@ -1,5 +1,5 @@
 import pathlib
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pandas as pd
 import pytest
@@ -137,12 +137,15 @@ def test_create_from_dataframe(
     ids=["local", "s3", "gcs"],
 )
 @pytest.mark.parametrize("filetype", SUPPORTED_FILE_TYPES)
-@patch("astro.files.base.smart_open.open")
-def test_export_to_dataframe(
-    mocked_smart_open, filetype, locations, type_method_map_fixture
-):
+def test_export_to_dataframe(filetype, locations, type_method_map_fixture):
     """Test export_to_dataframe() for all locations and filetypes"""
-    with patch(type_method_map_fixture[FileType(filetype)]) as mocked_read:
+    if filetype == "parquet":
+        data = str.encode("data")
+    else:
+        data = "data"
+    with patch(type_method_map_fixture[FileType(filetype)]) as mocked_read, patch(
+        "astro.files.base.smart_open.open", mock_open(read_data=data)
+    ) as mocked_smart_open:
 
         path = locations["path"] + "." + filetype
 
@@ -180,12 +183,15 @@ def test_export_to_dataframe(
     ids=["local", "s3", "gcs"],
 )
 @pytest.mark.parametrize("filetype", SUPPORTED_FILE_TYPES)
-@patch("astro.files.base.smart_open.open")
-def test_read_with_explicit_valid_type(
-    mocked_smart_open, filetype, locations, type_method_map_fixture
-):
+def test_read_with_explicit_valid_type(filetype, locations, type_method_map_fixture):
     """Test export_to_dataframe() for all locations and filetypes, where the file type is explicitly specified"""
-    with patch(type_method_map_fixture[FileType(filetype)]) as mocked_read:
+    if filetype == "parquet":
+        data = str.encode("data")
+    else:
+        data = "data"
+    with patch(type_method_map_fixture[FileType(filetype)]) as mocked_read, patch(
+        "astro.files.base.smart_open.open", mock_open(read_data=data)
+    ) as mocked_smart_open:
 
         path = locations["path"]
 

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -507,12 +507,9 @@ def test_load_file_with_named_schema(sample_dag, database_table_fixture, file_ty
         {
             "database": Database.BIGQUERY,
         },
-        {
-            "database": Database.POSTGRES,
-        },
     ],
     indirect=True,
-    ids=["snowflake", "bigquery", "postgresql"],
+    ids=["snowflake", "bigquery"],
 )
 def test_load_file_chunks(sample_dag, database_table_fixture):
     file_type = "csv"
@@ -520,13 +517,11 @@ def test_load_file_chunks(sample_dag, database_table_fixture):
 
     chunk_function = {
         "bigquery": "pandas.DataFrame.to_gbq",
-        "postgresql": "pandas.DataFrame.to_sql",
         "snowflake": "snowflake.connector.pandas_tools.write_pandas",
     }[db.sql_type]
 
     chunk_size_argument = {
         "bigquery": "chunksize",
-        "postgresql": "chunksize",
         "snowflake": "chunk_size",
     }[db.sql_type]
 

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -641,38 +641,6 @@ def test_aql_nested_ndjson_file_to_bigquery_explicit_illegal_sep_params(
     assert "payload_size" in df.columns
 
 
-@pytest.mark.parametrize(
-    "database_table_fixture",
-    [
-        {
-            "database": Database.POSTGRES,
-        },
-    ],
-    indirect=True,
-    ids=["postgresql"],
-)
-def test_aql_multilevel_nested_ndjson_file_default_params(
-    sample_dag, database_table_fixture, caplog
-):
-    """
-    Test the flattening of multilevel level nested ndjson, with default '_'.
-    Expected to fail since we do not support flattening of multilevel ndjson.
-    """
-    _, test_table = database_table_fixture
-
-    with pytest.raises(BackfillUnfinished):
-        with sample_dag:
-            load_file(
-                input_file=File(
-                    path=str(CWD) + "/../../data/github_multi_level_nested.ndjson"
-                ),
-                output_table=test_table,
-            )
-        test_utils.run_dag(sample_dag)
-    expected_error = "can't adapt type 'dict"
-    assert expected_error in caplog.text
-
-
 def test_populate_table_metadata(sample_dag):
     """
     Test default populating of table fields in load_fil op.


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently the postgres load numbers are far too slow for any production use-case. We need to find optimizations to bring the 10GB loading time to under 5 minutes for customers to reasonably use this feature.


Previous numbers:
| database                | dataset    | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   |
|:------------------------|:-----------|:-------------|:-------------|:----------------|:------------------|
| postgres_conn_benchmark | few_kb     | 494.42ms     | 36.06MB      | 570.0ms         | 50.0ms            |
| postgres_conn_benchmark | ten_kb     | 689.05ms     | 42.96MB      | 540.0ms         | 40.0ms            |
| postgres_conn_benchmark | hundred_kb | 580.7ms      | 36.43MB      | 570.0ms         | 50.0ms            |
| postgres_conn_benchmark | ten_mb     | 44.67s       | 1.38GB       | 31.03s          | 4.03s             |
| postgres_conn_benchmark | one_gb     | 5.56min      | 62.5MB       | 14.07s          | 1.14s             |
| postgres_conn_benchmark | five_gb    | 24.44min     | 78.15MB      | 1.34min         | 5.73s             |
| postgres_conn_benchmark | ten_gb     | 45.64min     | 61.71MB      | 2.37min         | 11.48s            |

closes: [#428](https://github.com/astronomer/astro-sdk/issues/428)
<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
In this PR we found two primary optimizations that have led to significant speed up

The first optimization is to not directly place a smart_open into the `read` function of pandas. There have been multiple reports of pandas and smart_open working very slow when used together. Instead, we read the `smart_open` file into an IO buffer (either StringIO or BytesIO). This also has the benefit that we do not need to write to disc if there is enough memory to hold the object.

The second optimization is postgres specific. The `pandas.to_sql` function uses the HIGHLY suboptimal `INSERT` statement for postgres. This is 10X slower than the `COPY` command. By saving objects as CSV buffers, we can use COPY to load the data into postgres as a stream instead of one value at a time.

Here are the new numbers with the optimizations:

| database   | dataset    | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   |
|:-----------|:-----------|:-------------|:-------------|:----------------|:------------------|
| postgres   | ten_kb     | 432.93ms     | 43.19MB      | 540.0ms         | 60.0ms            |
| postgres   | hundred_kb | 417.2ms      | 31.34MB      | 560.0ms         | 40.0ms            |
| postgres   | ten_mb     | 2.21s        | 79.91MB      | 1.76s           | 170.0ms           |
| postgres   | one_gb     | 13.9s        | 35.43MB      | 7.97s           | 5.76s             |
| postgres   | five_gb    | 50.23s       | 43.27MB      | 26.64s          | 18.7s             |
| postgres   | ten_gb     | 3.11min      | 43.29MB      | 1.36min         | 1.48min           |

## Does this introduce a breaking change?

No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
