### PR TITLE
Add 'columns_names_capitalization' param to control the cols case 

### DIFF
--- a/example_dags/example_amazon_s3_postgres.py
+++ b/example_dags/example_amazon_s3_postgres.py
@@ -30,7 +30,7 @@ def sample_create_table(input_table: Table):
     return "SELECT * FROM {{input_table}} LIMIT 10"
 
 
-@aql.dataframe(identifiers_as_lower=False)
+@aql.dataframe(columns_names_capitalization="original")
 def my_df_func(input_df: DataFrame):
     print(input_df)
 

--- a/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/example_dags/example_amazon_s3_snowflake_transform.py
@@ -25,7 +25,7 @@ def clean_data(input_table: Table):
     """
 
 
-@aql.dataframe()
+@aql.dataframe(columns_names_capitalization="original")
 def aggregate_data(df: pd.DataFrame):
     new_df = df.pivot_table(
         index="date", values="name", columns=["type"], aggfunc="count"

--- a/example_dags/example_google_bigquery_gcs_load_and_save.py
+++ b/example_dags/example_google_bigquery_gcs_load_and_save.py
@@ -40,7 +40,7 @@ with DAG(
     )
 
     # Setting "identifiers_as_lower" to True will lowercase all column names
-    @aql.dataframe(identifiers_as_lower=False)
+    @aql.dataframe(columns_names_capitalization="original")
     def extract_top_5_movies(input_df: pd.DataFrame):
         print(f"Total Number of records: {len(input_df)}")
         top_5_movies = input_df.sort_values(by="Rating", ascending=False)[

--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -44,3 +44,5 @@ ExportExistsStrategy = Literal["replace", "exception"]
 
 # TODO: check how snowflake names these
 MergeConflictStrategy = Literal["ignore", "update", "exception"]
+
+ColumnCapitalization = Literal["upper", "lower", "original"]

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -12,6 +12,7 @@ from sqlalchemy.sql.schema import Table as SqlaTable
 
 from astro.constants import (
     DEFAULT_CHUNK_SIZE,
+    ColumnCapitalization,
     ExportExistsStrategy,
     LoadExistStrategy,
     MergeConflictStrategy,
@@ -20,6 +21,7 @@ from astro.exceptions import NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import Metadata, Table
+from astro.utils.dataframe import convert_dataframe_col_case
 
 
 class BaseDatabase(ABC):
@@ -181,6 +183,7 @@ class BaseDatabase(ABC):
         table: Table,
         file: Optional[File] = None,
         dataframe: Optional[pd.DataFrame] = None,
+        columns_names_capitalization: ColumnCapitalization = "lower",
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file.
@@ -188,6 +191,8 @@ class BaseDatabase(ABC):
         :param table: The table to be created.
         :param file: File used to infer the new table columns.
         :param dataframe: Dataframe used to infer the new table columns if there is no file
+        :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
+            in the resulting dataframe
         """
         if file is None:
             if dataframe is None:
@@ -199,6 +204,11 @@ class BaseDatabase(ABC):
             source_dataframe = file.export_to_dataframe(
                 nrows=LOAD_TABLE_AUTODETECT_ROWS_COUNT
             )
+        source_dataframe = convert_dataframe_col_case(
+            df=source_dataframe,
+            columns_names_capitalization=columns_names_capitalization,
+        )
+
         db = SQLDatabase(engine=self.sqlalchemy_engine)
         db.prep_table(
             source_dataframe,
@@ -213,6 +223,7 @@ class BaseDatabase(ABC):
         table: Table,
         file: Optional[File] = None,
         dataframe: Optional[pd.DataFrame] = None,
+        columns_names_capitalization: ColumnCapitalization = "lower",
     ) -> None:
         """
         Create a table either using its explicitly defined columns or inferring
@@ -221,12 +232,15 @@ class BaseDatabase(ABC):
         :param table: The table to be created
         :param file: (optional) File used to infer the table columns.
         :param dataframe: (optional) Dataframe used to infer the new table columns if there is no file
-
+        :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
+            in the resulting dataframe
         """
         if table.columns:
             self.create_table_using_columns(table)
         else:
