### PR TITLE
Handle nrows for export_to_dataframe()

### DIFF
--- a/src/astro/files/types/ndjson.py
+++ b/src/astro/files/types/ndjson.py
@@ -32,10 +32,6 @@ class NDJSONFileType(FileType):
         return FileTypeConstants.NDJSON
 
     @staticmethod
-    def get_top_n_rows(self, df, n: int):
-        return df[n:]
-
-    @staticmethod
     def flatten(
         normalize_config: Optional[dict], stream: io.TextIOWrapper, **kwargs
     ) -> pd.DataFrame:

--- a/src/astro/files/types/ndjson.py
+++ b/src/astro/files/types/ndjson.py
@@ -68,5 +68,6 @@ class NDJSONFileType(FileType):
 
             row_count = result_df.shape[0]
 
-            rows = stream.readlines(DEFAULT_CHUNK_SIZE)
+            if nrows and row_count < nrows:
+                rows = stream.readlines(DEFAULT_CHUNK_SIZE)
         return result_df

--- a/src/astro/files/types/ndjson.py
+++ b/src/astro/files/types/ndjson.py
@@ -47,7 +47,7 @@ class NDJSONFileType(FileType):
         :rtype: `pandas.DataFrame`
         """
         normalize_config = normalize_config or {}
-        nrows = kwargs.get("nrows", None)
+        nrows = kwargs.get("nrows", float("inf"))
 
         result_df = None
         rows = stream.readlines(DEFAULT_CHUNK_SIZE)
@@ -68,5 +68,5 @@ class NDJSONFileType(FileType):
 
             row_count = result_df.shape[0]
             rows = stream.readlines(DEFAULT_CHUNK_SIZE)
-            
+
         return result_df

--- a/src/astro/files/types/ndjson.py
+++ b/src/astro/files/types/ndjson.py
@@ -52,7 +52,7 @@ class NDJSONFileType(FileType):
         result_df = None
         rows = stream.readlines(DEFAULT_CHUNK_SIZE)
         row_count = 0
-        while len(rows) > 0:
+        while len(rows) > 0 and (nrows and row_count < nrows):
             # Remove extra rows
             if nrows and nrows < row_count + len(rows):
                 diff = (row_count + len(rows)) - nrows
@@ -67,7 +67,6 @@ class NDJSONFileType(FileType):
                 result_df = pd.concat([result_df, df])
 
             row_count = result_df.shape[0]
-
-            if nrows and row_count < nrows:
-                rows = stream.readlines(DEFAULT_CHUNK_SIZE)
+            rows = stream.readlines(DEFAULT_CHUNK_SIZE)
+            
         return result_df

--- a/src/astro/files/types/ndjson.py
+++ b/src/astro/files/types/ndjson.py
@@ -48,9 +48,10 @@ class NDJSONFileType(FileType):
         """
         normalize_config = normalize_config or {}
         nrows = kwargs.get("nrows", float("inf"))
+        chunksize = kwargs.get("chunksize", DEFAULT_CHUNK_SIZE)
 
         result_df = None
-        rows = stream.readlines(DEFAULT_CHUNK_SIZE)
+        rows = stream.readlines(chunksize)
         row_count = 0
         while len(rows) > 0 and (nrows and row_count < nrows):
             # Remove extra rows

--- a/tests/files/type/test_ndjson.py
+++ b/tests/files/type/test_ndjson.py
@@ -59,5 +59,5 @@ def test_ndjson_file_nrows():
 
     # Case 3 : when the user don't pass nrows
     with open(sample_file) as stream:
-        df = file.export_to_dataframe(stream)
+        df = file.export_to_dataframe(stream, chunksize=10)
         assert df.shape[0] == 3

--- a/tests/files/type/test_ndjson.py
+++ b/tests/files/type/test_ndjson.py
@@ -39,3 +39,25 @@ def test_write_ndjson_file():
                 assert len(json.loads(line).keys()) == 2
                 count = count + 1
         assert count == 3
+
+
+def test_ndjson_file_nrows():
+    sample_file = pathlib.Path(
+        pathlib.Path(__file__).parent.parent.parent, "data/sample.ndjson"
+    )
+
+    file = NDJSONFileType(sample_file)
+    # Case 1 : when the file have sufficient rows
+    with open(sample_file) as stream:
+        df = file.export_to_dataframe(stream, nrows=2)
+        assert df.shape[0] == 2
+
+    # Case 2 : when the file don't have sufficient rows
+    with open(sample_file) as stream:
+        df = file.export_to_dataframe(stream, nrows=5)
+        assert df.shape[0] == 3
+
+    # Case 3 : when the user don't pass nrows
+    with open(sample_file) as stream:
+        df = file.export_to_dataframe(stream)
+        assert df.shape[0] == 3


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, export_to_dataframe() is reading the entire file and is not respecting nrows param.
nrows - https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html

Read a file using `file.export_to_dataframe(nrows=10)` the output will be the entire file and not just 10 rows

closes: #558

## What is the new behavior?
Read a file using file.export_to_dataframe(nrows=10) the output should  return dataframe with 10 rows

## Does this introduce a breaking change?
No