### PR TITLE
Unpin pandas upperbound dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.7"
 dependencies = [
     "apache-airflow>=2.0",
     "markupsafe>=1.1.1,<2.1.0",
-    "pandas>=1.3.4,<=1.3.5",
+    "pandas>=1.3.4",
     "pyarrow",
     "python-frontmatter",
     "smart-open",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.7"
 dependencies = [
     "apache-airflow>=2.0",
     "markupsafe>=1.1.1,<2.1.0",
-    "pandas>=1.3.4",
+    "pandas>=1.3.4,<2.0.0",  # Pinning it to <2.0.0 to avoid breaking changes
     "pyarrow",
     "python-frontmatter",
     "smart-open",


### PR DESCRIPTION
# Description
## What is the current behavior?
We have pinned Pandas library

[astro-sdk/pyproject.toml](https://github.com/astronomer/astro-sdk/blob/6b90c92029c7470f5e383345fcdaf77861c8cb94/pyproject.toml#L19)

Line 19 in [6b90c92](https://github.com/astronomer/astro-sdk/commit/6b90c92029c7470f5e383345fcdaf77861c8cb94)
 "pandas>=1.3.4,<=1.3.5", 

This was done in https://github.com/astronomer/astro-sdk/pull/130 but a lot of things have changed since. Let's investigate if this pin (upper bound) is still required.

Related Slack thread: https://astronomer.slack.com/archives/C03868KGF2Q/p1659546153698379?thread_ts=1659545419.511649&cid=C03868KGF2Q

closes: #604 

## What is the new behavior?
unpinned the upper bound of pandas dependency

## Does this introduce a breaking change?
Nope
