### PR TITLE
Allow running tests on PRs from forks + label

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
     branches: [ 'main' ]
   pull_request:
     branches: [ 'main' ]
+  # Run on PRs from forks
+  pull_request_target:
+    branches: [ 'main' ]
+    types: ['labeled']
 jobs:
   Pre-Commit:
     runs-on: ubuntu-latest
@@ -65,6 +69,16 @@ jobs:
       - run: nox -s build_docs
 
   Run-Optional-Packages-tests:
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork == false
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        contains(github.event.pull_request.labels.*.name, 'safe to test')
+      )
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -81,6 +95,14 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
+
+      - name: Checkout pull/${{ github.event.number }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+        if: github.event_name == 'pull_request_target'
+
       - uses: actions/setup-python@v3
         with:
           python-version: '3.8'
@@ -124,6 +146,16 @@ jobs:
       AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE: True
       FORCE_COLOR: "true"
   Run-Unit-tests-Airflow-2-3:
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork == false
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        contains(github.event.pull_request.labels.*.name, 'safe to test')
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -145,6 +177,13 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
+
+      - name: Checkout pull/${{ github.event.number }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+        if: github.event_name == 'pull_request_target'
       - uses: actions/setup-python@v3
         with:
           python-version: '3.8'
@@ -191,6 +230,16 @@ jobs:
 
 
   Run-Unit-tests-Airflow-2-2-5:
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork == false
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        contains(github.event.pull_request.labels.*.name, 'safe to test')
+      )
     runs-on: ubuntu-latest
     needs:
       - Run-Unit-tests-Airflow-2-3
@@ -210,6 +259,14 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
+
+      - name: Checkout pull/${{ github.event.number }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+        if: github.event_name == 'pull_request_target'
+
       - uses: actions/setup-python@v3
         with:
           python-version: '3.8'

--- a/docs/development/CONTRIBUTING.md
+++ b/docs/development/CONTRIBUTING.md
@@ -53,6 +53,11 @@ Follow the steps described in [development](DEVELOPMENT.md).
    PR guidelines described below.
    Create Pull Request!
 
+5. PRs from contributors who do not have "write" access to this repo will not run all the
+   tests until a committer (who has "write" access to this repo) adds a "safe to test" label on this PR.
+   This is so that we can avoid security risks mentioned in
+   [this blog post](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/).
+
 
 # Pull Request Guidelines
 


### PR DESCRIPTION
This will allow running tests on PRs from forks -- allowing outside contributors to contribute to this Repo. Committers of this repo (the one with write access) will need to add a "safe to test" label to run the tests. Until then the tests will not run.

This is deliberate as we want to be ultra sure on who can run CI with necessary secrets

closes https://github.com/astronomer/astro-sdk/issues/179

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
