### PR TITLE
Refactor table creation in load_file

### DIFF
--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -166,7 +166,9 @@ class BigqueryDatabase(BaseDatabase):
             statement += f" WHEN MATCHED THEN {update_statement}"
         self.run_sql(sql_statement=statement)
 
-    def check_native_path(self, source_file: File, target_table: Table) -> bool:
+    def is_native_load_file_available(
+        self, source_file: File, target_table: Table
+    ) -> bool:
         """
         Check if there is an optimised path for source to destination.
 
@@ -261,7 +263,6 @@ class BigqueryDatabase(BaseDatabase):
         self,
         source_file: File,
         target_table: Table,
-        if_exists: LoadExistStrategy = "replace",
         native_support_kwargs: Optional[Dict] = None,
         **kwargs,
     ):
@@ -280,11 +281,6 @@ class BigqueryDatabase(BaseDatabase):
         native_support_kwargs = native_support_kwargs or {}
 
         project_id = self.get_project_id(target_table)
-
-        if if_exists == "replace":
-            # We need to create an empty table as datatransfer job can only append to an existing table,
-            # so we need to create a table.
-            self.create_empty_table(source_file, target_table)
 
         transfer = S3ToBigqueryDataTransfer(
             target_table=target_table,

--- a/src/astro/files/types/json.py
+++ b/src/astro/files/types/json.py
@@ -14,7 +14,10 @@ class JSONFileType(FileType):
 
         :param stream: file stream object
         """
-        return pd.read_json(stream, **kwargs)
+        kwargs_copy = dict(kwargs)
+        # Pandas `read_json` does not support the `nrows` parameter unless we're using NDJSON
+        kwargs_copy.pop("nrows", None)
+        return pd.read_json(stream, **kwargs_copy)
 
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
         """Write json file to one of the supported locations

--- a/src/astro/files/types/parquet.py
+++ b/src/astro/files/types/parquet.py
@@ -14,7 +14,10 @@ class ParquetFileType(FileType):
 
         :param stream: file stream object
         """
-        return pd.read_parquet(stream, **kwargs)
+        kwargs_copy = dict(kwargs)
+        # Pandas `read_parquet` does not support the `nrows` parameter
+        kwargs_copy.pop("nrows", None)
+        return pd.read_parquet(stream, **kwargs_copy)
 
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
         """Write parquet file to one of the supported locations

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -3,6 +3,13 @@ from airflow.configuration import conf
 DEFAULT_SCHEMA = "tmp_astro"
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
 
+ALLOW_UNSAFE_DF_STORAGE = conf.getboolean(
+    "astro_sdk", "dataframe_allow_unsafe_storage", fallback=False
+)
+
+XCOM_BACKEND = conf.get("core", "xcom_backend")
+IS_CUSTOM_XCOM_BACKEND = XCOM_BACKEND != "airflow.models.xcom.BaseXCom"
+
 # We are not defining a fallback key on purpose. S3 Snowflake stages can also
 # be created without a storage integration, by using the Airflow AWS connection
 # properties.
@@ -12,4 +19,9 @@ SNOWFLAKE_STORAGE_INTEGRATION_AMAZON = conf.get(
 
 SNOWFLAKE_STORAGE_INTEGRATION_GOOGLE = conf.get(
     section="astro_sdk", key="snowflake_storage_integration_google", fallback=None
+)
+
+#: How many file rows should be loaded to infer the table columns types
+LOAD_TABLE_AUTODETECT_ROWS_COUNT = conf.getint(
+    section="astro_sdk", key="load_table_autodetect_rows_count", fallback=1000
 )

--- a/tests/databases/test_sqlite.py
+++ b/tests/databases/test_sqlite.py
@@ -123,6 +123,52 @@ def test_sqlite_create_table_with_columns(database_table_fixture):
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",
+    [{"database": Database.SQLITE, "table": Table()}],
+    indirect=True,
+    ids=["sqlite"],
+)
+def test_sqlite_create_table_autodetection_with_file(database_table_fixture):
+    """Create a table using specific columns and types"""
+    database, table = database_table_fixture
+
+    statement = f"PRAGMA table_info({table.name});"
+    response = database.run_sql(statement)
+    assert response.first() is None
+
+    filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
+    database.create_table(table, File(filepath))
+    response = database.run_sql(statement)
+    rows = response.fetchall()
+    assert len(rows) == 2
+    assert rows[0] == (0, "id", "BIGINT", 0, None, 0)
+    assert rows[1] == (1, "name", "TEXT", 0, None, 0)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [{"database": Database.SQLITE, "table": Table()}],
+    indirect=True,
+    ids=["sqlite"],
+)
+def test_sqlite_create_table_autodetection_without_file(database_table_fixture):
+    """Create a table using specific columns and types"""
+    database, table = database_table_fixture
+
+    statement = f"PRAGMA table_info({table.name});"
+    response = database.run_sql(statement)
+    assert response.first() is None
+
+    with pytest.raises(ValueError) as exc_info:
+        database.create_table(table)
+    assert exc_info.match(
+        "File is required for creating table using schema autodetection"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
     [
         {"database": Database.SQLITE},
     ],


### PR DESCRIPTION
Refactor how the `BaseDatabase` handles table creation during `load_file`.

We should give priority to creating the table using the `table.columns`, if they are specified by the user, and have the dataframe as a follow-up.

Most of the complexity of https://github.com/astronomer/astro-sdk/pull/487/ was the creation of tables.