### PR TITLE
Fix DistutilsOptionError #570

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
     env:
       MYPY_FORCE_COLOR: 1
       TERM: xterm-color
+      SETUPTOOLS_USE_DISTUTILS: stdlib
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
@@ -124,6 +125,7 @@ jobs:
           name: coverage${{ matrix.group }}
           path: .coverage
     env:
+      SETUPTOOLS_USE_DISTUTILS: stdlib
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
       POSTGRES_HOST: postgres


### PR DESCRIPTION
Co-authored-with: @uranusjr
Fix: #570

Aims to solve this issue in the CI:
```
File "/home/runner/work/astro-sdk/astro-sdk/.nox/type_check-3-8/lib/python3.8/site-packages/setuptools/config/pyprojecttoml.py", line 301, in _ensure_previously_set
          raise OptionError(msg)
      distutils.errors.DistutilsOptionError: No configuration found for dynamic 'description'.
      Some dynamic fields need to be specified via `tool.setuptools.dynamic`
      others must be specified via the equivalent attribute in `setup.py`.
      [end of output]
```