### PR TITLE
Column capitalization

### DIFF
--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -44,3 +44,5 @@ ExportExistsStrategy = Literal["replace", "exception"]
 
 # TODO: check how snowflake names these
 MergeConflictStrategy = Literal["ignore", "update", "exception"]
+
+ColumnCapitalization = Literal["upper", "lower", "original"]

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -302,6 +302,29 @@ class SnowflakeDatabase(BaseDatabase):
     # Table load methods
     # ---------------------------------------------------------
 
+    def create_table_using_schema_autodetection(
+        self,
+        table: Table,
+        file: Optional[File] = None,
+        dataframe: Optional[pd.DataFrame] = None,
+    ) -> None:
+        """
+        Create a SQL table, automatically inferring the schema using the given file.
+
+        :param table: The table to be created.
+        :param file: File used to infer the new table columns.
+        :param dataframe: Dataframe used to infer the new table columns if there is no file
+        """
+        if file:
+            dataframe = file.export_to_dataframe(
+                nrows=settings.LOAD_TABLE_AUTODETECT_ROWS_COUNT
+            )
+
+        if dataframe is not None:
+            dataframe.columns.str.upper()
+        # Make columns uppercase to prevent weird errors in snowflake
+        super().create_table_using_schema_autodetection(table, dataframe=dataframe)
+
     def is_native_load_file_available(
         self, source_file: File, target_table: Table
     ) -> bool:

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -37,6 +37,9 @@ COPY_OPTIONS = {
     FileType.PARQUET: "MATCH_BY_COLUMN_NAME=CASE_INSENSITIVE",
 }
 
+NATIVE_LOAD_SUPPORTED_FILE_TYPES = (FileType.CSV, FileType.NDJSON, FileType.PARQUET)
+NATIVE_LOAD_SUPPORTED_FILE_LOCATIONS = (FileLocation.GS, FileLocation.S3)
+
 
 @dataclass
 class SnowflakeStage:
@@ -291,6 +294,23 @@ class SnowflakeDatabase(BaseDatabase):
     # ---------------------------------------------------------
     # Table load methods
     # ---------------------------------------------------------
+
+    def is_native_load_file_available(
+        self, source_file: File, target_table: Table
+    ) -> bool:
+        """
+        Check if there is an optimised path for source to destination.
+
+        :param source_file: File from which we need to transfer data
+        :param target_table: Table that needs to be populated with file data
+        """
+        is_file_type_supported = (
+            source_file.type.name in NATIVE_LOAD_SUPPORTED_FILE_TYPES
+        )
+        is_file_location_supported = (
+            source_file.location.location_type in NATIVE_LOAD_SUPPORTED_FILE_LOCATIONS
+        )
+        return is_file_type_supported and is_file_location_supported
 
     def load_file_to_table_natively(
         self,

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -299,7 +299,7 @@ class SnowflakeDatabase(BaseDatabase):
         if_exists: LoadExistStrategy = "replace",
         native_support_kwargs: Optional[Dict] = None,
         **kwargs,
-    ):
+    ) -> None:
         """
         Load the content of a file to an existing Snowflake table natively by:
         - Creating a Snowflake external stage
@@ -308,18 +308,20 @@ class SnowflakeDatabase(BaseDatabase):
         Requirements:
         - The user must have permissions to create a STAGE in Snowflake.
         - If loading from GCP Cloud Storage, `native_support_kwargs` must define `storage_integration`
-        - If loading from AWS S3, the credentials for creating the stage may be retrieved from
-          the Airflow connection or from the `storage_integration` attribute within `native_support_kwargs`.
+        - If loading from AWS S3, the credentials for creating the stage may be retrieved from the Airflow connection or from the `storage_integration` attribute within `native_support_kwargs`.
 
-        :param source_file:
-        :param target_table:
-        :param if_exists
+        :param source_file: File from which we need to transfer data
+        :param target_table: Table to which the content of the file will be loaded to 
+        :param if_exists: Strategy used to load (currently supported: "append" or "replace")
+        :param native_support_kwargs: kwargs to be used by method involved in native support flow
+
 
         .. seealso::
             `Snowflake official documentation on COPY INTO
             <https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html>`_
             `Snowflake official documentation on CREATE STAGE
             <https://docs.snowflake.com/en/sql-reference/sql/create-stage.html>`_
+
         """
         native_support_kwargs = native_support_kwargs or {}
         storage_integration = native_support_kwargs.get("storage_integration")

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -308,10 +308,12 @@ class SnowflakeDatabase(BaseDatabase):
         Requirements:
         - The user must have permissions to create a STAGE in Snowflake.
         - If loading from GCP Cloud Storage, `native_support_kwargs` must define `storage_integration`
