### PR TITLE
Added 'extend_existing' to Sqla Table object

### DIFF
--- a/docs/astro/sql/operators/drop.rst
+++ b/docs/astro/sql/operators/drop.rst
@@ -8,7 +8,7 @@ When to Use drop operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The drop operator is used to delete tables from the database if they exist. It can be used on both Temporary as well as Persistent Tables.
 
-.. literalinclude:: ../../../../example_dags/example_snowflake_partial_table_with_append.py
+.. literalinclude:: ../../../../example_dags/example_sqlite_load_transform.py
    :language: python
    :start-after: [START drop_table_example]
    :end-before: [END drop_table_example]

--- a/example_dags/example_sqlite_load_transform.py
+++ b/example_dags/example_sqlite_load_transform.py
@@ -1,16 +1,18 @@
+import time
 from datetime import datetime
 
 from airflow import DAG
 
 from astro import sql as aql
 from astro.files import File
+from astro.sql import drop_table
 from astro.sql.table import Table
 
 START_DATE = datetime(2000, 1, 1)
 
 
 @aql.transform()
-def top_five_animations(input_table: Table):
+def get_top_five_animations(input_table: Table):
     return """
         SELECT Title, Rating
         FROM {{input_table}}
@@ -19,6 +21,8 @@ def top_five_animations(input_table: Table):
         LIMIT 5;
     """
 
+
+imdb_movies_name = "imdb_movies" + str(int(time.time()))
 
 with DAG(
     "example_sqlite_load_transform",
@@ -32,14 +36,21 @@ with DAG(
             path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb.csv"
         ),
         task_id="load_csv",
-        output_table=Table(name="imdb_movies", conn_id="sqlite_default"),
+        output_table=Table(name=imdb_movies_name, conn_id="sqlite_default"),
     )
 
-    top_five_animations(
+    top_five_animations = get_top_five_animations(
         input_table=imdb_movies,
         output_table=Table(
             name="top_animation",
             conn_id="sqlite_default",
         ),
     )
+    # Note - Using persistent table just to showcase drop_table operator.
+    # [START drop_table_example]
+    truncate_results = drop_table(
+        table=Table(name=imdb_movies_name, conn_id="sqlite_default")
+    )
+    # [END drop_table_example]
+    truncate_results.set_upstream(top_five_animations)
     aql.cleanup()

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -477,7 +477,10 @@ class BaseDatabase(ABC):
         :param table: Astro Table to be converted to SQLAlchemy table instance
         """
         return SqlaTable(
-            table.name, table.sqlalchemy_metadata, autoload_with=self.sqlalchemy_engine
+            table.name,
+            table.sqlalchemy_metadata,
+            autoload_with=self.sqlalchemy_engine,
+            extend_existing=True,
         )
 
     # ---------------------------------------------------------


### PR DESCRIPTION
# Description
## What is the current behavior?
Quite often this test group fails to run in the CI:

nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group 1 --cov=src --cov-report=xml --cov-branch

With:

=========================== short test summary info ============================
FAILED tests/test_example_dags.py::test_example_dag[example_snowflake_partial_table_with_append]
==== 1 failed, 29 passed, 329 deselected, 22 warnings in 294.40s (0:04:54) =====

Even if there were no changes that affected this test/our code-base, for instance:
https://github.com/astronomer/astro-sdk/pull/480
https://github.com/astronomer/astro-sdk/runs/7231300739

closes: #516 


## What is the new behavior?
The issue was with SQLA's reflection cache which keeps track of the tables created and maintains all the tables in a map 
`schema_columns[self.normalize_name(table_name)]`. When this test was individually run there are no issues on local since SQLA cache is just initialized just for this test and because of which this was an intermittent issue CI. The fix is to introduce a parameter [extend_existing](https://docs.sqlalchemy.org/en/14/core/metadata.html?highlight=table#sqlalchemy.schema.Table.params.extend_existing) which basically ensures the cache is not used.

Ran test multiple time to ensure this is working:
https://github.com/astronomer/astro-sdk/actions/runs/2832783413

## Does this introduce a breaking change?
Nope