### PR TITLE
Add all done trigger rule to cleanup op

### DIFF
--- a/src/astro/sql/operators/cleanup.py
+++ b/src/astro/sql/operators/cleanup.py
@@ -62,7 +62,11 @@ class CleanupOperator(BaseOperator):
         task_id = task_id or get_unique_task_id("_cleanup")
 
         super().__init__(
-            task_id=task_id, retries=retries, retry_delay=retry_delay, **kwargs
+            task_id=task_id,
+            retries=retries,
+            retry_delay=retry_delay,
+            trigger_rule="all_done",
+            **kwargs,
         )
 
     def execute(self, context: Context) -> None:


### PR DESCRIPTION
# Description
## What is the current behavior?
Current Implementation:
When adding aql.cleanup() to a dag to clear temp tables. It will run after all task success. however, if there are failures in the tasks.

closes: #525

## What is the new behavior?
Added trigger rule 'all_done' to the cleanup operator, so it executes at the end of the dag run and clear all the temp tables. 

One advantage of this is we don't have to keep iterating over all operators and checking the states. cleanup operator will only execute when all task are done. 

## Does this introduce a breaking change?
Nope.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