-        - If loading from AWS S3, the credentials for creating the stage may be retrieved from the Airflow connection or from the `storage_integration` attribute within `native_support_kwargs`.
+        - If loading from AWS S3, the credentials for creating the stage may be
+        retrieved from the Airflow connection or from the `storage_integration`
+        attribute within `native_support_kwargs`.
 
         :param source_file: File from which we need to transfer data
-        :param target_table: Table to which the content of the file will be loaded to 
+        :param target_table: Table to which the content of the file will be loaded to
         :param if_exists: Strategy used to load (currently supported: "append" or "replace")
         :param native_support_kwargs: kwargs to be used by method involved in native support flow
 

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -335,7 +335,7 @@ class SnowflakeDatabase(BaseDatabase):
         :param source_file: File from which we need to transfer data
         :param target_table: Table to which the content of the file will be loaded to
         :param if_exists: Strategy used to load (currently supported: "append" or "replace")
-        :param native_support_kwargs: kwargs to be used by method involved in native support flow
+        :param native_support_kwargs: may be used for the stage creation, as described above.
 
 
         .. seealso::

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -8,7 +8,7 @@ except ImportError:
     from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
-from astro.constants import MergeConflictStrategy
+from astro.constants import ColumnCapitalization, MergeConflictStrategy
 from astro.sql.operators.append import APPEND_COLUMN_TYPE, AppendOperator
 from astro.sql.operators.cleanup import CleanupOperator
 from astro.sql.operators.dataframe import DataframeOperator
