### PR TITLE
Document the cleanup operator

### DIFF
--- a/docs/aep/README.md
+++ b/docs/aep/README.md
@@ -4,7 +4,7 @@ The purpose of an Astro Enhancement Proposal (AEP) is to introduce any significa
 
 This is required in order to balance the need to support new features, use cases, while avoiding accidentally introducing half thought-out interfaces that cause unnecessary problems when changed.
 
-This documentation is heavily based on the [Airflow Improvement Proposals](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals).
+This documentation is heavily based on the [Airflow Improvement Proposals](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals).
 
 
 ## What is considered a significant change that needs an API?

--- a/docs/astro/sql/operators/cleanup.rst
+++ b/docs/astro/sql/operators/cleanup.rst
@@ -12,3 +12,5 @@ The ``cleanup`` operator is used to clean temporary tables(:ref:`table`). It mon
    :language: python
    :start-after: [START cleanup_example]
    :end-before: [END cleanup_example]
+
+Users can also specify the temporary tables they want to delete by passing a list of tables in the parameter ``tables_to_cleanup``. If non temporary tables are passed they won't be deleted.

--- a/docs/astro/sql/operators/cleanup.rst
+++ b/docs/astro/sql/operators/cleanup.rst
@@ -4,7 +4,7 @@ cleanup operator
 
 .. _cleanup_operator:
 
-When to Use cleanup operator
+When to use the ``cleanup`` operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Cleanup operator is used to clean temporary tables(:ref:`table`) created. It monitors the status of all the other tasks and execute at the end to clear all the temporary tables(:ref:`table`) created in a dag run. It is recommended to add ``cleanup`` operator in every DAG that uses the Astro SDK.
 

--- a/docs/astro/sql/operators/cleanup.rst
+++ b/docs/astro/sql/operators/cleanup.rst
@@ -4,7 +4,7 @@ cleanup operator
 
 When to Use cleanup operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Cleanup operator is used to clean :ref:`temp_table` created. It monitors the status of all the other tasks and execute at the end to clear all the :ref:`temp_table` created in a dag run. It is recommended to add cleanup operator in every DAG that uses AstroSDK.
+Cleanup operator is used to clean :ref:`temp_table` created. It monitors the status of all the other tasks and execute at the end to clear all the :ref:`temp_table` created in a dag run. It is recommended to add ``cleanup`` operator in every DAG that uses the Astro SDK.
 
 .. literalinclude:: ../../../../example_dags/example_amazon_s3_postgres.py
    :language: python

--- a/docs/astro/sql/operators/cleanup.rst
+++ b/docs/astro/sql/operators/cleanup.rst
@@ -2,9 +2,11 @@
 cleanup operator
 ======================================
 
+.. _cleanup_operator:
+
 When to Use cleanup operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Cleanup operator is used to clean :ref:`temp_table` created. It monitors the status of all the other tasks and execute at the end to clear all the :ref:`temp_table` created in a dag run. It is recommended to add ``cleanup`` operator in every DAG that uses the Astro SDK.
+Cleanup operator is used to clean temporary tables(:ref:`table`) created. It monitors the status of all the other tasks and execute at the end to clear all the temporary tables(:ref:`table`) created in a dag run. It is recommended to add ``cleanup`` operator in every DAG that uses the Astro SDK.
 
 .. literalinclude:: ../../../../example_dags/example_amazon_s3_postgres.py
    :language: python

--- a/docs/astro/sql/operators/cleanup.rst
+++ b/docs/astro/sql/operators/cleanup.rst
@@ -1,0 +1,12 @@
+======================================
+cleanup operator
+======================================
+
+When to Use cleanup operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cleanup operator is used to clean :ref:`temp_table` created. It monitors the status of all the other tasks and execute at the end to clear all the :ref:`temp_table` created in a dag run. It is recommended to add cleanup operator in every DAG that uses AstroSDK.
+
+.. literalinclude:: ../../../../example_dags/example_amazon_s3_postgres.py
+   :language: python
+   :start-after: [cleanup_example_start]
+   :end-before: [cleanup_example_end]

--- a/docs/astro/sql/operators/cleanup.rst
+++ b/docs/astro/sql/operators/cleanup.rst
@@ -10,5 +10,5 @@ Cleanup operator is used to clean temporary tables(:ref:`table`) created. It mon
 
 .. literalinclude:: ../../../../example_dags/example_amazon_s3_postgres.py
    :language: python
-   :start-after: [cleanup_example_start]
-   :end-before: [cleanup_example_end]
+   :start-after: [START cleanup_example]
+   :end-before: [END cleanup_example]

