### PR TITLE
Add schema settings on database level

### DIFF
--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -23,7 +23,7 @@ or by updating Airflow's configuration
    [astro_sdk]
    schema = "tmp"
 
-We can also configure schema on database level.
+We can also configure the default schema specific to the database type (example: specific to Snowflake, BigQuery, Postgres). If both the default and database-specific schemas are defined, the preference is given to the database-specific value.
 
 .. code:: python
 

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -1,0 +1,31 @@
+Configuration Reference
+=======================
+
+Configuring database default schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We can configure the default schema that will be used for all operation involving database.
+environment variable :
+
+.. code:: shell
+
+   AIRFLOW__ASTRO_SDK__SCHEMA="tmp"
+
+or by updating Airflow's configuration
+
+.. code:: shell
+
+   [astro_sdk]
+   schema = "tmp"
+
+We can also configure schema on database level.
+
+.. code:: python
+
+   AIRFLOW__ASTRO_SDK__POSTGRES_DEFAULT_SCHEMA = "tmp"
+
+or by updating Airflow's configuration
+
+.. code:: shell
+
+   [astro_sdk]
+   postgres_default_schema = "tmp"

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -1,7 +1,7 @@
 Configuration
 =============
 
-Configuring database default schema
+Configuring the database default schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 We can configure the default schema that will be used for all operation involving database.
 environment variable :

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -1,5 +1,5 @@
-Configuration Reference
-=======================
+Configuration
+=============
 
 Configuring database default schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -3,7 +3,13 @@ Configuration
 
 Configuring the database default schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-We can configure the default schema that will be used for all operation involving database.
+If users don't define a specific `Table` (metadata) `schema`, the Astro SDK will fall back to the global default schema configuration.
+
+There are two options to define the default schema:
+1. At a global level, for all databases
+2. At a database level, for each specific database
+
+If the user does not configure the database-specific configuration, the Astro SDK will use the global default schema (which has the value `tmp_astro` if undefined). Example:
 environment variable :
 
 .. code:: shell

--- a/docs/configurations.rst
+++ b/docs/configurations.rst
@@ -2,14 +2,14 @@ Configuration
 =============
 
 Configuring the database default schema
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If users don't define a specific `Table` (metadata) `schema`, the Astro SDK will fall back to the global default schema configuration.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If users don't define a specific ``Table`` (metadata) ``schema``, the Astro SDK will fall back to the global default schema configuration.
 
 There are two options to define the default schema:
 1. At a global level, for all databases
 2. At a database level, for each specific database
 
-If the user does not configure the database-specific configuration, the Astro SDK will use the global default schema (which has the value `tmp_astro` if undefined). Example:
+If the user does not configure the database-specific configuration, the Astro SDK will use the global default schema (which has the value ``tmp_astro`` if undefined). Example:
 environment variable :
 
 .. code:: shell

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ Welcome to astro-sdk's documentation!
 
 .. toctree::
    :maxdepth: 1
-   :caption: Configurations
+   :caption: Reference
    :glob:
 
    configurations.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,7 +49,7 @@ Welcome to astro-sdk's documentation!
    :glob:
 
    concepts.rst
-   
+
 .. toctree::
    :maxdepth: 1
    :caption: Reference

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,13 @@ Welcome to astro-sdk's documentation!
 
    CHANGELOG.md
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Configurations
+   :glob:
+
+   configurations.rst
+
 
 Indices and Tables
 ==================

--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -7,6 +7,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
+DEFAULT_SCHEMA = "tmp_astro"
 DEFAULT_CHUNK_SIZE = 1000000
 PYPI_PROJECT_NAME = "astro-sdk-python"
 

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -58,6 +58,7 @@ class BaseDatabase(ABC):
     illegal_column_name_chars: List[str] = []
     illegal_column_name_chars_replacement: List[str] = []
     NATIVE_LOAD_EXCEPTIONS: Any = DatabaseCustomError
+    DEFAULT_SCHEMA = SCHEMA
 
     def __init__(self, conn_id: str):
         self.conn_id = conn_id
@@ -170,7 +171,7 @@ class BaseDatabase(ABC):
         if table.metadata and table.metadata.is_empty() and self.default_metadata:
             table.metadata = self.default_metadata
         if not table.metadata.schema:
-            table.metadata.schema = SCHEMA
+            table.metadata.schema = self.DEFAULT_SCHEMA
         return table
 
     # ---------------------------------------------------------

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -38,7 +38,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
 from tenacity import retry, stop_after_attempt
 