@@ -245,7 +245,7 @@ def dataframe(
     database: Optional[str] = None,
     schema: Optional[str] = None,
     task_id: Optional[str] = None,
-    identifiers_as_lower: Optional[bool] = True,
+    columns_names_capitalization: ColumnCapitalization = "lower",
 ) -> Callable[..., pd.DataFrame]:
     """
     This decorator will allow users to write python functions while treating SQL tables as dataframes
@@ -257,7 +257,7 @@ def dataframe(
         "conn_id": conn_id,
         "database": database,
         "schema": schema,
-        "identifiers_as_lower": identifiers_as_lower,
+        "columns_names_capitalization": columns_names_capitalization,
     }
     if task_id:
         param_map["task_id"] = task_id

--- a/src/astro/utils/dataframe.py
+++ b/src/astro/utils/dataframe.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from astro.constants import ColumnCapitalization
+
+
+def convert_dataframe_col_case(
+    df: pd.DataFrame, columns_names_capitalization: ColumnCapitalization
+):
+    """
+    Convert cols of a dataframe to required case. Options - lower/Upper
+
+    :param df: dataframe whose cols will be altered
+    :param columns_names_capitalization: String Literal with possible values - lower/Upper
+    """
+    if columns_names_capitalization == "lower":
+        df.columns = [col_label.lower() for col_label in df.columns]
+    elif columns_names_capitalization == "upper":
+        df.columns = [col_label.upper() for col_label in df.columns]
+    return df

--- a/tests/benchmark/Dockerfile
+++ b/tests/benchmark/Dockerfile
@@ -11,6 +11,7 @@ ENV AIRFLOW_HOME=/opt/app/
 ENV PYTHONPATH=/opt/app/
 ENV ASTRO_PUBLISH_BENCHMARK_DATA=True
 ENV GCP_BUCKET=dag-authoring
+ENV AIRFLOW__ASTRO_SDK__SNOWFLAKE_STORAGE_INTEGRATION_GOOGLE=gcs_int_python_sdk
 
 # Debian Bullseye is shipped with Python 3.9
 # Upgrade built-in pip

--- a/tests/benchmark/Makefile
+++ b/tests/benchmark/Makefile
@@ -46,7 +46,7 @@ local: check_google_credentials
 	@rm -rf astro-sdk
 
 
-run_job: check_google_credentials
+run_job: 
 	@gcloud container clusters get-credentials astro-sdk --zone us-central1-a --project ${GCP_PROJECT}
 	@kubectl apply -f infrastructure/kubernetes/namespace.yaml
 	@kubectl apply -f infrastructure/kubernetes/postgres.yaml

--- a/tests/benchmark/Makefile
+++ b/tests/benchmark/Makefile
@@ -19,6 +19,10 @@ clean:
 	@rm -f unittests.cfg
 	@rm -f unittests.db
 	@rm -f webserver_config.py
+	@rm -f ../../unittests.cfg
+	@rm -f ../../unittests.db
+	@rm -f ../../airflow.cfg
+	@rm -f ../../airflow.db
 
 # Takes approximately 7min
 setup_gke:
@@ -45,8 +49,7 @@ local: check_google_credentials
    		benchmark
 	@rm -rf astro-sdk
 
-
-run_job: 
+run_job:
 	@gcloud container clusters get-credentials astro-sdk --zone us-central1-a --project ${GCP_PROJECT}
 	@kubectl apply -f infrastructure/kubernetes/namespace.yaml
 	@kubectl apply -f infrastructure/kubernetes/postgres.yaml

--- a/tests/benchmark/config.json
+++ b/tests/benchmark/config.json
@@ -3,7 +3,7 @@
     {
       "name": "postgres",
       "params": {
-        "conn_id": "postgres_conn_benchmark",
+        "conn_id": "postgres_conn",
         "metadata": {
           "database": "postgres"
         }

--- a/tests/benchmark/config.json
+++ b/tests/benchmark/config.json
@@ -1,9 +1,15 @@
 {
   "databases": [
     {
+      "name": "snowflake",
+      "params": {
+        "conn_id": "snowflake_conn"
+      }
+    },
+    {
       "name": "postgres",
       "params": {
-        "conn_id": "postgres_conn",
+        "conn_id": "postgres_conn_benchmark",
         "metadata": {
           "database": "postgres"
         }
@@ -16,12 +22,6 @@
         "metadata": {
           "database": "bigquery"
         }
-      }
-    },
-    {
-      "name": "snowflake",
-      "params": {
-        "conn_id": "snowflake_conn"
       }
     }
   ],

--- a/tests/benchmark/debug.yaml
+++ b/tests/benchmark/debug.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: troubleshoot
+  namespace: benchmark
+spec:
+  containers:
+  - name: troubleshoot-benchmark
+    image: gcr.io/astronomer-dag-authoring/benchmark
+    # Just spin & wait forever
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 30; done;" ]

--- a/tests/sql/operators/test_dataframe.py
+++ b/tests/sql/operators/test_dataframe.py
@@ -261,3 +261,49 @@ def test_postgres_dataframe_without_table_arg(sample_dag):
         )
         validate_result(pg_df)
     test_utils.run_dag(sample_dag)
+
+
+def test_columns_names_capitalization(sample_dag):
+    """Test dataframe operator with columns_names_capitalization param"""
+
+    @aql.dataframe(columns_names_capitalization="lower")
+    def sample_df_1():  # skipcq: PY-D0003
+        return pandas.DataFrame(
+            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
+        )
+
+    @aql.dataframe(columns_names_capitalization="upper")
+    def sample_df_2():  # skipcq: PY-D0003
+        return pandas.DataFrame(
+            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
+        )
+
+    @aql.dataframe(columns_names_capitalization="original")
+    def sample_df_3():  # skipcq: PY-D0003
+        return pandas.DataFrame(
+            {"numbers": [1, 2, 3], "COLORS": ["red", "white", "blue"]}
+        )
+
+    with sample_dag:
+        res_1 = sample_df_1()
+        res_2 = sample_df_2()
+        res_3 = sample_df_3()
+    test_utils.run_dag(sample_dag)
+
+    columns = XCom.get_one(
+        execution_date=DEFAULT_DATE, key=res_1.key, task_id=res_1.operator.task_id
+    )
+    assert all(x.islower() for x in columns)
+
+    columns = XCom.get_one(
+        execution_date=DEFAULT_DATE, key=res_2.key, task_id=res_2.operator.task_id
+    )
+    assert all(x.isupper() for x in columns)
+
+    columns = XCom.get_one(
+        execution_date=DEFAULT_DATE, key=res_3.key, task_id=res_3.operator.task_id
+    )
+    cols = list(columns.columns)
+    cols.sort()
+    assert cols[1].islower()
+    assert cols[0].isupper()


### PR DESCRIPTION
# Description
## What is the current behavior?
To achieve a first end-to-end delivery of the Snowflake optimization:
https://github.com/astronomer/astro-sdk/pull/487
https://github.com/astronomer/astro-sdk/pull/544

There was an assumption that to avoid issues with Snowflake mixed-capitalized column names, it was acceptable to convert all characters to uppercase.

1.     it is not consistent with the dataframe decorator parameter: identifiers_as_lower
2.     it does not support the use case where users may prefer to convert everything to uppercase

closes: #564

## What is the new behavior?

The goal with this ticket is to add the following argument to both aql.dataframe and aql.load_file (snowflake-only), removing the previous identifiers_as_lower parameter:

columns_names_capitalization=["upper", "lower", "original"]

### Checklist
- [X] Replace the aql.dataframe argument identifiers_as_lower by columns_names_capitalization
- [ ] Add support for columns_names_capitalization when using load_file to Snowflake
- [X] Have tests covering these scenarios
- [ ] Update release notes