--- a/docs/astro/sql/operators/cleanup.rst
+++ b/docs/astro/sql/operators/cleanup.rst
@@ -6,7 +6,7 @@ cleanup operator
 
 When to use the ``cleanup`` operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Cleanup operator is used to clean temporary tables(:ref:`table`) created. It monitors the status of all the other tasks and execute at the end to clear all the temporary tables(:ref:`table`) created in a dag run. It is recommended to add ``cleanup`` operator in every DAG that uses the Astro SDK.
+The ``cleanup`` operator is used to clean temporary tables(:ref:`table`). It monitors the status of all the tasks within a DAG and deletes the created temporary tables(:ref:`table`) by the end of the DAG run. It is recommended to add ``cleanup`` operator in every DAG that uses the Astro SDK.
 
 .. literalinclude:: ../../../../example_dags/example_amazon_s3_postgres.py
    :language: python

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -17,8 +17,8 @@ There are two types of tables:
 
     .. literalinclude:: ../example_dags/example_amazon_s3_postgres_load_and_save.py
        :language: python
-       :start-after: [named_table_example_start]
-       :end-before: [named_table_example_end]
+       :start-after: [START named_table_example]
+       :end-before: [END named_table_example]
 
 #. **Temporary Tables**
 
@@ -31,5 +31,5 @@ There are two types of tables:
 
         .. literalinclude:: ../example_dags/example_amazon_s3_postgres.py
            :language: python
-           :start-after: [temp_table_example_start]
-           :end-before: [temp_table_example_end]
+           :start-after: [START temp_table_example]
+           :end-before: [END temp_table_example]

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,28 +1,35 @@
-============
+========
 Concepts
-============
+========
 
-.. _named_table:
+.. _table:
 
-Named Tables
-~~~~~~~~~~~~~
+Tables
+~~~~~~~
 
-These are tables that are of some importance to users and will we persist in a database even after a DAG run is finished. You can create these tables by passing in a ``name`` parameter while creating a ``astro.sql.table.Table`` object.
+Tables represent the location and, optionally, the column types of a SQL Database table. They are used in most Astro SDK tasks and decorators.
 
-.. literalinclude:: ../example_dags/example_amazon_s3_postgres_load_and_save.py
-   :language: python
-   :start-after: [named_table_example_start]
-   :end-before: [named_table_example_end]
+There are two types of tables:
 
+#. **Persistent Table**
 
-.. _temp_table:
+    These are tables that are of some importance to users and will we persist in a database even after a DAG run is finished and won't be deleted by :ref:`cleanup_operator`. Users can still drop them by using ``drop_table operator(to be replaced with ref)``. You can create these tables by passing in a ``name`` parameter while creating a ``astro.sql.table.Table`` object.
 
-Temporary Tables
-~~~~~~~~~~~~~~~~~~~
+    .. literalinclude:: ../example_dags/example_amazon_s3_postgres_load_and_save.py
+       :language: python
+       :start-after: [named_table_example_start]
+       :end-before: [named_table_example_end]
 
-These are the tables that only exist while a dag is running and will be deleted from the database post that. There is an assumption that these tables are not considered important to the user and only hold intermediate data. You can create these by not passing the ``name`` parameter while creating a ``astro.sql.table.Table`` object.
+#. **Temporary Tables**
 