-            self.create_table_using_schema_autodetection(table, file, dataframe)
+            self.create_table_using_schema_autodetection(
+                table, file, dataframe, columns_names_capitalization
+            )
 
     def create_table_from_select_statement(
         self,
@@ -270,6 +284,7 @@ class BaseDatabase(ABC):
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         use_native_support: bool = True,
         native_support_kwargs: Optional[Dict] = None,
+        columns_names_capitalization: ColumnCapitalization = "lower",
         **kwargs,
     ):
         """
@@ -283,6 +298,8 @@ class BaseDatabase(ABC):
         :param use_native_support: Use native support for data transfer if available on the destination
         :param normalize_config: pandas json_normalize params config
         :param native_support_kwargs: kwargs to be used by method involved in native support flow
+        :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
+            in the resulting dataframe
         """
         normalize_config = normalize_config or {}
         input_files = resolve_file_path_pattern(
@@ -293,7 +310,11 @@ class BaseDatabase(ABC):
         self.create_schema_if_needed(output_table.metadata.schema)
         if if_exists == "replace" or not self.table_exists(output_table):
             self.drop_table(output_table)
-            self.create_table(output_table, input_files[0])
+            self.create_table(
+                output_table,
+                input_files[0],
+                columns_names_capitalization=columns_names_capitalization,
+            )
             if_exists = "append"
 
         # TODO: many native transfers support the input_file.path - it may be better

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -218,7 +218,7 @@ class BaseDatabase(ABC):
         table: Table,
         file: Optional[File] = None,
         dataframe: Optional[pd.DataFrame] = None,
-        columns_names_capitalization: ColumnCapitalization = "lower",
+        columns_names_capitalization: ColumnCapitalization = "original",
     ) -> None:
         """
         Create a table either using its explicitly defined columns or inferring
@@ -279,7 +279,7 @@ class BaseDatabase(ABC):
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         use_native_support: bool = True,
         native_support_kwargs: Optional[Dict] = None,
-        columns_names_capitalization: ColumnCapitalization = "lower",
+        columns_names_capitalization: ColumnCapitalization = "original",
         **kwargs,
     ):
         """

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -21,7 +21,6 @@ from astro.exceptions import NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import Metadata, Table
-from astro.utils.dataframe import convert_dataframe_col_case
 
 
 class BaseDatabase(ABC):
@@ -204,10 +203,6 @@ class BaseDatabase(ABC):
             source_dataframe = file.export_to_dataframe(
                 nrows=LOAD_TABLE_AUTODETECT_ROWS_COUNT
             )
