### PR TITLE
Add benchmarking result from GCS to Bigquery after optimization

### DIFF
--- a/tests/benchmark/results.md
+++ b/tests/benchmark/results.md
@@ -59,6 +59,16 @@ For Machine types: n2-standard-4
 |stackoverflow/stackoverflow_posts_1g.ndjson|1GB  | 85.409014          |
 |trimmed/pypi/*                             |5GB  | 48.973093          |
 
+#### Results post optimization to load files from GCS to Bigquery using BigqueryHook
+
+|Dataset                                    |Size | Duration(seconds)  |
+|-------------------------------------------|-----|--------------------|
+|covid_overview/covid_overview_10kb.csv     |10 KB| 13.57           |
+|tate_britain/artist_data_100kb.csv         |100KB| 16.10          |
+|imdb/title_ratings_10mb.csv                |10MB | 19.40         |
+|stackoverflow/stackoverflow_posts_1g.ndjson|1GB  | 30.26          |
+|trimmed/pypi/*                             |5GB  | 59.90          |
+
 
 ## Performance evaluation of loading datasets from GCS with Astro Python SDK 0.11.0 into Snowflake
 


### PR DESCRIPTION
Add result based on merged [PR-489](https://github.com/astronomer/astro-sdk/pull/489)

# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently the result of the loadFile after optimisation is not part of [Result.md](https://github.com/astronomer/astro-sdk/blob/main/tests/benchmark/results.md) but just part of the PR description in the [PR-489](https://github.com/astronomer/astro-sdk/pull/489).

## What is the new behavior?
Add result based on merged [PR-489](https://github.com/astronomer/astro-sdk/pull/489)

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #562 


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
