### PR TITLE
Fix MyPY issue of 'path' and 'conn_id' property of Class File

### DIFF
--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -5,6 +5,7 @@ import smart_open
 
 from astro.constants import FileType
 from astro.files.locations import create_file_location
+from astro.files.locations.base import BaseFileLocation
 from astro.files.types import create_file_type
 
 
@@ -29,14 +30,14 @@ class File:
         :param filetype: constant to provide an explicit file type
         :param normalize_config: parameters in dict format of pandas json_normalize() function.
         """
-        self.location = create_file_location(path, conn_id)
+        self.location: BaseFileLocation = create_file_location(path, conn_id)
         self.type = create_file_type(
             path=path, filetype=filetype, normalize_config=normalize_config
         )
 
     @property
     def path(self) -> str:
-        return self.location.path  # type: ignore
+        return self.location.path
 
     @property
     def conn_id(self) -> Optional[str]:

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -41,7 +41,7 @@ class File:
 
     @property
     def conn_id(self) -> Optional[str]:
-        return self.location.conn_id  # type: ignore
+        return self.location.conn_id
 
     @property
     def size(self) -> int:

--- a/src/astro/files/locations/base.py
+++ b/src/astro/files/locations/base.py
@@ -23,7 +23,7 @@ class BaseFileLocation(ABC):
         :param conn_id: Airflow connection ID
         """
         self.path: str = path
-        self.conn_id = conn_id
+        self.conn_id: Optional[str] = conn_id
 
     @property
     def hook(self):

--- a/src/astro/files/locations/base.py
+++ b/src/astro/files/locations/base.py
@@ -22,7 +22,7 @@ class BaseFileLocation(ABC):
         :param path: Path to a file in the filesystem/Object stores
         :param conn_id: Airflow connection ID
         """
-        self.path = path
+        self.path: str = path
         self.conn_id = conn_id
 
     @property

--- a/src/astro/files/locations/local.py
+++ b/src/astro/files/locations/local.py
@@ -21,7 +21,6 @@ class LocalLocation(BaseFileLocation):
         if path_object.is_dir():
             paths = [str(filepath) for filepath in path_object.rglob("*")]
         else:
-
             paths = glob.glob(url.path)
         return paths
 

--- a/src/astro/files/locations/local.py
+++ b/src/astro/files/locations/local.py
@@ -21,6 +21,7 @@ class LocalLocation(BaseFileLocation):
         if path_object.is_dir():
             paths = [str(filepath) for filepath in path_object.rglob("*")]
         else:
+
             paths = glob.glob(url.path)
         return paths
 


### PR DESCRIPTION
# Description
## What is the current behavior?
MyPy was complaining that we are returning Any from a function that is supposed to return str
```
@property
    def path(self) -> str:
        return self.location.path
```
Version

    Astro: 0.11.0

To Reproduce
Remove # type: ignore from the path and conn_id property functions.

closes: #543

## What is the new behavior?
Removed the `#type: ignore` that suppressed the issue; now MyPy is not complaining.

## Does this introduce a breaking change?
Nope