-        source_dataframe = convert_dataframe_col_case(
-            df=source_dataframe,
-            columns_names_capitalization=columns_names_capitalization,
-        )
 
         db = SQLDatabase(engine=self.sqlalchemy_engine)
         db.prep_table(

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -184,7 +184,7 @@ class BaseDatabase(ABC):
         table: Table,
         file: Optional[File] = None,
         dataframe: Optional[pd.DataFrame] = None,
-        columns_names_capitalization: ColumnCapitalization = "lower",
+        columns_names_capitalization: ColumnCapitalization = "lower",  # skipcq
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file.

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -14,6 +14,7 @@ from snowflake.connector.errors import ProgrammingError
 from astro import settings
 from astro.constants import (
     DEFAULT_CHUNK_SIZE,
+    ColumnCapitalization,
     FileLocation,
     FileType,
     LoadExistStrategy,
@@ -22,6 +23,7 @@ from astro.constants import (
 from astro.databases.base import BaseDatabase
 from astro.files import File
 from astro.sql.table import Metadata, Table
+from astro.utils.dataframe import convert_dataframe_col_case
 
 DEFAULT_CONN_ID = SnowflakeHook.default_conn_name
 
@@ -306,6 +308,7 @@ class SnowflakeDatabase(BaseDatabase):
         table: Table,
         file: Optional[File] = None,
         dataframe: Optional[pd.DataFrame] = None,
+        columns_names_capitalization: ColumnCapitalization = "lower",
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file.
@@ -321,8 +324,9 @@ class SnowflakeDatabase(BaseDatabase):
 
         # Snowflake doesn't handle well mixed capitalisation of column name chars
         # we are handling this more gracefully in a separate PR
-        if dataframe is not None:
-            dataframe.columns.str.upper()
+        dataframe = convert_dataframe_col_case(
+            df=dataframe, columns_names_capitalization=columns_names_capitalization
+        )
 
         super().create_table_using_schema_autodetection(table, dataframe=dataframe)
 

--- a/src/astro/files/types/csv.py
+++ b/src/astro/files/types/csv.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
-from astro.utils.dataframe import convert_dataframe_col_case
+from astro.utils.dataframe import convert_columns_names_capitalization
 
 
 class CSVFileType(FileType):
@@ -20,7 +20,7 @@ class CSVFileType(FileType):
             in the resulting dataframe
         """
         df = pd.read_csv(stream, **kwargs)
-        df = convert_dataframe_col_case(
+        df = convert_columns_names_capitalization(
             df=df, columns_names_capitalization=columns_names_capitalization
         )
         return df

--- a/src/astro/files/types/csv.py
+++ b/src/astro/files/types/csv.py
@@ -4,17 +4,26 @@ import pandas as pd
 
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
+from astro.utils.dataframe import convert_dataframe_col_case
 
 
 class CSVFileType(FileType):
     """Concrete implementation to handle CSV file type"""
 
-    def export_to_dataframe(self, stream, **kwargs) -> pd.DataFrame:
+    def export_to_dataframe(
+        self, stream, columns_names_capitalization="original", **kwargs
+    ) -> pd.DataFrame:
         """read csv file from one of the supported locations and return dataframe
 
         :param stream: file stream object
+        :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
+            in the resulting dataframe
         """
-        return pd.read_csv(stream, **kwargs)
+        df = pd.read_csv(stream, **kwargs)
+        df = convert_dataframe_col_case(
+            df=df, columns_names_capitalization=columns_names_capitalization
+        )
+        return df
 
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
         """Write csv file to one of the supported locations

--- a/src/astro/files/types/json.py
+++ b/src/astro/files/types/json.py
@@ -4,20 +4,32 @@ import pandas as pd
 
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
+from astro.utils.dataframe import convert_dataframe_col_case
 
 
 class JSONFileType(FileType):
     """Concrete implementation to handle JSON file type"""
 
-    def export_to_dataframe(self, stream: io.TextIOWrapper, **kwargs):
+    def export_to_dataframe(
+        self,
+        stream: io.TextIOWrapper,
+        columns_names_capitalization="original",
+        **kwargs
+    ) -> pd.DataFrame:
         """read json file from one of the supported locations and return dataframe
 
         :param stream: file stream object
+        :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
+            in the resulting dataframe
         """
         kwargs_copy = dict(kwargs)
         # Pandas `read_json` does not support the `nrows` parameter unless we're using NDJSON
         kwargs_copy.pop("nrows", None)
-        return pd.read_json(stream, **kwargs_copy)
+        df = pd.read_json(stream, **kwargs_copy)
+        df = convert_dataframe_col_case(
+            df=df, columns_names_capitalization=columns_names_capitalization
+        )
+        return df
 
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
         """Write json file to one of the supported locations

--- a/src/astro/files/types/json.py
+++ b/src/astro/files/types/json.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
-from astro.utils.dataframe import convert_dataframe_col_case
+from astro.utils.dataframe import convert_columns_names_capitalization
 
 
 class JSONFileType(FileType):
@@ -26,7 +26,7 @@ class JSONFileType(FileType):
         # Pandas `read_json` does not support the `nrows` parameter unless we're using NDJSON
         kwargs_copy.pop("nrows", None)
         df = pd.read_json(stream, **kwargs_copy)
-        df = convert_dataframe_col_case(
+        df = convert_columns_names_capitalization(
             df=df, columns_names_capitalization=columns_names_capitalization
         )
         return df

--- a/src/astro/files/types/ndjson.py
+++ b/src/astro/files/types/ndjson.py
@@ -7,17 +7,26 @@ import pandas as pd
 from astro.constants import DEFAULT_CHUNK_SIZE
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
+from astro.utils.dataframe import convert_dataframe_col_case
 
 
 class NDJSONFileType(FileType):
     """Concrete implementation to handle NDJSON file type"""
 
-    def export_to_dataframe(self, stream, **kwargs):
+    def export_to_dataframe(
+        self, stream, columns_names_capitalization="original", **kwargs
+    ):
         """read ndjson file from one of the supported locations and return dataframe
 
         :param stream: file stream object
+        :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
+            in the resulting dataframe
         """
-        return NDJSONFileType.flatten(self.normalize_config, stream, **kwargs)
+        df = NDJSONFileType.flatten(self.normalize_config, stream, **kwargs)
+        df = convert_dataframe_col_case(
+            df=df, columns_names_capitalization=columns_names_capitalization
+        )
+        return df
 
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
         """Write ndjson file to one of the supported locations

--- a/src/astro/files/types/ndjson.py
+++ b/src/astro/files/types/ndjson.py
@@ -7,7 +7,7 @@ import pandas as pd
 from astro.constants import DEFAULT_CHUNK_SIZE
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
-from astro.utils.dataframe import convert_dataframe_col_case
+from astro.utils.dataframe import convert_columns_names_capitalization
 
 
 class NDJSONFileType(FileType):
@@ -23,7 +23,7 @@ class NDJSONFileType(FileType):
             in the resulting dataframe
         """
         df = NDJSONFileType.flatten(self.normalize_config, stream, **kwargs)
-        df = convert_dataframe_col_case(
+        df = convert_columns_names_capitalization(
             df=df, columns_names_capitalization=columns_names_capitalization
         )
         return df

--- a/src/astro/files/types/parquet.py
+++ b/src/astro/files/types/parquet.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
-from astro.utils.dataframe import convert_dataframe_col_case
+from astro.utils.dataframe import convert_columns_names_capitalization
 
 
 class ParquetFileType(FileType):
@@ -24,7 +24,7 @@ class ParquetFileType(FileType):
         kwargs_copy.pop("nrows", None)
 
         df = pd.read_parquet(stream, **kwargs_copy)
-        df = convert_dataframe_col_case(
+        df = convert_columns_names_capitalization(
             df=df, columns_names_capitalization=columns_names_capitalization
         )
         return df

--- a/src/astro/files/types/parquet.py
+++ b/src/astro/files/types/parquet.py
@@ -4,20 +4,30 @@ import pandas as pd
 
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
+from astro.utils.dataframe import convert_dataframe_col_case
 
 
 class ParquetFileType(FileType):
     """Concrete implementation to handle Parquet file type"""
 
-    def export_to_dataframe(self, stream, **kwargs):
+    def export_to_dataframe(
+        self, stream, columns_names_capitalization="original", **kwargs
+    ):
         """read parquet file from one of the supported locations and return dataframe
 
         :param stream: file stream object
+        :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
+            in the resulting dataframe
         """
         kwargs_copy = dict(kwargs)
         # Pandas `read_parquet` does not support the `nrows` parameter
         kwargs_copy.pop("nrows", None)
-        return pd.read_parquet(stream, **kwargs_copy)
+
+        df = pd.read_parquet(stream, **kwargs_copy)
+        df = convert_dataframe_col_case(
+            df=df, columns_names_capitalization=columns_names_capitalization
+        )
+        return df
 
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
         """Write parquet file to one of the supported locations

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -8,7 +8,7 @@ except ImportError:
     from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
-from astro.constants import MergeConflictStrategy
+from astro.constants import ColumnCapitalization, MergeConflictStrategy
 from astro.sql.operators.append import APPEND_COLUMN_TYPE, AppendOperator
 from astro.sql.operators.cleanup import CleanupOperator
 from astro.sql.operators.dataframe import DataframeOperator
@@ -245,7 +245,7 @@ def dataframe(
     database: Optional[str] = None,
     schema: Optional[str] = None,
     task_id: Optional[str] = None,
-    identifiers_as_lower: Optional[bool] = True,
+    columns_names_capitalization: ColumnCapitalization = "lower",
 ) -> Callable[..., pd.DataFrame]:
     """
     This decorator will allow users to write python functions while treating SQL tables as dataframes
@@ -257,7 +257,7 @@ def dataframe(
         "conn_id": conn_id,
         "database": database,
         "schema": schema,
-        "identifiers_as_lower": identifiers_as_lower,
+        "columns_names_capitalization": columns_names_capitalization,
     }
     if task_id:
         param_map["task_id"] = task_id

--- a/src/astro/sql/operators/dataframe.py
+++ b/src/astro/sql/operators/dataframe.py
@@ -9,7 +9,7 @@ from astro.constants import ColumnCapitalization
 from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.sql.table import Table
-from astro.utils.dataframe import convert_dataframe_col_case
+from astro.utils.dataframe import convert_columns_names_capitalization
 from astro.utils.table import find_first_table
 
 
@@ -21,7 +21,7 @@ def _get_dataframe(
     """
     database = create_database(table.conn_id)
     df = database.export_table_to_pandas_dataframe(source_table=table)
-    df = convert_dataframe_col_case(
+    df = convert_columns_names_capitalization(
         df=df, columns_names_capitalization=columns_names_capitalization
     )
 
@@ -134,7 +134,7 @@ class DataframeOperator(DecoratedOperator):
         )
 
         pandas_dataframe = self.python_callable(*self.op_args, **self.op_kwargs)
-        pandas_dataframe = convert_dataframe_col_case(
+        pandas_dataframe = convert_columns_names_capitalization(
             df=pandas_dataframe,
             columns_names_capitalization=self.columns_names_capitalization,
         )

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -103,6 +103,7 @@ class LoadFile(BaseOperator):
             chunk_size=self.chunk_size,
             use_native_support=self.use_native_support,
             native_support_kwargs=self.native_support_kwargs,
+            columns_names_capitalization=self.columns_names_capitalization,
         )
         self.log.info("Completed loading the data into %s.", self.output_table)
         return self.output_table

--- a/src/astro/utils/dataframe.py
+++ b/src/astro/utils/dataframe.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from astro.constants import ColumnCapitalization
+
+
+def convert_dataframe_col_case(
+    df: pd.DataFrame, columns_names_capitalization: ColumnCapitalization
+):
+    """
+    Convert cols of a dataframe to required case. Options - lower/Upper
+
+    :param df: dataframe whose cols will be altered
+    :param columns_names_capitalization: String Literal with possible values - lower/Upper
+    """
+    if columns_names_capitalization == "lower":
+        df.columns = [col_label.lower() for col_label in df.columns]
+    elif columns_names_capitalization == "upper":
+        df.columns = [col_label.upper() for col_label in df.columns]
+    return df

--- a/src/astro/utils/dataframe.py
+++ b/src/astro/utils/dataframe.py
@@ -12,8 +12,9 @@ def convert_dataframe_col_case(
     :param df: dataframe whose cols will be altered
     :param columns_names_capitalization: String Literal with possible values - lower/Upper
     """
-    if columns_names_capitalization == "lower":
-        df.columns = [col_label.lower() for col_label in df.columns]
-    elif columns_names_capitalization == "upper":
-        df.columns = [col_label.upper() for col_label in df.columns]
+    if isinstance(df, pd.DataFrame):
+        if columns_names_capitalization == "lower":
+            df.columns = [col_label.lower() for col_label in df.columns]
+        elif columns_names_capitalization == "upper":
+            df.columns = [col_label.upper() for col_label in df.columns]
     return df

--- a/src/astro/utils/dataframe.py
+++ b/src/astro/utils/dataframe.py
@@ -3,7 +3,7 @@ import pandas as pd
 from astro.constants import ColumnCapitalization
 
 
-def convert_dataframe_col_case(
+def convert_columns_names_capitalization(
     df: pd.DataFrame, columns_names_capitalization: ColumnCapitalization
 ):
     """

--- a/tests/sql/operators/test_dataframe.py
+++ b/tests/sql/operators/test_dataframe.py
@@ -197,46 +197,6 @@ def test_dataframe_from_sql_basic_op_arg_and_kwarg(
     )
 
 
-@pytest.mark.parametrize(
-    "database_table_fixture",
-    [
-        {
-            "database": Database.POSTGRES,
-            "file": File(path=str(CWD) + "/../../data/homes_upper.csv"),
-        },
-    ],
-    indirect=True,
-    ids=["postgresql"],
-)
-@pytest.mark.parametrize(
-    "identifiers_as_lower",
-    [True, False],
-    ids=["identifiers_as_lower=True", "identifiers_as_lower=False"],
-)
-def test_dataframe_with_lower_and_upper_case(
-    sample_dag, database_table_fixture, identifiers_as_lower
-):
-    """
-    Test dataframe operator 'identifiers_as_lower' param which converts
-    all col names in lower case, which is useful to maintain consistency,
-    since snowflake return all col name in caps.
-    """
-    _, test_table = database_table_fixture
-
-    @aql.dataframe(identifiers_as_lower=identifiers_as_lower)
-    def my_df_func(df: pandas.DataFrame):  # skipcq: PY-D0003
-        return df.columns
-
-    with sample_dag:
-        res = my_df_func(df=test_table)
-    test_utils.run_dag(sample_dag)
-
-    columns = XCom.get_one(
-        execution_date=DEFAULT_DATE, key=res.key, task_id=res.operator.task_id
-    )
-    assert all(x.islower() for x in columns) == identifiers_as_lower
-
-
 def test_postgres_dataframe_without_table_arg(sample_dag):
     """Test dataframe operator without table argument"""
 

--- a/tests/sql/operators/test_dataframe.py
+++ b/tests/sql/operators/test_dataframe.py
@@ -261,3 +261,49 @@ def test_postgres_dataframe_without_table_arg(sample_dag):
         )
         validate_result(pg_df)
     test_utils.run_dag(sample_dag)
+
+
+def test_columns_names_capitalization(sample_dag):
+    """Test dataframe operator with columns_names_capitalization param"""
+
+    @aql.dataframe(columns_names_capitalization="lower")
+    def sample_df_1():  # skipcq: PY-D0003
+        return pandas.DataFrame(
+            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
+        )
+
+    @aql.dataframe(columns_names_capitalization="upper")
+    def sample_df_2():  # skipcq: PY-D0003
+        return pandas.DataFrame(
+            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
+        )
+
+    @aql.dataframe(columns_names_capitalization="original")
+    def sample_df_3():  # skipcq: PY-D0003
+        return pandas.DataFrame(
+            {"numbers": [1, 2, 3], "COLORS": ["red", "white", "blue"]}
+        )
+
+    with sample_dag:
+        res_1 = sample_df_1()
+        res_2 = sample_df_2()
+        res_3 = sample_df_3()
+    test_utils.run_dag(sample_dag)
+
+    columns = XCom.get_one(
+        execution_date=DEFAULT_DATE, key=res_1.key, task_id=res_1.operator.task_id
+    )
+    assert all(x.islower() for x in columns)
+
+    columns = XCom.get_one(
+        execution_date=DEFAULT_DATE, key=res_2.key, task_id=res_2.operator.task_id
+    )
+    assert all(x.isupper() for x in columns)
+
+    columns = XCom.get_one(
+        execution_date=DEFAULT_DATE, key=res_3.key, task_id=res_3.operator.task_id
+    )
+    cols = list(columns.columns)
+    cols.sort()
+    assert cols[1].islower()
+    assert cols[0].isupper()


### PR DESCRIPTION
# Description
## What is the current behavior?
To achieve a first end-to-end delivery of the Snowflake optimization:
https://github.com/astronomer/astro-sdk/pull/487
https://github.com/astronomer/astro-sdk/pull/544

There was an assumption that to avoid issues with Snowflake mixed-capitalized column names, it was acceptable to convert all characters to uppercase.

1.     it is not consistent with the dataframe decorator parameter: identifiers_as_lower
2.     it does not support the use case where users may prefer to convert everything to uppercase

closes: #564

## What is the new behavior?

The goal with this ticket is to add the following argument to both aql.dataframe and aql.load_file (snowflake-only), removing the previous identifiers_as_lower parameter:

columns_names_capitalization=["upper", "lower", "original"]

### Checklist
- [X] Replace the aql.dataframe argument identifiers_as_lower by columns_names_capitalization
- [X] Add support for columns_names_capitalization when using load_file to Snowflake
- [X] Have tests covering these scenarios
- [ ] Update release notes
