### PR TITLE
Document the drop table operator

### DIFF
--- a/docs/astro/sql/operators/drop.rst
+++ b/docs/astro/sql/operators/drop.rst
@@ -1,0 +1,14 @@
+======================================
+drop operator
+======================================
+
+.. _drop_operator:
+
+When to Use drop operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The drop operator is used to delete tables from the database if they exist. It can be used on both Temporary as well as Persistent Tables.
+
+.. literalinclude:: ../../../../example_dags/example_snowflake_partial_table_with_append.py
+   :language: python
+   :start-after: [START drop_table_example]
+   :end-before: [END drop_table_example]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,13 @@ Welcome to astro-sdk's documentation!
 
    CHANGELOG.md
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Operators
+   :glob:
+
+   astro/sql/operators/*
+
 
 Indices and Tables
 ==================

--- a/example_dags/example_snowflake_partial_table_with_append.py
+++ b/example_dags/example_snowflake_partial_table_with_append.py
@@ -136,9 +136,11 @@ def example_snowflake_partial_table_with_append():
     # We truncate this table only to avoid wasting Snowflake resources
     # Why? Between 2022-03-25 and 2022-04-11 it accumulated 301G (89 million rows) because
     # this example DAG used to append rows without deleting them
+    # [START drop_table_example]
     truncate_results = drop_table(
         table=Table(name="homes_reporting", conn_id=SNOWFLAKE_CONN_ID)
     )
+    # [END drop_table_example]
     truncate_results.set_upstream(record_results)
     cleanup()
 


### PR DESCRIPTION
# Description
## What is the current behavior?
In the past, we had a tutorial which illustrated how to use each of our operators/decorators:
https://github.com/astronomer/astro-sdk/blob/be6280df00ccff0d7a1c0dfb099b2065303dbe88/REFERENCE.md

closes: #588 

## What is the new behavior?
Have a reference page per operator/decorator similar to
https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/operators/ecs.html#howto-operator-ecsoperator

In which we reference parts of an (automated tested) example DAG which illustrates the usage of that operator/decorator.

Many of these use cases already exist in our example DAGs - we should reference them.

drop_table

    single example


## Does this introduce a breaking change?
Nope

### Checklist
- [X] Extended the README / documentation, if necessary
