### PR TITLE
Add schema settings on database level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+.PHONY: help
+.DEFAULT_GOAL:= help
+SHELL := /bin/bash
+PROJECT_NAME := astro-sdk
+SYSTEM_PYTHON := python3.9
+
+# Set default virtualenv path, if not defined
+ifndef VIRTUALENV_PATH
+mkdir -p ~/.virtualenvs/
+override VIRTUALENV_PATH = ~/.virtualenvs/$(PROJECT_NAME)
+endif
+
+PYTHON = $(VIRTUALENV_PATH)/bin/python
+PIP = $(VIRTUALENV_PATH)/bin/pip
+PYTEST = $(VIRTUALENV_PATH)/bin/pytest
+PRECOMMIT = $(VIRTUALENV_PATH)/bin/pre-commit
+
+
+clean: ## Remove temporary files
+	@echo "Removing cached and temporary files from current directory"
+	@rm -rf logs
+	@find . -name "*.pyc" -delete
+	@find . -type d -name "__pycache__" -exec rm -rf {} +
+	@find . -name "*.sw[a-z]" -delete
+	@find . -type d -name "*.egg-info" -exec rm -rf {} +
+
+virtualenv:  ## Create Python virtualenv
+	@test -d $(VIRTUALENV_PATH) && \
+	(echo "The virtualenv $(VIRTUALENV_PATH) already exists. Skipping.") || \
+	(echo "Creating the virtualenv $(VIRTUALENV_PATH) using $(SYSTEM_PYTHON)" & \
+	$(SYSTEM_PYTHON) -m venv $(VIRTUALENV_PATH))
+
+install: virtualenv  ## Install python dependencies in existing virtualenv
+	@echo "Installing Python dependencies using $(PIP)"
+	@$(PIP) install --upgrade pip
+	@$(PIP) install nox
+	@$(PIP) install pre-commit
+	@$(PIP) install -e .[all]
+	@$(PIP) install .[tests]
+
+config:  ## Create sample configuration files related to Snowflake, Amazon and Google
+	@test -e .env && \
+		(echo "The file .env already exist. Skipping.") || \
+		(echo "Creating .env..." && \
+		cat .env-template > .env && \
+		echo "Please, update .env with your credentials")
+	@test -e test-connections.yaml && \
+		(echo "The file test-connections.yaml already exist. Skipping.") || \
+		(echo "Creating test-connections.yaml..." && \
+		cat .github/ci-test-connections.yaml > test-connections.yaml && \
+		echo "Please, update test-connections.yaml with your credentials")
+
+setup: config virtualenv install ## Setup a local development environment
+
+quality:
+	@$(PRECOMMIT) run --all-files
+
+test: virtualenv config ## Run all tests (use option: db=[db] run only run database-specific ones)
+ifdef db
+	@$(PYTEST) -s --cov --cov-branch --cov-report=term-missing -m "$(db)"
+else
+	@$(PYTEST) -s --cov --cov-branch --cov-report=term-missing
+endif
+
+unit: virtualenv config ## Run unit tests
+	@$(PYTEST) -s --cov --cov-branch --cov-report=term-missing -m "not integration"
+
+integration: virtualenv config  ## Run integration tests
+	@$(PYTEST) -s --cov --cov-branch --cov-report=term-missing -m integration
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SYSTEM_PYTHON := python3.9
 
 # Set default virtualenv path, if not defined
 ifndef VIRTUALENV_PATH
-mkdir -p ~/.virtualenvs/
+$(shell mkdir -p ~/.virtualenvs/)
 override VIRTUALENV_PATH = ~/.virtualenvs/$(PROJECT_NAME)
 endif
 

--- a/docs/aep/README.md
+++ b/docs/aep/README.md
@@ -4,7 +4,7 @@ The purpose of an Astro Enhancement Proposal (AEP) is to introduce any significa
 
 This is required in order to balance the need to support new features, use cases, while avoiding accidentally introducing half thought-out interfaces that cause unnecessary problems when changed.
 
-This documentation is heavily based on the [Airflow Improvement Proposals](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals).
+This documentation is heavily based on the [Airflow Improvement Proposals](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals).
 
 
 ## What is considered a significant change that needs an API?

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -392,3 +392,458 @@ or
 
 In all scenarios, even if the user gives a non-temporary table, only temporary
 tables will actually be deleted.
