### PR TITLE
Transform doc

### DIFF
--- a/docs/astro/sql/operators/transform.rst
+++ b/docs/astro/sql/operators/transform.rst
@@ -1,0 +1,25 @@
+======================================
+transform operator
+======================================
+
+.. _transform_operator:
+
+When to use the ``transform`` operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The transform function of the SQL decorator is the ``T`` of the ELT system. Each step of the transform pipeline creates a new table from the ``SELECT`` statement and enables tasks to pass those tables as if they were native Python objects.
+
+Example 1:
+    The following example applies a SQL ``SELECT`` statement to a ``imdb_movies`` table and saves the result to a ``top_animation`` table.
+
+    .. literalinclude:: ../../../../example_dags/example_sqlite_load_transform.py
+       :language: python
+       :start-after: [START transform_example_1]
+       :end-before: [END transform_example_1]
+
+Example 2:
+    The following example DAG shows how we can quickly pass tables between tasks when completing a data transformation.
+
+    .. literalinclude:: ../../../../example_dags/example_amazon_s3_snowflake_transform.py
+       :language: python
+       :start-after: [START transform_example_2]
+       :end-before: [END transform_example_2]

--- a/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/example_dags/example_amazon_s3_snowflake_transform.py
@@ -12,17 +12,24 @@ from astro.files import File
 from astro.sql.table import Metadata, Table
 
 
+# [START transform_example_2]  skipcq: PY-W0069
 @aql.transform()
 def combine_data(center_1: Table, center_2: Table):
     return """SELECT * FROM {{center_1}}
     UNION SELECT * FROM {{center_2}}"""
 
 
+# [END transform_example_2]  skipcq: PY-W0069
+
+# [START transform_example_3]  skipcq: PY-W0069
 @aql.transform()
 def clean_data(input_table: Table):
     return """SELECT *
     FROM {{input_table}} WHERE type NOT LIKE 'Guinea Pig'
     """
+
+
+# [END transform_example_3]  skipcq: PY-W0069
 
 
 @aql.dataframe(columns_names_capitalization="original")

--- a/example_dags/example_sqlite_load_transform.py
+++ b/example_dags/example_sqlite_load_transform.py
@@ -9,6 +9,7 @@ from astro.sql.table import Table
 START_DATE = datetime(2000, 1, 1)
 
 
+# [START transform_example_1]  skipcq: PY-W0069
 @aql.transform()
 def top_five_animations(input_table: Table):
     return """
@@ -19,6 +20,8 @@ def top_five_animations(input_table: Table):
         LIMIT 5;
     """
 
+
+# [END transform_example_1]  skipcq: PY-W0069
 
 with DAG(
     "example_sqlite_load_transform",


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
In the past, we had a tutorial which illustrated how to use each of our operators/decorators:
https://github.com/astronomer/astro-sdk/blob/be6280df00ccff0d7a1c0dfb099b2065303dbe88/REFERENCE.md

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #587 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Have a reference page per operator/decorator similar to
https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/operators/ecs.html#howto-operator-ecsoperator

In which we reference parts of an (automated tested) example DAG which illustrates the usage of that operator/decorator.

Many of these use cases already exist in our example DAGs - we should reference them.


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
