### PR TITLE
Change catching ValueError and AttributeError to DatabaseCustomError

### DIFF
--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -24,6 +24,15 @@ from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import Metadata, Table
 
 
+class DatabaseCustomError(ValueError, AttributeError):
+    """
+    Inappropriate argument value (of correct type) or attribute
+    not found while running query. while running query
+    """
+
+    pass
+
+
 class BaseDatabase(ABC):
     """
     Base class to represent all the Database interactions.
@@ -48,7 +57,7 @@ class BaseDatabase(ABC):
     # illegal_column_name_chars[0] will be replaced by value in illegal_column_name_chars_replacement[0]
     illegal_column_name_chars: List[str] = []
     illegal_column_name_chars_replacement: List[str] = []
-    NATIVE_LOAD_EXCEPTIONS: Any = (ValueError, AttributeError)
+    NATIVE_LOAD_EXCEPTIONS: Any = DatabaseCustomError
 
     def __init__(self, conn_id: str):
         self.conn_id = conn_id

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -1,4 +1,5 @@
 """Google BigQuery table implementation."""
+import logging
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -332,10 +333,11 @@ class BigqueryDatabase(BaseDatabase):
         """
         try:
             return str(self.hook.project_id)
-        except AttributeError:
+        except AttributeError as exe:
+            logging.warning(exe)
             raise DatabaseCustomError(
                 f"conn_id {target_table.conn_id} has no project id"
-            )
+            ) from exe
 
     def load_local_file_to_table(
         self,

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -31,7 +31,7 @@ from astro.constants import (
     LoadExistStrategy,
     MergeConflictStrategy,
 )
-from astro.databases.base import BaseDatabase
+from astro.databases.base import BaseDatabase, DatabaseCustomError
 from astro.files import File
 from astro.sql.table import Metadata, Table
 
@@ -159,8 +159,7 @@ class SnowflakeDatabase(BaseDatabase):
     """
 
     NATIVE_LOAD_EXCEPTIONS: Any = (
-        ValueError,
-        AttributeError,
+        DatabaseCustomError,
         ProgrammingError,
         DatabaseError,
         OperationalError,
@@ -235,7 +234,7 @@ class SnowflakeDatabase(BaseDatabase):
             auth = f"storage_integration = {storage_integration};"
         else:
             if file.location.location_type == FileLocation.GS:
-                raise ValueError(
+                raise DatabaseCustomError(
                     "In order to create an stage for GCS, `storage_integration` is required."
                 )
             elif file.location.location_type == FileLocation.S3:
@@ -243,7 +242,7 @@ class SnowflakeDatabase(BaseDatabase):
                 if aws.access_key and aws.secret_key:
                     auth = f"credentials=(aws_key_id='{aws.access_key}' aws_secret_key='{aws.secret_key}');"
                 else:
-                    raise ValueError(
+                    raise DatabaseCustomError(
                         "In order to create an stage for S3, one of the following is required: "
                         "* `storage_integration`"
                         "* AWS_KEY_ID and SECRET_KEY_ID"
@@ -419,7 +418,11 @@ class SnowflakeDatabase(BaseDatabase):
         sql_statement = (
             f"COPY INTO {table_name} FROM @{stage.qualified_name}/{file_path}"
         )
-        self.hook.run(sql_statement)
+        try:
+            self.hook.run(sql_statement)
+        except (ValueError, AttributeError) as exe:
+            logging.warning(exe)
+            raise DatabaseCustomError
         self.drop_stage(stage)
 
     def load_pandas_dataframe_to_table(
@@ -591,7 +594,7 @@ class SnowflakeDatabase(BaseDatabase):
         values_to_check.extend(target_cols)
         for v in values_to_check:
             if not is_valid_snow_identifier(v):
-                raise ValueError(
+                raise DatabaseCustomError(
                     f"The identifier {v} is invalid. Please check to prevent SQL injection"
                 )
         if if_conflicts == "update":

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -422,7 +422,7 @@ class SnowflakeDatabase(BaseDatabase):
             self.hook.run(sql_statement)
         except (ValueError, AttributeError) as exe:
             logging.warning(exe)
-            raise DatabaseCustomError
+            raise DatabaseCustomError from exe
         self.drop_stage(stage)
 
     def load_pandas_dataframe_to_table(

--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -15,6 +15,7 @@ from google.cloud.bigquery_datatransfer_v1.types import (
 
 from astro.constants import Database
 from astro.databases import create_database
+from astro.databases.base import DatabaseCustomError
 from astro.databases.google.bigquery import BigqueryDatabase, S3ToBigqueryDataTransfer
 from astro.exceptions import NonExistentTableException
 from astro.files import File
@@ -243,7 +244,7 @@ def test_load_file_to_table_natively_for_fallback(
     mock_load_file, database_table_fixture
 ):
     """Test loading on files to bigquery natively for fallback."""
-    mock_load_file.side_effect = AttributeError
+    mock_load_file.side_effect = DatabaseCustomError
     database, target_table = database_table_fixture
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
     response = database.load_file_to_table_natively_with_fallback(

--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -253,6 +253,36 @@ def test_load_file_to_table_natively_for_fallback(
     assert response is None
 
 
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.BIGQUERY,
+            "table": Table(metadata=Metadata(schema=SCHEMA)),
+        },
+    ],
+    indirect=True,
+    ids=["bigquery"],
+)
+def test_load_file_to_table_natively_for_fallback_wrong_file_location(
+    database_table_fixture,
+):
+    """
+    Test loading on files to bigquery natively for fallback without fallback
+    gracefully for wrong file location.
+    """
+    database, target_table = database_table_fixture
+    filepath = "https://www.data.com/data/sample.json"
+
+    response = database.load_file_to_table_natively_with_fallback(
+        source_file=File(filepath),
+        target_table=target_table,
+        enable_native_fallback=False,
+    )
+    assert response is None
+
+
 @pytest.mark.parametrize(
     "database_table_fixture",
     [

--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -283,6 +283,39 @@ def test_load_file_to_table_natively_for_fallback_wrong_file_location(
     assert response is None
 
 
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.BIGQUERY,
+            "table": Table(metadata=Metadata(schema=SCHEMA)),
+        },
+    ],
+    indirect=True,
+    ids=["bigquery"],
+)
+@mock.patch("astro.databases.google.bigquery.BigqueryDatabase.hook")
+def test_get_project_id_raise_exception(
+    mock_hook,
+    database_table_fixture,
+):
+    """
+    Test loading on files to bigquery natively for fallback without fallback
+    gracefully for wrong file location.
+    """
+
+    class CustomAttibuteError:
+        def __str__(self):
+            raise AttributeError
+
+    mock_hook.project_id = CustomAttibuteError()
+    database, target_table = database_table_fixture
+
+    with pytest.raises(DatabaseCustomError):
+        database.get_project_id(target_table=target_table)
+
+
 @pytest.mark.parametrize(
     "database_table_fixture",
     [


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently in Snowflake load_file, ValueError and AttributeError are being catched at function level but it should be caught at the line and thrown that error.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #583 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Create class `DatabaseCustomError` to raise generic errors like ValueError and AttributeError 
- Raise the specific errors and change the tests.

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
