### PR TITLE
Rename aql.truncate to aql.drop_table and fix dependency issue

### DIFF
--- a/example_dags/example_snowflake_partial_table_with_append.py
+++ b/example_dags/example_snowflake_partial_table_with_append.py
@@ -9,10 +9,10 @@ from astro.sql import (
     append,
     cleanup,
     dataframe,
+    drop_table,
     load_file,
     run_raw_sql,
     transform,
-    truncate,
 )
 from astro.sql.table import Metadata, Table
 
@@ -136,7 +136,7 @@ def example_snowflake_partial_table_with_append():
     # We truncate this table only to avoid wasting Snowflake resources
     # Why? Between 2022-03-25 and 2022-04-11 it accumulated 301G (89 million rows) because
     # this example DAG used to append rows without deleting them
-    truncate_results = truncate(
+    truncate_results = drop_table(
         table=Table(name="homes_reporting", conn_id=SNOWFLAKE_CONN_ID)
     )
     truncate_results.set_upstream(record_results)

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -12,12 +12,12 @@ from astro.constants import MergeConflictStrategy
 from astro.sql.operators.append import APPEND_COLUMN_TYPE, AppendOperator
 from astro.sql.operators.cleanup import CleanupOperator
 from astro.sql.operators.dataframe import DataframeOperator
+from astro.sql.operators.drop import DropTableOperator
 from astro.sql.operators.export_file import export_file  # noqa: F401
 from astro.sql.operators.load_file import load_file  # noqa: F401
 from astro.sql.operators.merge import MERGE_COLUMN_TYPE, MergeOperator
 from astro.sql.operators.raw_sql import RawSQLOperator
 from astro.sql.operators.transform import TransformOperator  # noqa: F401
-from astro.sql.operators.truncate import TruncateOperator
 from astro.sql.table import Table
 
 
@@ -224,18 +224,18 @@ def merge(
     ).output
 
 
-def truncate(
+def drop_table(
     table: Table,
     **kwargs: Any,
-) -> TruncateOperator:
+):
     """
-    Truncate a table.
+    Drops a table.
 
-    :param table: Table to be truncated
+    :param table: Table to be dropped
     :param kwargs:
     """
 
-    return TruncateOperator(table=table, **kwargs)
+    return DropTableOperator(table=table, **kwargs).output
 
 
 def dataframe(

--- a/src/astro/sql/operators/drop.py
+++ b/src/astro/sql/operators/drop.py
@@ -7,8 +7,10 @@ from astro.databases import create_database
 from astro.sql.table import Table
 
 
-class TruncateOperator(BaseOperator):
-    """Airflow Operator for truncating SQL tables."""
+class DropTableOperator(BaseOperator):
+    """Airflow Operator for dropping SQL tables."""
+
+    template_fields = ("table",)
 
     def __init__(
         self,
@@ -17,14 +19,15 @@ class TruncateOperator(BaseOperator):
         **kwargs,
     ):
         self.table = table
-        task_id = task_id or get_unique_task_id(table.name + "_truncate")
+        task_id = task_id or get_unique_task_id("_drop")
         super().__init__(
             task_id=task_id,
             **kwargs,
         )
 
-    def execute(self, context: Dict) -> None:  # skipcq: PYL-W0613
+    def execute(self, context: Dict) -> Table:  # skipcq: PYL-W0613
         """Method run when the Airflow runner calls the operator."""
         database = create_database(self.table.conn_id)
         self.table = database.populate_table_metadata(self.table)
         database.drop_table(self.table)
+        return self.table


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently the functionality of the TruncateOperator actually acts like a DropTable Operator. We should therefore move this functionality into an `aql.drop_table` function and create a separate `truncate` function in a different PR.

Closes #554
Fixes #515


## What is the new behavior?
Now the function name properly reflects the actions performed. This is a critical bug as people can accidentally drop tables. 

## Does this introduce a breaking change?
Yes, but we can mitigate breaking changes by implementing #555 . It's worth noting that the behavior we're breaking is itself broken behavior.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