-.. literalinclude:: ../example_dags/example_amazon_s3_postgres.py
-   :language: python
-   :start-after: [temp_table_example_start]
-   :end-before: [temp_table_example_end]
+    It is a common pattern to create intermediate tables during a workflow that don't need to be persisted afterwards. To accomplish this, users can use Temporary Tables in conjunction with the :ref:`cleanup_operator` task.
+
+    There are two approaches to create temporary tables:
+
+    #. Explicit: instantiate a ``astro.sql.table.Table`` using the argument  `temp=True`
+    #. Implicit: instantiate a ``astro.sql.table.Table`` without giving it a name, and without specifying the `temp` argument
+
+        .. literalinclude:: ../example_dags/example_amazon_s3_postgres.py
+           :language: python
+           :start-after: [temp_table_example_start]
+           :end-before: [temp_table_example_end]

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,0 +1,28 @@
+============
+Concepts
+============
+
+.. _named_table:
+
+Named Tables
+~~~~~~~~~~~~~
+
+These are tables that are of some importance to users and will we persist in a database even after a DAG run is finished. You can create these tables by passing in a ``name`` parameter while creating a ``astro.sql.table.Table`` object.
+
+.. literalinclude:: ../example_dags/example_amazon_s3_postgres_load_and_save.py
+   :language: python
+   :start-after: [named_table_example_start]
+   :end-before: [named_table_example_end]
+
+
+.. _temp_table:
+
+Temporary Tables
+~~~~~~~~~~~~~~~~~~~
+
+These are the tables that only exist while a dag is running and will be deleted from the database post that. There is an assumption that these tables are not considered important to the user and only hold intermediate data. You can create these by not passing the ``name`` parameter while creating a ``astro.sql.table.Table`` object.
+
+.. literalinclude:: ../example_dags/example_amazon_s3_postgres.py
+   :language: python
+   :start-after: [temp_table_example_start]
+   :end-before: [temp_table_example_end]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,19 @@ Welcome to astro-sdk's documentation!
 
    CHANGELOG.md
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Operators
+   :glob:
+
+   astro/sql/operators/*
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Concepts
+   :glob:
+
+   concepts.rst
 
 Indices and Tables
 ==================

--- a/example_dags/example_amazon_s3_postgres.py
+++ b/example_dags/example_amazon_s3_postgres.py
@@ -38,14 +38,14 @@ def my_df_func(input_df: DataFrame):
 with dag:
     my_homes_table = aql.load_file(
         input_file=File(path=f"{s3_bucket}/homes.csv"),
-        # [temp_table_example_start]
+        # [START temp_table_example]  skipcq: PY-W0069
         output_table=Table(
             conn_id="postgres_conn",
         ),
-        # [temp_table_example_end]
+        # [END temp_table_example]  skipcq: PY-W0069
     )
     sample_table = sample_create_table(my_homes_table)
     my_df_func(sample_table)
-    # [cleanup_example_start]
+    # [START cleanup_example]  skipcq: PY-W0069
     aql.cleanup()
-    # [cleanup_example_end]
+    # [END cleanup_example]  skipcq: PY-W0069

--- a/example_dags/example_amazon_s3_postgres.py
+++ b/example_dags/example_amazon_s3_postgres.py
@@ -38,10 +38,14 @@ def my_df_func(input_df: DataFrame):
 with dag:
     my_homes_table = aql.load_file(
         input_file=File(path=f"{s3_bucket}/homes.csv"),
+        # [temp_table_example_start]
         output_table=Table(
             conn_id="postgres_conn",
         ),
+        # [temp_table_example_end]
     )
     sample_table = sample_create_table(my_homes_table)
     my_df_func(sample_table)
+    # [cleanup_example_start]
     aql.cleanup()
+    # [cleanup_example_end]

--- a/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -25,7 +25,9 @@ s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 def example_amazon_s3_postgres_load_and_save():
     t1 = aql.load_file(
         input_file=File(path=f"{s3_bucket}/homes.csv"),
+        # [named_table_example_start]
         output_table=Table(name="expected_table_from_s3", conn_id="postgres_conn"),
+        # [named_table_example_end]
     )
 
     aql.export_file(

--- a/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -25,9 +25,9 @@ s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 def example_amazon_s3_postgres_load_and_save():
     t1 = aql.load_file(
         input_file=File(path=f"{s3_bucket}/homes.csv"),
-        # [named_table_example_start]
+        # [START named_table_example]  skipcq: PY-W0069
         output_table=Table(name="expected_table_from_s3", conn_id="postgres_conn"),
-        # [named_table_example_end]
+        # [END named_table_example]  skipcq: PY-W0069
     )
 
     aql.export_file(


### PR DESCRIPTION
# Description
## What is the current behavior?
In the past, we had a tutorial which illustrated how to use each of our operators/decorators:
https://github.com/astronomer/astro-sdk/blob/be6280df00ccff0d7a1c0dfb099b2065303dbe88/REFERENCE.md

closes: #594

## What is the new behavior?

Have a reference page per operator/decorator similar to
https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/operators/ecs.html#howto-operator-ecsoperator
In which we reference parts of an (automated tested) example DAG which illustrates the usage of that operator/decorator.

Many of these use cases already exist in our example DAGs - we should reference them.

cleanup
        single example

If no example DAGs or operators are illustrating the functionalities, we should create them.

## Does this introduce a breaking change?
Nope

**Acceptance Criteria**
* [X] cleanup
    - single example
- [ ] All checks and tests in the CI should pass
- [ ] Unit tests (90% code coverage or more, [once available](https://github.com/astronomer/astro-sdk/issues/191))
- [ ] Integration tests (if the feature relates to a new database or external service)
- [X] Example DAG
- [X] Improve the documentation (README, Sphinx, and any other relevant)