### PR TITLE
Remove markupsafe from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ license = {file = "LICENSE"}
 requires-python = ">=3.7"
 dependencies = [
     "apache-airflow>=2.0",
-    "markupsafe>=1.1.1,<2.1.0",
     "pandas>=1.3.4,<=1.3.5",
     "pyarrow",
     "python-frontmatter",


### PR DESCRIPTION
# Description
## What is the current behavior?
We might not need `markupsafe` package.

closes: #622 

## What is the new behavior?
remove it from pyprojects.py and try if our test cases pass without it.

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] All checks and tests in the CI should pass
