### PR TITLE
Move config to store DF in XCom to settings file

### DIFF
--- a/src/astro/sql/operators/dataframe.py
+++ b/src/astro/sql/operators/dataframe.py
@@ -2,12 +2,12 @@ import inspect
 from typing import Callable, Dict, Optional, Tuple, Union
 
 import pandas as pd
-from airflow.configuration import conf
 from airflow.decorators.base import DecoratedOperator
 
 from astro.constants import ColumnCapitalization
 from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
+from astro.settings import ALLOW_UNSAFE_DF_STORAGE, IS_CUSTOM_XCOM_BACKEND
 from astro.sql.table import Table
 from astro.utils.dataframe import convert_columns_names_capitalization
 from astro.utils.table import find_first_table
@@ -149,10 +149,6 @@ class DataframeOperator(DecoratedOperator):
             )
             return self.output_table
         else:
-            if conf.get(
-                "core", "xcom_backend"
-            ) == "airflow.models.xcom.BaseXCom" and not conf.getboolean(
-                "astro_sdk", "dataframe_allow_unsafe_storage"
-            ):
+            if not IS_CUSTOM_XCOM_BACKEND and not ALLOW_UNSAFE_DF_STORAGE:
                 raise IllegalLoadToDatabaseException()
             return pandas_dataframe

--- a/src/astro/sql/operators/dataframe.py
+++ b/src/astro/sql/operators/dataframe.py
@@ -4,10 +4,10 @@ from typing import Callable, Dict, Optional, Tuple, Union
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
 
+from astro import settings
 from astro.constants import ColumnCapitalization
 from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
-from astro.settings import ALLOW_UNSAFE_DF_STORAGE, IS_CUSTOM_XCOM_BACKEND
 from astro.sql.table import Table
 from astro.utils.dataframe import convert_columns_names_capitalization
 from astro.utils.table import find_first_table
@@ -149,6 +149,9 @@ class DataframeOperator(DecoratedOperator):
             )
             return self.output_table
         else:
-            if not IS_CUSTOM_XCOM_BACKEND and not ALLOW_UNSAFE_DF_STORAGE:
+            if (
+                not settings.IS_CUSTOM_XCOM_BACKEND
+                and not settings.ALLOW_UNSAFE_DF_STORAGE
+            ):
                 raise IllegalLoadToDatabaseException()
             return pandas_dataframe

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional, Union
 
 import pandas as pd
-from airflow.configuration import conf
 from airflow.models import BaseOperator
 from airflow.models.xcom_arg import XComArg
 
@@ -9,6 +8,7 @@ from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistS
 from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
+from astro.settings import ALLOW_UNSAFE_DF_STORAGE, IS_CUSTOM_XCOM_BACKEND
 from astro.sql.table import Table
 from astro.utils.task_id_helper import get_task_id
 
@@ -74,11 +74,7 @@ class LoadFile(BaseOperator):
         if self.output_table:
             return self.load_data_to_table(input_file)
         else:
-            if conf.get(
-                "core", "xcom_backend"
-            ) == "airflow.models.xcom.BaseXCom" and not conf.getboolean(
-                "astro_sdk", "dataframe_allow_unsafe_storage"
-            ):
+            if not IS_CUSTOM_XCOM_BACKEND and not ALLOW_UNSAFE_DF_STORAGE:
                 raise IllegalLoadToDatabaseException()
             return self.load_data_to_dataframe(input_file)
 

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -4,11 +4,11 @@ import pandas as pd
 from airflow.models import BaseOperator
 from airflow.models.xcom_arg import XComArg
 
+from astro import settings
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
 from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
-from astro.settings import ALLOW_UNSAFE_DF_STORAGE, IS_CUSTOM_XCOM_BACKEND
 from astro.sql.table import Table
 from astro.utils.task_id_helper import get_task_id
 
@@ -74,7 +74,10 @@ class LoadFile(BaseOperator):
         if self.output_table:
             return self.load_data_to_table(input_file)
         else:
-            if not IS_CUSTOM_XCOM_BACKEND and not ALLOW_UNSAFE_DF_STORAGE:
+            if (
+                not settings.IS_CUSTOM_XCOM_BACKEND
+                and not settings.ALLOW_UNSAFE_DF_STORAGE
+            ):
                 raise IllegalLoadToDatabaseException()
             return self.load_data_to_dataframe(input_file)
 

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -9,6 +9,7 @@ Run test:
     python3 -m unittest tests.operators.test_load_file.TestLoadFile.test_aql_local_file_to_postgres
 
 """
+import importlib
 import os
 import pathlib
 from unittest import mock
@@ -72,6 +73,10 @@ def test_load_file_with_http_path_file(sample_dag, database_table_fixture):
     os.environ, {"AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE": "False"}
 )
 def test_unsafe_loading_of_dataframe(sample_dag):
+    from astro import settings
+
+    importlib.reload(settings)
+
     with pytest.raises(IllegalLoadToDatabaseException):
         load_file(
             input_file=File(

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -68,7 +68,6 @@ def test_load_file_with_http_path_file(sample_dag, database_table_fixture):
     assert df.shape == (3, 9)
 
 
-@pytest.mark.integration
 @mock.patch.dict(
     os.environ, {"AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE": "False"}
 )


### PR DESCRIPTION
This way if we want to ever rename the config, we only need to do it at a single place and it is easy to find which configs users can control.

At some point we should have a doc page that shows all the available configs



## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
