### PR TITLE
Add missing task terminal states to CleanUp Operator

### DIFF
--- a/src/astro/sql/operators/cleanup.py
+++ b/src/astro/sql/operators/cleanup.py
@@ -97,7 +97,15 @@ class CleanupOperator(BaseOperator):
             (ti.task_id, ti.state)
             for ti in task_instances
             if ti.task_id != self.task_id
-            and ti.state not in [State.SUCCESS, State.FAILED, State.SKIPPED]
+            and ti.state
+            not in [
+                State.SUCCESS,
+                State.FAILED,
+                State.SKIPPED,
+                State.UPSTREAM_FAILED,
+                State.REMOVED,
+                State.SHUTDOWN,
+            ]
         ]
         if running_tasks:
             self.log.info(


### PR DESCRIPTION
# Description
## What is the current behavior?
When adding aql.cleanup() to a dag to clear temp tables. It will run after all task success. however, if there are failures in the tasks. it will hang up because some of the terminal states are not checked.

closes: #525


## What is the new behavior?
Added terminal states to check logic

## Does this introduce a breaking change?
No

## Alternative Solution
https://github.com/astronomer/astro-sdk/pull/541

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
