### PR TITLE
Fix makefile error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SYSTEM_PYTHON := python3.9
 
 # Set default virtualenv path, if not defined
 ifndef VIRTUALENV_PATH
-mkdir -p ~/.virtualenvs/
+$(shell mkdir -p ~/.virtualenvs/)
 override VIRTUALENV_PATH = ~/.virtualenvs/$(PROJECT_NAME)
 endif
 


### PR DESCRIPTION
# Description
On my machine, I'm getting the below error with the existing makefile
```
(dev) (base) pankaj@Pankajs-MacBook-Pro astro-sdk % make help
Makefile:9: *** missing separator.  Stop.
```