### PR TITLE
Example Dynamic Map Task with Astro-SDK

### DIFF
--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from pandas import DataFrame
 
 from airflow import DAG
 from airflow.decorators import task
+from pandas import DataFrame
 from astro import sql as aql
 from astro.sql import Table
 from astro.sql.table import Metadata

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -15,20 +15,20 @@ def summarize_campaign(capaign_id: str):
 with DAG(
     dag_id="example_dynamic_map_task",
     schedule_interval=None,
-    start_date=datetime(2021, 1, 1),
+    start_date=datetime(2022, 1, 1),
     catchup=False,
 ) as dag:
-    input_table_2 = Table(
-        name="dummy_table",
+    bq_table = Table(
+        name="active_campaigns",
         metadata=Metadata(
-            schema="pankaj_upsert_dataset",
+            schema="dag_authoring",
         ),
         conn_id="google_cloud_default",
     )
 
-    @aql.run_raw_sql(conn_id="google_cloud_default")
+    @aql.transform()
     def get_campaigns(table: Table):
-        return """select * from {{table}}"""
+        return """select campaign_id from {{table}}"""
 
 
-    summarize_campaign.expand(capaign_id=get_campaigns(table=input_table_2))
+    summarize_campaign.expand(capaign_id=get_campaigns(table=bq_table))

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pandas import DataFrame
 
 from airflow import DAG
 from airflow.decorators import task
@@ -10,6 +11,14 @@ from astro.sql.table import Metadata
 @task
 def summarize_campaign(capaign_id: str):
     print(capaign_id)
+
+
+@aql.dataframe(identifiers_as_lower=False)
+def my_df_func(input_df: DataFrame):
+    res = []
+    for row in input_df.iterrows():
+        res.append(row[0])
+    return res
 
 
 with DAG(
@@ -31,4 +40,4 @@ with DAG(
         return """select campaign_id from {{table}}"""
 
 
-    summarize_campaign.expand(capaign_id=get_campaigns(table=bq_table))
+    summarize_campaign.expand(capaign_id=my_df_func(get_campaigns(table=bq_table)))

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -1,3 +1,11 @@
+"""
+This Example DAG:
+- Pull CSV from S3 and load in bigquery table
+- Run select query on bigquery table
+- Expand on the returned rows i.e if bigquery table contain n rows then
+    n copy of ``summarize_campaign`` task will be created dynamically
+    using dynamic task mapping
+"""
 import os
 from datetime import datetime
 
@@ -10,11 +18,8 @@ from astro.sql import Table
 from astro.sql.table import Metadata
 
 ASTRO_BIGQUERY_DATASET = os.getenv("ASTRO_BIGQUERY_DATASET", "dag_authoring")
-ASTRO_GCP_LOCATION = os.getenv("ASTRO_GCP_LOCATION", "us")
 ASTRO_GCP_CONN_ID = os.getenv("ASTRO_GCP_CONN_ID", "google_cloud_default")
-ASTRO_BIGQUERY_SCHEMA = os.getenv("ASTRO_BIGQUERY_SCHEMA", "dag_authoring")
-ASTRO_BIGQUERY_TABLE = os.getenv("ASTRO_BIGQUERY_TABLE", "campaigns")
-s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
+ASTRO_S3_BUCKET = os.getenv("S3_BUCKET", "s3://tmp9")
 
 
 @task
@@ -38,7 +43,7 @@ with DAG(
         return """select id from {{table}}"""
 
     bq_table = aql.load_file(
-        input_file=File(path=f"{s3_bucket}/ads.csv"),
+        input_file=File(path=f"{ASTRO_S3_BUCKET}/ads.csv"),
         output_table=Table(
             metadata=Metadata(
                 schema=ASTRO_BIGQUERY_DATASET,

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -3,34 +3,17 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.decorators import task
-from airflow.providers.google.cloud.operators.bigquery import (
-    BigQueryCreateEmptyDatasetOperator,
-    BigQueryCreateEmptyTableOperator,
-    BigQueryDeleteDatasetOperator,
-    BigQueryInsertJobOperator,
-)
-
 from astro import sql as aql
 from astro.sql import Table
 from astro.sql.table import Metadata
+from astro.files import File
 
 ASTRO_BIGQUERY_DATASET = os.getenv("ASTRO_BIGQUERY_DATASET", "dag_authoring")
 ASTRO_GCP_LOCATION = os.getenv("ASTRO_GCP_LOCATION", "us")
 ASTRO_GCP_CONN_ID = os.getenv("ASTRO_GCP_CONN_ID", "google_cloud_default")
 ASTRO_BIGQUERY_SCHEMA = os.getenv("ASTRO_BIGQUERY_SCHEMA", "dag_authoring")
 ASTRO_BIGQUERY_TABLE = os.getenv("ASTRO_BIGQUERY_TABLE", "campaigns")
-
-ASTRO_BIGQUERY_SCHEMA_FIELDS = [
-    {"name": "campaign_id", "type": "INTEGER", "mode": "REQUIRED"},
-    {"name": "name", "type": "STRING", "mode": "NULLABLE"},
-    {"name": "ds", "type": "STRING", "mode": "NULLABLE"},
-]
-INSERT_DATE = datetime.now().strftime("%Y-%m-%d")
-INSERT_ROWS_QUERY = (
-    f"INSERT {ASTRO_BIGQUERY_SCHEMA}.{ASTRO_BIGQUERY_TABLE} VALUES "
-    f"(1, 'astro-release', '{INSERT_DATE}'), "
-    f"(2, 'astro-demo', '{INSERT_DATE}');"
-)
+s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 
 
 @task
@@ -39,64 +22,31 @@ def summarize_campaign(capaign_id: str):
 
 
 def handle_result(result):
-    print("result = ", result)
     return result.fetchall()
 
 
 with DAG(
-    dag_id="example_dynamic_map_task",
-    schedule_interval=None,
-    start_date=datetime(2022, 1, 1),
-    catchup=False,
+        dag_id="example_dynamic_map_task",
+        schedule_interval=None,
+        start_date=datetime(2022, 1, 1),
+        catchup=False,
 ) as dag:
-    create_dataset = BigQueryCreateEmptyDatasetOperator(
-        task_id="create_dataset",
-        dataset_id=ASTRO_BIGQUERY_DATASET,
-        location=ASTRO_GCP_LOCATION,
-        gcp_conn_id=ASTRO_GCP_CONN_ID,
-    )
-
-    create_table = BigQueryCreateEmptyTableOperator(
-        task_id="create_table",
-        dataset_id=ASTRO_BIGQUERY_DATASET,
-        table_id=ASTRO_BIGQUERY_TABLE,
-        schema_fields=ASTRO_BIGQUERY_SCHEMA_FIELDS,
-        location=ASTRO_GCP_LOCATION,
-        gcp_conn_id=ASTRO_GCP_CONN_ID,
-    )
-
-    insert_query_job = BigQueryInsertJobOperator(
-        task_id="insert_query_job",
-        configuration={
-            "query": {
-                "query": INSERT_ROWS_QUERY,
-                "useLegacySql": False,
-            }
-        },
-        location=ASTRO_GCP_LOCATION,
-        gcp_conn_id=ASTRO_GCP_CONN_ID,
-    )
-
     bq_table = Table(
-        name=ASTRO_BIGQUERY_TABLE,
         metadata=Metadata(
             schema=ASTRO_BIGQUERY_DATASET,
         ),
         conn_id=ASTRO_GCP_CONN_ID,
     )
 
+    my_homes_table = aql.load_file(
+        input_file=File(path=f"{s3_bucket}/ads.csv"),
+        output_table=bq_table,
+    )
+
     @aql.run_raw_sql(handler=handle_result)
     def get_campaigns(table: Table):
         return """select campaign_id from {{table}}"""
 
-    delete_dataset = BigQueryDeleteDatasetOperator(
-        task_id="delete_dataset",
-        dataset_id=ASTRO_BIGQUERY_DATASET,
-        delete_contents=True,
-        gcp_conn_id=ASTRO_GCP_CONN_ID,
-        trigger_rule="all_done",
-    )
-
     t1 = get_campaigns(bq_table)
     summarize_campaign.expand(capaign_id=t1)
-    create_dataset >> create_table >> insert_query_job >> t1 >> delete_dataset
+    aql.cleanup()

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.decorators import task
+from astro import sql as aql
+from astro.sql import Table
+from astro.sql.table import Metadata
+
+
+@task
+def summarize_campaign(capaign_id: str):
+    print(capaign_id)
+
+
+with DAG(
+    dag_id="example_dynamic_map_task",
+    schedule_interval=None,
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+) as dag:
+    input_table_2 = Table(
+        name="dummy_table",
+        metadata=Metadata(
+            schema="pankaj_upsert_dataset",
+        ),
+        conn_id="google_cloud_default",
+    )
+
+    @aql.run_raw_sql(conn_id="google_cloud_default")
+    def get_campaigns(table: Table):
+        return """select * from {{table}}"""
+
+
+    summarize_campaign.expand(capaign_id=get_campaigns(table=input_table_2))

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -1,19 +1,45 @@
+import os
 from datetime import datetime
 
 from airflow import DAG
 from airflow.decorators import task
+from airflow.providers.google.cloud.operators.bigquery import (
+    BigQueryCreateEmptyDatasetOperator,
+    BigQueryCreateEmptyTableOperator,
+    BigQueryDeleteDatasetOperator,
+    BigQueryInsertJobOperator,
+)
 
 from astro import sql as aql
 from astro.sql import Table
 from astro.sql.table import Metadata
 
+ASTRO_BIGQUERY_DATASET = os.getenv("ASTRO_BIGQUERY_DATASET", "dag_authoring")
+ASTRO_GCP_LOCATION = os.getenv("ASTRO_GCP_LOCATION", "us")
+ASTRO_GCP_CONN_ID = os.getenv("ASTRO_GCP_CONN_ID", "google_cloud_default")
+ASTRO_BIGQUERY_SCHEMA = os.getenv("ASTRO_BIGQUERY_SCHEMA", "dag_authoring")
+ASTRO_BIGQUERY_TABLE = os.getenv("ASTRO_BIGQUERY_TABLE", "campaigns")
+
+ASTRO_BIGQUERY_SCHEMA_FIELDS = [
+    {"name": "campaign_id", "type": "INTEGER", "mode": "REQUIRED"},
+    {"name": "name", "type": "STRING", "mode": "NULLABLE"},
+    {"name": "ds", "type": "STRING", "mode": "NULLABLE"},
+]
+INSERT_DATE = datetime.now().strftime("%Y-%m-%d")
+INSERT_ROWS_QUERY = (
+    f"INSERT {ASTRO_BIGQUERY_SCHEMA}.{ASTRO_BIGQUERY_TABLE} VALUES "
+    f"(1, 'astro-release', '{INSERT_DATE}'), "
+    f"(2, 'astro-demo', '{INSERT_DATE}');"
+)
+
 
 @task
-def summarize_campaign(capaign_id):
+def summarize_campaign(capaign_id: str):
     print(capaign_id)
 
 
 def handle_result(result):
+    print("result = ", result)
     return result.fetchall()
 
 
@@ -23,16 +49,54 @@ with DAG(
     start_date=datetime(2022, 1, 1),
     catchup=False,
 ) as dag:
+    create_dataset = BigQueryCreateEmptyDatasetOperator(
+        task_id="create_dataset",
+        dataset_id=ASTRO_BIGQUERY_DATASET,
+        location=ASTRO_GCP_LOCATION,
+        gcp_conn_id=ASTRO_GCP_CONN_ID,
+    )
+
+    create_table = BigQueryCreateEmptyTableOperator(
+        task_id="create_table",
+        dataset_id=ASTRO_BIGQUERY_DATASET,
+        table_id=ASTRO_BIGQUERY_TABLE,
+        schema_fields=ASTRO_BIGQUERY_SCHEMA_FIELDS,
+        location=ASTRO_GCP_LOCATION,
+        gcp_conn_id=ASTRO_GCP_CONN_ID,
+    )
+
+    insert_query_job = BigQueryInsertJobOperator(
+        task_id="insert_query_job",
+        configuration={
+            "query": {
+                "query": INSERT_ROWS_QUERY,
+                "useLegacySql": False,
+            }
+        },
+        location=ASTRO_GCP_LOCATION,
+        gcp_conn_id=ASTRO_GCP_CONN_ID,
+    )
+
     bq_table = Table(
-        name="active_campaigns",
+        name=ASTRO_BIGQUERY_TABLE,
         metadata=Metadata(
-            schema="dag_authoring",
+            schema=ASTRO_BIGQUERY_DATASET,
         ),
-        conn_id="google_cloud_default",
+        conn_id=ASTRO_GCP_CONN_ID,
     )
 
     @aql.run_raw_sql(handler=handle_result)
     def get_campaigns(table: Table):
         return """select campaign_id from {{table}}"""
 
-    summarize_campaign.expand(capaign_id=get_campaigns(table=bq_table))
+    delete_dataset = BigQueryDeleteDatasetOperator(
+        task_id="delete_dataset",
+        dataset_id=ASTRO_BIGQUERY_DATASET,
+        delete_contents=True,
+        gcp_conn_id=ASTRO_GCP_CONN_ID,
+        trigger_rule="all_done",
+    )
+
+    t1 = get_campaigns(bq_table)
+    summarize_campaign.expand(capaign_id=t1)
+    create_dataset >> create_table >> insert_query_job >> t1 >> delete_dataset

--- a/example_dags/example_bigquery_dynamic_map_task.py
+++ b/example_dags/example_bigquery_dynamic_map_task.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from airflow import DAG
 from airflow.decorators import task
 from pandas import DataFrame
+
 from astro import sql as aql
 from astro.sql import Table
 from astro.sql.table import Metadata
@@ -38,6 +39,5 @@ with DAG(
     @aql.transform()
     def get_campaigns(table: Table):
         return """select campaign_id from {{table}}"""
-
 
     summarize_campaign.expand(capaign_id=my_df_func(get_campaigns(table=bq_table)))

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -31,6 +31,7 @@ def session():
         "example_google_bigquery_gcs_load_and_save",
         "example_snowflake_partial_table_with_append",
         "example_sqlite_load_transform",
+        "example_dynamic_map_task",
     ],
 )
 def test_example_dag(session, dag_id):


### PR DESCRIPTION
# Description
Add Example DAG for Dynamic Map Task with Astro-SDK. 
DAG does
- load data from s3 to bigquery table
- get_campaigns task execute SQL query and get a Table object 
-  expanding summarize_campaign task so if the bigquery table has n row then n copy of summarize_campaign will be created 
- clean table

closes: #377 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->



<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:


-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->


## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