-from astro import settings
 from astro.constants import (
     DEFAULT_CHUNK_SIZE,
     FileLocation,
@@ -48,6 +47,7 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase, DatabaseCustomError
 from astro.files import File
+from astro.settings import BIGQUERY_SCHEMA
 from astro.sql.table import Metadata, Table
 
 DEFAULT_CONN_ID = BigQueryHook.default_conn_name
@@ -65,6 +65,7 @@ class BigqueryDatabase(BaseDatabase):
     logic in other parts of our code-base.
     """
 
+    DEFAULT_SCHEMA = BIGQUERY_SCHEMA
     NATIVE_PATHS = {
         FileLocation.GS: "load_gs_file_to_table",
         FileLocation.S3: "load_s3_file_to_table",
@@ -116,7 +117,7 @@ class BigqueryDatabase(BaseDatabase):
 
         :return:
         """
-        return Metadata(schema=settings.SCHEMA, database=self.hook.project_id)
+        return Metadata(schema=self.DEFAULT_SCHEMA, database=self.hook.project_id)
 
     def schema_exists(self, schema: str) -> bool:
         """

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -10,7 +10,7 @@ from psycopg2 import sql as postgres_sql
 
 from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy, MergeConflictStrategy
 from astro.databases.base import BaseDatabase
-from astro.settings import SCHEMA
+from astro.settings import POSTGRES_SCHEMA
 from astro.sql.table import Metadata, Table
 
 DEFAULT_CONN_ID = PostgresHook.default_conn_name
@@ -22,6 +22,7 @@ class PostgresDatabase(BaseDatabase):
     logic in other parts of our code-base.
     """
 
+    DEFAULT_SCHEMA = POSTGRES_SCHEMA
     illegal_column_name_chars: List[str] = ["."]
     illegal_column_name_chars_replacement: List[str] = ["_"]
 
@@ -41,7 +42,7 @@ class PostgresDatabase(BaseDatabase):
     def default_metadata(self) -> Metadata:
         """Fill in default metadata values for table objects addressing postgres databases"""
         database = self.hook.get_connection(self.conn_id).schema
-        return Metadata(database=database, schema=SCHEMA)
+        return Metadata(database=database, schema=self.DEFAULT_SCHEMA)
 
     def schema_exists(self, schema) -> bool:
         """

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
-from settings import SNOWFLAKE_SCHEMA
 from snowflake.connector import pandas_tools
 from snowflake.connector.errors import (
     DatabaseError,
@@ -34,6 +33,7 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase, DatabaseCustomError
 from astro.files import File
+from astro.settings import SNOWFLAKE_SCHEMA
 from astro.sql.table import Metadata, Table
 
 DEFAULT_CONN_ID = SnowflakeHook.default_conn_name

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from settings import SNOWFLAKE_SCHEMA
 from snowflake.connector import pandas_tools
 from snowflake.connector.errors import (
     DatabaseError,
@@ -172,6 +173,7 @@ class SnowflakeDatabase(BaseDatabase):
         ForbiddenError,
         RequestTimeoutError,
     )
+    DEFAULT_SCHEMA = SNOWFLAKE_SCHEMA
 
     def __init__(self, conn_id: str = DEFAULT_CONN_ID):
         super().__init__(conn_id)

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -1,7 +1,11 @@
 from airflow.configuration import conf
+from constants import DEFAULT_SCHEMA
 
-DEFAULT_SCHEMA = "tmp_astro"
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
+POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_sql_schema", fallback=SCHEMA)
+BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_sql_schema", fallback=SCHEMA)
+SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_sql_schema", fallback=SCHEMA)
+
 
 ALLOW_UNSAFE_DF_STORAGE = conf.getboolean(
     "astro_sdk", "dataframe_allow_unsafe_storage", fallback=False

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -3,9 +3,9 @@ from airflow.configuration import conf
 from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
-POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_sql_schema", fallback=SCHEMA)
-BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_sql_schema", fallback=SCHEMA)
-SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_sql_schema", fallback=SCHEMA)
+POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback=SCHEMA)
+BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHEMA)
+SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)
 
 
 ALLOW_UNSAFE_DF_STORAGE = conf.getboolean(

--- a/src/astro/settings.py
+++ b/src/astro/settings.py
@@ -1,5 +1,6 @@
 from airflow.configuration import conf
-from constants import DEFAULT_SCHEMA
+
+from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
 POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_sql_schema", fallback=SCHEMA)


### PR DESCRIPTION
# Description
## What is the current behavior?
When a user is using Astro-SDK for multiple databases. We impose a requirement of having the same-named SCHEMA in all the databases. Which is unrealistic.

related: #304

## What is the new behavior?
Now we have defined config variables to define SCHEMA per-database level.

Users can either configure env var:
AIRFLOW_ASTRO_SDK__POSTGRES_SQL_SCHEMA
AIRFLOW_ASTRO_SDK__BIGQUERY_SQL_SCHEMA
AIRFLOW_ASTRO_SDK__SNOWFLAKE_SQL_SCHEMA
or define them in airflow's config.

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