+
+## Configuring default schema
+
+We can configure the default schema that will be used for all operation involving database.
+environment variable :
+```shell
+AIRFLOW__ASTRO_SDK__SCHEMA="tmp"
+```
+or by updating Airflow's configuration
+```editorconfig
+[astro_sdk]
+schema = "tmp"
+```
+We can fur<h1 align="center">
+  Astro Python SDK
+</h1>
+  <h3 align="center">
+  Tutorial<br><br>
+</h3>
+
+# Introduction
+
+This tutorial demonstrates how to use the Astro Python SDK through a simple ETL example that you can run on your local machine:
+* **Extract** a file from S3 into a Snowflake relational table
+* **Transform** that table in Snowflake
+* **Load** that transformed table into a reporting table in Snowflake
+
+You'll need to use existing Amazon S3 and Snowflake accounts, or create some trial versions.
+
+***
+# Let's do some setup
+
+## Install Airflow
+
+* Install Python and `virtualenv` (ignore if already installed).
+
+  For macOS, you can follow these steps:
+    * Install homebrew:
+
+      ```shell
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      ```
+    * `brew install python`
+    * `brew install pip`
+    * `pip install virtualenv `
+
+* Create a new virtual environment by running:
+
+  ```shell
+  python3 -m virtualenv env
+  ```
+
+* Activate environment ``source env/bin/activate``
+* [Install Airflow](https://airflow.apache.org/docs/apache-airflow/stable/start/local.html)
+
+## Set up your data stores
+
+### Set up S3
+
+[Setup](https://docs.aws.amazon.com/AmazonS3/latest/userguide/GetStartedWithS3.html) an S3 account and storage bucket.
+
+Upload this datafile from your local machine to your newly created aws bucket
+
+```
+order_id,customer_id,purchase_date,amount
+ORDER1,CUST1,1/1/2021,100
+ORDER2,CUST2,2/2/2022,200
+ORDER3,CUST3,3/3/2023,300
+```
+
+### Set up Snowflake
+
+Sign up for a [free Snowflake trial](https://signup.snowflake.com/), selecting the Enterprise Edition.
+
+Once your workspace is ready, navigate to a worksheet and enter these commands:
+
+```sql
+create warehouse ASTRO_SDK_DW;
+create database ASTRO_SDK_DB;
+create schema ASTRO_SDK_SCHEMA;
+```
+Then, in the classic Snowflake console in the upper right, select the role, warehouse, database and schema
+to look like this:
+
+![classic-console](../images/snowflake-classic-console.png)
+
+Note that you can set the warehouse, database, and schema names to something else, but you'll just
+need to be consistent with whatever names you choose throughout the remainder of this tutorial.
+
+## Install Astro-SDK on your local machine
+
+* Run the following command to install the Python SDK, with the extra packages necessary to access AWS and Snowflake.
+
+
+  ```shell
+  pip install 'astro-sdk-python[amazon,snowflake]>=0.11'
+  ```
+
+* Create the following environment variables
+
+  ```shell
+  export AIRFLOW__CORE__ENABLE_XCOM_PICKLING=True
+  export AIRFLOW__ASTRO_SDK__SQL_SCHEMA=<snowflake_schema>
+  ```
+
+If you're using macOS, set this environment variable too [(background)](https://github.com/apache/airflow/issues/12808):
+
+  ```shell
+  export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+  ```
+
+* Start Airflow by running `airflow standalone` command and check out the Webserver
+at [`http://localhost:8080/`](http://localhost:8080/).
+
+## Setup Airflow connections
+
+* In your Astronomer Airflow UI select Admin-->Connectors
+
+![connections](../images/airflow-webserver-connection.png)
+
+
+### Connect S3 to Airflow
+
+Click on the blue "+" icon to *Add a new record*
+
+Set these fields:
+
+* Connection Id: `aws_default`
+* Connection Type: `S3`
+* Extra: `{"aws_access_key_id": "<your_access_key>", "aws_secret_access_key": "<you_secret_access_key>"}`
+
+### Connect Snowflake to Airflow
+
+Click on the blue "+" icon to *Add a new record*
+
+* Connection Id: `snowflake_default`
+* Connection Type: `Snowflake`
+* Host: `https://<account>.<region>.snowflakecomputing.com/`. This is the URL where you can log into your Snowflake account
+* Schema: `ASTRO_SDK_SCHEMA`
+* Login:
+* Password:
+* Account:
+* Database: `ASTRO_SDK_DB`
+* Region: (something like `us-east-1` or `us-central1.gcp`)
+* Role: `ACCOUNTADMIN`
+* Warehouse: `ASTRO_SDK_DW`
+
+
+***
+# Create and populate some tables in Snowflake
+
+We'll create some auxiliary tables in Snowflake and populate with a small amount of data for our ETL example.
+
+* Create and populate a customer table to join with an orders table that we create with the Astro Python SDK:
+
+```sql
+
+CREATE OR REPLACE TABLE customers_table (customer_id CHAR(10), customer_name VARCHAR(100), type VARCHAR(10) );
+
+INSERT INTO customers_table (CUSTOMER_ID, CUSTOMER_NAME,TYPE) VALUES ('CUST1','NAME1','TYPE1'),('CUST2','NAME2','TYPE1'),('CUST3','NAME3','TYPE2');
+```
+
+* Create and populate a reporting table into which we'll merge our transformed data:
+
+```sql
+
+CREATE OR REPLACE TABLE reporting_table (
+    CUSTOMER_ID CHAR(30), CUSTOMER_NAME VARCHAR(100), ORDER_ID CHAR(10), PURCHASE_DATE DATE, AMOUNT FLOAT, TYPE CHAR(10));
+
+INSERT INTO reporting_table (CUSTOMER_ID, CUSTOMER_NAME, ORDER_ID, PURCHASE_DATE, AMOUNT, TYPE) VALUES
+('INCORRECT_CUSTOMER_ID','INCORRECT_CUSTOMER_NAME','ORDER2','2/2/2022',200,'TYPE1'),
+('CUST3','NAME3','ORDER3','3/3/2023',300,'TYPE2'),
+('CUST4','NAME4','ORDER4','4/4/2022',400,'TYPE2');
+```
+***
+# Simple ETL workflow
+
+Use your favorite code editor or text editor to copy-paste the following code into a *.py file in <your-project>/dags/ directory.
+
+Here's the code for the simple ETL workflow:
+
+```python
+from datetime import datetime
+
+from airflow.models import DAG
+from pandas import DataFrame
+
+from astro import sql as aql
+from astro.files import File
+from astro.sql.table import Table
+
+S3_FILE_PATH = "s3://<aws-bucket-name>"
+S3_CONN_ID = "aws_default"
+SNOWFLAKE_CONN_ID = "snowflake_default"
+SNOWFLAKE_ORDERS = "orders_table"
+SNOWFLAKE_FILTERED_ORDERS = "filtered_table"
+SNOWFLAKE_JOINED = "joined_table"
+SNOWFLAKE_CUSTOMERS = "customers_table"
+SNOWFLAKE_REPORTING = "reporting_table"
+
+
+@aql.transform
+def filter_orders(input_table: Table):
+    return "SELECT * FROM {{input_table}} WHERE amount > 150"
+
+
+@aql.transform
+def join_orders_customers(filtered_orders_table: Table, customers_table: Table):
+    return """SELECT c.customer_id, customer_name, order_id, purchase_date, amount, type
+    FROM {{filtered_orders_table}} f JOIN {{customers_table}} c
+    ON f.customer_id = c.customer_id"""
+
+
+@aql.dataframe
+def transform_dataframe(df: DataFrame):
+    purchase_dates = df.loc[:, "purchase_date"]
+    print("purchase dates:", purchase_dates)
+    return purchase_dates
+
+
+dag = DAG(
+    dag_id="astro_orders",
+    start_date=datetime(2019, 1, 1),
+    schedule_interval="@daily",
+    catchup=False,
+)
+
+with dag:
+    # Extract a file with a header from S3 into a temporary Table, referenced by the
+    # variable `orders_data`
+    orders_data = aql.load_file(
+        # data file needs to have a header row
+        input_file=File(
+            path=S3_FILE_PATH + "/orders_data_header.csv", conn_id=S3_CONN_ID
+        ),
+        output_table=Table(conn_id=SNOWFLAKE_CONN_ID),
+    )
+
+    # Create a Table object for customer data in our Snowflake database
+    customers_table = Table(
+        name=SNOWFLAKE_CUSTOMERS,
+        conn_id=SNOWFLAKE_CONN_ID,
+    )
+
+    # Filter the orders data and then join with the customer table,
+    # saving the output into a temporary table referenced by the Table instance `joined_data`
+    joined_data = join_orders_customers(filter_orders(orders_data), customers_table)
+
+    # Merge the joined data into our reporting table, based on the order_id .
+    # If there's a conflict in the customer_id or customer_name then use the ones from
+    # the joined data
+    reporting_table = aql.merge(
+        target_table=Table(
+            name=SNOWFLAKE_REPORTING,
+            conn_id=SNOWFLAKE_CONN_ID,
+        ),
+        source_table=joined_data,
+        target_conflict_columns=["order_id"],
+        columns=["customer_id", "customer_name"],
+        if_conflicts="update",
+    )
+
+    purchase_dates = transform_dataframe(reporting_table)
+
+    # Delete temporary and unnamed tables created by `load_file` and `transform`, in this example
+    # both `orders_data` and `joined_data`
+    aql.cleanup()
+```
+***
+# Run it!
+
+In your Airflow UI's home page, you should see a DAG called astro_orders. Toggle the DAG to unpause it:
+![toggle](../images/unpause-dag.png)
+
+
+Then, trigger it to run it:
+![trigger](../images/trigger-dag.png)
+
+
+Click on the astro_orders DAG name to see the grid view of its execution:
+![gridview](../images/select-dag-grid-view.png)
+
+***
+# Walk through the code
+
+## Extract
+
+To extract from S3 into a SQL Table, we need only specify the location on S3 of the data and a connection for Snowflake that the Python SDK can use for internal purposes:
+
+```python
+# Extract a file with a header from S3 into a temporary Table, referenced by the
+# variable `orders_data`
+orders_data = aql.load_file(
+    # data file needs to have a header row
+    input_file=File(path=S3_FILE_PATH + "/orders_data_header.csv", conn_id=S3_CONN_ID),
+    output_table=Table(conn_id=SNOWFLAKE_CONN_ID),
+)
+```
+
+In this example, we do not want to persist the content of `orders_data` after the DAG is completed.
+When we create a `Table` object without a name, that table is considered a temporary table.
+The Astro SDK will delete all temporary tables if the user adds the task `aql.cleanup` to the DAG.
+
+## Transform
+
+We can execute a filter and join in a single line of code to fill in a value for `joined_data`:
+
+```python
+@aql.transform
+def filter_orders(input_table: Table):
+    return "SELECT * FROM {{input_table}} WHERE amount > 150"
+
+
+@aql.transform
+def join_orders_customers(filtered_orders_table: Table, customers_table: Table):
+    return """SELECT c.customer_id, customer_name, order_id, purchase_date, amount, type
+    FROM {{filtered_orders_table}} f JOIN {{customers_table}} c
+    ON f.customer_id = c.customer_id"""
+
+
+# Create a Table object for customer data in our Snowflake database
+customers_table = Table(
+    name=SNOWFLAKE_CUSTOMERS,
+    conn_id=SNOWFLAKE_CONN_ID,
+)
+
+
+# Filter the orders data and then join with the customer table,
+# saving the output into a temporary table referenced by the Table instance `joined_data`
+joined_data = join_orders_customers(filter_orders(orders_data), customers_table)
+```
+
+Since the table `customers_table` is named, it is not considered temporary and will not be deleted
+by the end of the DAG run. However, The table `joined_data`, however, was not named in this DAG
+and therefore it will be deleted by the `aql.cleanup` step.
+
+## Merge
+
+As our penultimate transformation, we call a database-agnostic merge function:
+
+```python
+# Merge the joined data into our reporting table, based on the order_id .
+# If there's a conflict in the customer_id or customer_name then use the ones from
+# the joined data
+reporting_table = aql.merge(
+    target_table=Table(
+        name=SNOWFLAKE_REPORTING,
+        conn_id=SNOWFLAKE_CONN_ID,
+    ),
+    source_table=joined_data,
+    target_conflict_columns=["order_id"],
+    columns=["customer_id", "customer_name"],
+    if_conflicts="update",
+)
+```
+
+
+## Dataframe transformation
+
+As an illustration of the `@aql.dataframe` decorator, we show a simple dataframe operation:
+
+```python
+@aql.dataframe
+def transform_dataframe(df: DataFrame):
+    purchase_dates = df.loc[:, "purchase_date"]
+    print("purchase dates:", purchase_dates)
+    return purchase_dates
+```
+
+
+After all that, you'll find the meager output of this example in the logs of the final task:
+![log](../images/task-logs.png)
+
+To view this log output, in the tree view of the DAG, click on the green box next to
+`transform_dataframe` and then on "Log" button.
+
+
+## Clean up temporary tables
+
+Finally, if there were temporary tables (`table.temp=True` or an unnamed tables) in the DAG,
+the user should consider cleaning them up by the end of the DAG run.
+
+It is possible to achieve this using one of the following approaches:
+
+(1) Clean all temporary tables by the end of the DAG run
+
+```python
+# Delete all temporary
+aql.cleanup()
+```
+
+(2) Specify a subset of temporary tables to be deleted
+
+The user may also opt for explicitly setting a subset of tables to be deleted,
+by using one of the following
+
+```python
+aql.cleanup([orders_data, joined_data])
+```
+
+or
+```python
+[orders_data, joined_data] >> aql.cleanup()
+```
+
+In all scenarios, even if the user gives a non-temporary table, only temporary
+tables will actually be deleted.
+
+## Configuring default schema
+
+We can configure the default schema that will be used for all operation involving database.
+environment variable :
+```shell
+AIRFLOW__ASTRO_SDK__SCHEMA="tmp"
+```
+or by updating Airflow's configuration
+```editorconfig
+[astro_sdk]
+schema = "tmp"
+```
+We can further configure schema per database level, this is useful for cases where there are multiple dags or same
+dag which interacts with multiple databases.
+
+### postgres
+environment variable
+```shell
+AIRFLOW__ASTRO_SDK__POSTGRES_DEFAULT_SCHEMA="tmp"
+```
+or Airflow's configuration
+```
+[astro_sdk]
+postgres_default_schema = "tmp"
+```
+
+### snowflake
+environment variable
+```shell
+AIRFLOW__ASTRO_SDK__SNOWFLAKE_DEFAULT_SCHEMA="tmp"
+```
+or Airflow's configuration
+```
+[astro_sdk]
+snowflake_default_schema = "tmp"
+```
+
+### bigquery
+environment variable
+```shell
+AIRFLOW__ASTRO_SDK__BIGQUERY_DEFAULT_SCHEMA="tmp"
+```
+or Airflow's configuration
+```
+[astro_sdk]
+bigquery_default_schema = "tmp"
+```

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -1,10 +1,10 @@
 import os
 from datetime import datetime
-from pandas import DataFrame
 
 from airflow import DAG
 from airflow.decorators import task
 
+from pandas import DataFrame
 from astro import sql as aql
 from astro.files import File
 from astro.sql import Table

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from pandas import DataFrame
 
 from airflow import DAG
 from airflow.decorators import task
@@ -22,8 +23,12 @@ def summarize_campaign(capaign_id: str):
     print(capaign_id)
 
 
-def handle_result(result):
-    return result.fetchall()
+@aql.dataframe(identifiers_as_lower=False)
+def my_df_func(input_df: DataFrame):
+    res = []
+    for row in input_df.iterrows():
+        res.append(row[0])
+    return res
 
 
 with DAG(
@@ -50,3 +55,4 @@ with DAG(
 
     summarize_campaign.expand(capaign_id=get_campaigns(bq_table))
     aql.cleanup()
+

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -1,11 +1,3 @@
-"""
-This Example DAG:
-- Pull CSV from S3 and load in bigquery table
-- Run select query on bigquery table
-- Expand on the returned rows i.e if bigquery table contain n rows then
-    n copy of ``summarize_campaign`` task will be created dynamically
-    using dynamic task mapping
-"""
 import os
 from datetime import datetime
 
@@ -18,8 +10,11 @@ from astro.sql import Table
 from astro.sql.table import Metadata
 
 ASTRO_BIGQUERY_DATASET = os.getenv("ASTRO_BIGQUERY_DATASET", "dag_authoring")
+ASTRO_GCP_LOCATION = os.getenv("ASTRO_GCP_LOCATION", "us")
 ASTRO_GCP_CONN_ID = os.getenv("ASTRO_GCP_CONN_ID", "google_cloud_default")
-ASTRO_S3_BUCKET = os.getenv("S3_BUCKET", "s3://tmp9")
+ASTRO_BIGQUERY_SCHEMA = os.getenv("ASTRO_BIGQUERY_SCHEMA", "dag_authoring")
+ASTRO_BIGQUERY_TABLE = os.getenv("ASTRO_BIGQUERY_TABLE", "campaigns")
+s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 
 
 @task
@@ -43,7 +38,7 @@ with DAG(
         return """select id from {{table}}"""
 
     bq_table = aql.load_file(
-        input_file=File(path=f"{ASTRO_S3_BUCKET}/ads.csv"),
+        input_file=File(path=f"{s3_bucket}/ads.csv"),
         output_table=Table(
             metadata=Metadata(
                 schema=ASTRO_BIGQUERY_DATASET,

--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -7,6 +7,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
+DEFAULT_SCHEMA = "tmp_astro"
 DEFAULT_CHUNK_SIZE = 1000000
 PYPI_PROJECT_NAME = "astro-sdk-python"
 

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -24,6 +24,15 @@ from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import Metadata, Table
 
 
+class DatabaseCustomError(ValueError, AttributeError):
+    """
+    Inappropriate argument value (of correct type) or attribute
+    not found while running query. while running query
+    """
+
+    pass
+
+
 class BaseDatabase(ABC):
     """
     Base class to represent all the Database interactions.
@@ -48,7 +57,7 @@ class BaseDatabase(ABC):
     # illegal_column_name_chars[0] will be replaced by value in illegal_column_name_chars_replacement[0]
     illegal_column_name_chars: List[str] = []
     illegal_column_name_chars_replacement: List[str] = []
-    NATIVE_LOAD_EXCEPTIONS: Any = (ValueError, AttributeError)
+    NATIVE_LOAD_EXCEPTIONS: Any = DatabaseCustomError
     DEFAULT_SCHEMA = SCHEMA
 
     def __init__(self, conn_id: str):

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -49,6 +49,7 @@ class BaseDatabase(ABC):
     illegal_column_name_chars: List[str] = []
     illegal_column_name_chars_replacement: List[str] = []
     NATIVE_LOAD_EXCEPTIONS: Any = (ValueError, AttributeError)
+    DEFAULT_SCHEMA = SCHEMA
 
     def __init__(self, conn_id: str):
         self.conn_id = conn_id
@@ -161,7 +162,7 @@ class BaseDatabase(ABC):
         if table.metadata and table.metadata.is_empty() and self.default_metadata:
             table.metadata = self.default_metadata
         if not table.metadata.schema:
-            table.metadata.schema = SCHEMA
+            table.metadata.schema = self.DEFAULT_SCHEMA
         return table
 
     # ---------------------------------------------------------

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -37,7 +37,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
 from tenacity import retry, stop_after_attempt
 
-from astro import settings
 from astro.constants import (
     DEFAULT_CHUNK_SIZE,
     FileLocation,
@@ -47,6 +46,7 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase
 from astro.files import File
+from astro.settings import BIGQUERY_SCHEMA
 from astro.sql.table import Metadata, Table
 
 DEFAULT_CONN_ID = BigQueryHook.default_conn_name
@@ -64,6 +64,7 @@ class BigqueryDatabase(BaseDatabase):
     logic in other parts of our code-base.
     """
 
+    DEFAULT_SCHEMA = BIGQUERY_SCHEMA
     NATIVE_PATHS = {
         FileLocation.GS: "load_gs_file_to_table",
         FileLocation.S3: "load_s3_file_to_table",
@@ -117,7 +118,7 @@ class BigqueryDatabase(BaseDatabase):
 
         :return:
         """
-        return Metadata(schema=settings.SCHEMA, database=self.hook.project_id)
+        return Metadata(schema=self.DEFAULT_SCHEMA, database=self.hook.project_id)
 
     def schema_exists(self, schema: str) -> bool:
         """

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -10,7 +10,7 @@ from psycopg2 import sql as postgres_sql
 
 from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy, MergeConflictStrategy
 from astro.databases.base import BaseDatabase
-from astro.settings import SCHEMA
+from astro.settings import POSTGRES_SCHEMA
 from astro.sql.table import Metadata, Table
 
 DEFAULT_CONN_ID = PostgresHook.default_conn_name
@@ -22,6 +22,7 @@ class PostgresDatabase(BaseDatabase):
     logic in other parts of our code-base.
     """
 
+    DEFAULT_SCHEMA = POSTGRES_SCHEMA
     illegal_column_name_chars: List[str] = ["."]
     illegal_column_name_chars_replacement: List[str] = ["_"]
 
@@ -41,7 +42,7 @@ class PostgresDatabase(BaseDatabase):
     def default_metadata(self) -> Metadata:
         """Fill in default metadata values for table objects addressing postgres databases"""
         database = self.hook.get_connection(self.conn_id).schema
-        return Metadata(database=database, schema=SCHEMA)
+        return Metadata(database=database, schema=self.DEFAULT_SCHEMA)
 
     def schema_exists(self, schema) -> bool:
         """

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from pandas.io.sql import SQLDatabase
-from settings import SNOWFLAKE_SCHEMA
 from snowflake.connector import pandas_tools
 from snowflake.connector.errors import (
     DatabaseError,
@@ -35,6 +34,7 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase
 from astro.files import File
+from astro.settings import SNOWFLAKE_SCHEMA
 from astro.sql.table import Metadata, Table
 
 DEFAULT_CONN_ID = SnowflakeHook.default_conn_name

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from pandas.io.sql import SQLDatabase
+from settings import SNOWFLAKE_SCHEMA
 from snowflake.connector import pandas_tools
 from snowflake.connector.errors import (
     DatabaseError,
@@ -173,6 +175,7 @@ class SnowflakeDatabase(BaseDatabase):
         ForbiddenError,
         RequestTimeoutError,
     )
+    DEFAULT_SCHEMA = SNOWFLAKE_SCHEMA
 
     def __init__(self, conn_id: str = DEFAULT_CONN_ID):
         super().__init__(conn_id)

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from pandas.io.sql import SQLDatabase
 from snowflake.connector import pandas_tools
 from snowflake.connector.errors import (
     DatabaseError,

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -3,9 +3,9 @@ from airflow.configuration import conf
 from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
-POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback=SCHEMA)
-BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHEMA)
-SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)
+POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_sql_schema", fallback=SCHEMA)
+BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_sql_schema", fallback=SCHEMA)
+SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_sql_schema", fallback=SCHEMA)
 
 
 ALLOW_UNSAFE_DF_STORAGE = conf.getboolean(

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -1,7 +1,11 @@
 from airflow.configuration import conf
+from constants import DEFAULT_SCHEMA
 
-DEFAULT_SCHEMA = "tmp_astro"
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
+POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_sql_schema", fallback=SCHEMA)
+BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_sql_schema", fallback=SCHEMA)
+SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_sql_schema", fallback=SCHEMA)
+
 
 ALLOW_UNSAFE_DF_STORAGE = conf.getboolean(
     "astro_sdk", "dataframe_allow_unsafe_storage", fallback=False

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -3,9 +3,9 @@ from airflow.configuration import conf
 from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
-POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_sql_schema", fallback=SCHEMA)
-BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_sql_schema", fallback=SCHEMA)
-SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_sql_schema", fallback=SCHEMA)
+POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback=SCHEMA)
+BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHEMA)
+SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)
 
 
 ALLOW_UNSAFE_DF_STORAGE = conf.getboolean(

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -1,5 +1,6 @@
 from airflow.configuration import conf
-from constants import DEFAULT_SCHEMA
+
+from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
 POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_sql_schema", fallback=SCHEMA)

--- a/tests/benchmark/results.md
+++ b/tests/benchmark/results.md
@@ -182,3 +182,19 @@ Note - These results are generated manually, there is a issue added for the same
 | bigquery   | one_gb     | 4.25min      | 66.32MB      | 54.88ms         | 48.01ms           |
 | bigquery   | ten_kb     | 2.9min       | 55.51MB      | 40.74ms         | 34.94ms           |
 | bigquery   | ten_mb     | 4.17min      | 57.6MB       | 46.64ms         | 46.83ms           |
+
+### Local to Bigquery using native path
+
+| database   | dataset   | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   |
+|:-----------|:----------|:-------------|:-------------|:----------------|:------------------|
+| bigquery   | one_gb    | 13.18min     | 231.33MB     | 10.5min         | 1.15min           |
+| bigquery   | ten_kb    | 12.46s       | 62.74MB      | 8.28s           | 730.0ms           |
+| bigquery   | ten_mb    | 14.36s       | 39.78MB      | 8.2s            | 780.0ms           |
+
+### Local to Bigquery using default path
+
+| database   | dataset   | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   |
+|:-----------|:----------|:-------------|:-------------|:----------------|:------------------|
+| bigquery   | one_gb    | 12.23min     | 231.33MB     | 10.5min         | 1.15min           |
+| bigquery   | ten_kb    | 17.06s       | 61.65MB      | 7.16s           | 1.01s             |
+| bigquery   | ten_mb    | 15.22s       | 66.08MB      | 7.35s           | 940.0ms           |

--- a/tests/databases/test_snowflake.py
+++ b/tests/databases/test_snowflake.py
@@ -1,6 +1,7 @@
 """Tests specific to the Sqlite Database implementation."""
 import os
 import pathlib
+from unittest import mock
 from unittest.mock import patch
 
 import pandas as pd
@@ -10,6 +11,7 @@ from sqlalchemy.exc import ProgrammingError
 
 from astro.constants import Database, FileLocation, FileType
 from astro.databases import create_database
+from astro.databases.base import DatabaseCustomError
 from astro.databases.snowflake import SnowflakeDatabase, SnowflakeStage
 from astro.exceptions import NonExistentTableException
 from astro.files import File
@@ -182,6 +184,68 @@ def test_load_file_to_table(database_table_fixture):
         ]
     )
     test_utils.assert_dataframes_are_equal(df, expected)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.SNOWFLAKE,
+            "table": Table(metadata=Metadata(schema=SCHEMA)),
+        },
+    ],
+    indirect=True,
+    ids=["snowflake"],
+)
+@mock.patch("astro.databases.snowflake.SnowflakeDatabase.hook")
+@mock.patch("astro.databases.snowflake.SnowflakeDatabase.create_stage")
+def test_load_file_to_table_natively_for_fallback(
+    mock_stage, mock_hook, database_table_fixture
+):
+    """Test loading on files to bigquery natively for fallback."""
+    mock_hook.run.side_effect = ValueError
+    mock_stage.return_value = SnowflakeStage(
+        name="mock_stage",
+        url="gcs://bucket/prefix",
+        metadata=Metadata(database="SNOWFLAKE_DATABASE", schema="SNOWFLAKE_SCHEMA"),
+    )
+    database, target_table = database_table_fixture
+    filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
+    response = database.load_file_to_table_natively_with_fallback(
+        source_file=File(filepath),
+        target_table=target_table,
+        enable_native_fallback=False,
+    )
+    assert response is None
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.SNOWFLAKE,
+            "table": Table(name="test_table", metadata=Metadata(schema=SCHEMA)),
+        },
+    ],
+    indirect=True,
+    ids=["snowflake"],
+)
+@mock.patch("astro.databases.snowflake.is_valid_snow_identifier")
+def test_build_merge_sql(mock_is_valid_snow_identifier, database_table_fixture):
+    """Test build merge SQL for DatabaseCustomError"""
+    mock_is_valid_snow_identifier.return_value = False
+    database, target_table = database_table_fixture
+    with pytest.raises(DatabaseCustomError):
+        database._build_merge_sql(
+            source_table=Table(
+                name="source_test_table", metadata=Metadata(schema=SCHEMA)
+            ),
+            target_table=target_table,
+            source_to_target_columns_map={"list": "val"},
+            target_conflict_columns=["target"],
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
## What is the current behavior?
When a user is using Astro-SDK for multiple databases. We impose a requirement of having the same-named SCHEMA in all the databases. Which is unrealistic.

related: #304

## What is the new behavior?
Now we have defined config variables to define SCHEMA per-database level.

Users can either configure env var:
AIRFLOW_ASTRO_SDK__POSTGRES_SQL_SCHEMA
AIRFLOW_ASTRO_SDK__BIGQUERY_SQL_SCHEMA
AIRFLOW_ASTRO_SDK__SNOWFLAKE_SQL_SCHEMA
or define them in airflow's config.

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
