### PR TITLE
Make Markdown-link-check more resilient

### DIFF
--- a/.github/workflows/mlc_config.json
+++ b/.github/workflows/mlc_config.json
@@ -1,7 +1,15 @@
 {
+  "aliveStatusCodes": [
+    200,
+    206
+  ],
+  "fallbackRetryDelay": "30s",
   "ignorePatterns": [
     {
       "pattern": "^http://localhost:"
     }
-  ]
+  ],
+  "retryCount": 5,
+  "retryOn429": true,
+  "timeout": "20s"
 }


### PR DESCRIPTION
As shown in https://github.com/astronomer/astro-sdk/runs/7745673277?check_suite_focus=true#step:4:295 some links error out with 429 (too many requests).

This commit adds 5 retries on 429 status code and adds more resilient configs
