### PR TITLE
Add document for merge operator

### DIFF
--- a/docs/astro/sql/operators/append.rst
+++ b/docs/astro/sql/operators/append.rst
@@ -1,8 +1,8 @@
+.. _append_operator:
+
 ======================================
 append operator
 ======================================
-
-.. _append_operator:
 
 When to use the ``append`` operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -40,4 +40,4 @@ When tables have different schema, we can map different column names by passing 
 
 Conflicts
 ~~~~~~~~~
-``append operator`` doesn't handle the conflicts that may arise while appending data. If you want to handle those scenarios, you can use ``merge operator``
+``append operator`` doesn't handle the conflicts that may arise while appending data. If you want to handle those scenarios, you can use :ref:`merge_operator`.

--- a/docs/astro/sql/operators/drop.rst
+++ b/docs/astro/sql/operators/drop.rst
@@ -8,7 +8,7 @@ When to Use drop operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The drop operator is used to delete tables from the database if they exist. It can be used on both Temporary as well as Persistent Tables.
 
-.. literalinclude:: ../../../../example_dags/example_snowflake_partial_table_with_append.py
+.. literalinclude:: ../../../../example_dags/example_sqlite_load_transform.py
    :language: python
    :start-after: [START drop_table_example]
    :end-before: [END drop_table_example]

--- a/docs/astro/sql/operators/load_file.rst
+++ b/docs/astro/sql/operators/load_file.rst
@@ -1,3 +1,5 @@
+.. _load_file:
+
 ======================================
 load_file operator
 ======================================
@@ -40,7 +42,7 @@ Parameters to use when loading a file to the database table
 
     Note - When we are using ``if_exists='replace'`` we are dropping the existing table and then creating a new table. Here we are not reusing the schema.
 
-#. **output_table** - We can specify the output table to be created by passing in this parameter, which is expected to be an instance of ``astro.sql.table.Table``. Users can specify the schema of tables by passing in the ``columns`` parameter of ``astro.sql.table.Table`` object, which is expected to be a list of the instance of ``sqlalchemy.Column``. If the user doesn't specify the schema, the schema is inferred using pandas.
+#. **output_table** - We can specify the output table to be created by passing in this parameter, which is expected to be an instance of ``astro.sql.table.Table``. Users can specify the schema of tables by passing in the ``columns`` parameter of ``astro.sql.table.Table`` object, which is expected to be a list of the instance of `sqlalchemy.Column <https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.Column>`_. . If the user doesn't specify the schema, the schema is inferred using pandas.
 
     .. literalinclude:: ../../../../example_dags/example_load_file.py
        :language: python

--- a/docs/astro/sql/operators/merge.rst
+++ b/docs/astro/sql/operators/merge.rst
@@ -12,7 +12,7 @@ Merge operator is used when you expect some conflicts while merging two tables d
 Prerequisite
 ------------
 
-Merge operator internally run different SQL queries based on the databases and some databases only allow you to run these queries if there are constraints on columns specified in parameter ``target_conflict_columns``. Below is the list of databases and their constraint requirement.
+Merge operator internally runs different SQL queries based on the databases and some databases only allow you to run these queries if there are constraints on columns specified in parameter ``target_conflict_columns``. Below is the list of databases and their constraint requirement.
 
 .. list-table::
    :widths: auto

--- a/docs/astro/sql/operators/merge.rst
+++ b/docs/astro/sql/operators/merge.rst
@@ -1,3 +1,5 @@
+.. _merge_operator:
+
 ======================================
 merge operator
 ======================================
@@ -5,24 +7,57 @@ merge operator
 When to use the ``merge`` operator
 ----------------------------------
 
-Merge operator is used when you expects some conflicts while merging two tables due to underline constraints. If you don't expect any conflicts you can use :ref:`append_operator`. There are two common cases when merging tables.
+Merge operator is used when you expect some conflicts while merging two tables due to underline constraints. If you don't expect any conflicts you can use :ref:`append_operator`. There are two common cases when merging tables.
 
-When tables have same schema
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If the tables have same schema, we have to specify the complete ``list`` or ``tuple`` of columns in ``columns`` parameters because AstroSDK also have to handle :ref:`merge_conflicts` and it cannot assume which columns can raise conflicts, unlike :ref:`append_operator`. User can also select subset of columns to be part of merge.
+Prerequisite
+------------
+
+Merge operator internally run different SQL queries based on the databases and some databases only allow you to run these queries if there are constraints on columns specified in parameter ``target_conflict_columns``. Below is the list of databases and their constraint requirement.
+
+.. list-table::
+   :widths: auto
+   :header-rows: 1
+
+   * - Database
+     - Constraint required
+   * - Bigquery
+     - No
+   * - Postgres
+     - Yes
+   * - Snowflake
+     - Yes
+   * - SQLite
+     - Yes
 
 
+Schema
+------
 
-When table have different schema
+When tables have the same schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If the tables have the same schema, we have to specify the complete ``list`` or ``tuple`` of columns in ``columns`` parameters because AstroSDK also has to handle :ref:`merge_conflicts` and it cannot assume which columns can raise conflicts, unlike :ref:`append_operator`. Users can also select a subset of columns to be part of the merge.
+
+.. literalinclude:: ../../../../example_dags/example_merge.py
+   :language: python
+   :start-after: [START merge_col_list_example]
+   :end-before: [END merge_col_list_example]
+
+When tables have different schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 If tables have different schema user is expected to pass a ``dict`` mapped from ``source_table`` columns to ``target_table`` columns.
 
-
+.. literalinclude:: ../../../../example_dags/example_merge.py
+   :language: python
+   :start-after: [START merge_col_dict_example]
+   :end-before: [END merge_col_dict_example]
 
 .. _merge_conflicts:
+
 Conflicts
-~~~~~~~~~
-Conflicts arises due to ``target_table`` having constraints on columns. For example we can have duplicate primary key in ``source_table`` and ``target_table``. Now there are three strategy to deal with this situation.
+---------
+Conflicts arise due to ``target_table`` having constraints on columns. For example, we can have duplicate primary keys in ``source_table`` and ``target_table``. Now there are three strategies to deal with this situation.
 
 #. **ignore**
 
@@ -51,7 +86,7 @@ Conflicts arises due to ``target_table`` having constraints on columns. For exam
          - 9
 
 
-    .. list-table:: post merge Target table
+    .. list-table:: post-merge Target table
        :widths: auto
        :header-rows: 1
 
@@ -91,7 +126,7 @@ Conflicts arises due to ``target_table`` having constraints on columns. For exam
          - 9
 
 
-    .. list-table:: post merge Target table
+    .. list-table:: post-merge Target table
        :widths: auto
        :header-rows: 1
 
@@ -105,4 +140,4 @@ Conflicts arises due to ``target_table`` having constraints on columns. For exam
          - 2
 
 #. **exception**
-    This option will simply raise an exception if there is any conflicts at the time of merging.
+    This option will simply raise an exception if there are any conflicts at the time of merging.

--- a/docs/astro/sql/operators/merge.rst
+++ b/docs/astro/sql/operators/merge.rst
@@ -1,0 +1,108 @@
+======================================
+merge operator
+======================================
+
+When to use the ``merge`` operator
+----------------------------------
+
+Merge operator is used when you expects some conflicts while merging two tables due to underline constraints. If you don't expect any conflicts you can use :ref:`append_operator`. There are two common cases when merging tables.
+
+When tables have same schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If the tables have same schema, we have to specify the complete ``list`` or ``tuple`` of columns in ``columns`` parameters because AstroSDK also have to handle :ref:`merge_conflicts` and it cannot assume which columns can raise conflicts, unlike :ref:`append_operator`. User can also select subset of columns to be part of merge.
+
+
+
+When table have different schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If tables have different schema user is expected to pass a ``dict`` mapped from ``source_table`` columns to ``target_table`` columns.
+
+
+
+.. _merge_conflicts:
+Conflicts
+~~~~~~~~~
+Conflicts arises due to ``target_table`` having constraints on columns. For example we can have duplicate primary key in ``source_table`` and ``target_table``. Now there are three strategy to deal with this situation.
+
+#. **ignore**
+
+    Assumption - There is a unique constraint on table col A and user has specified ``if_conflicts='ignore'`` and ``target_conflict_columns=['A']``.
+
+    .. list-table:: Target
+       :widths: auto
+       :header-rows: 1
+
+       * - A
+         - B
+       * - 1
+         - 2
+       * - 3
+         - 4
+
+    .. list-table:: Source
+       :widths: auto
+       :header-rows: 1
+
+       * - A
+         - B
+       * - 8
+         - 2
+       * - 3
+         - 9
+
+
+    .. list-table:: post merge Target table
+       :widths: auto
+       :header-rows: 1
+
+       * - A
+         - B
+       * - 1
+         - 2
+       * - 3
+         - 4
+       * - 8
+         - 2
+
+#. **update**
+
+    Assumption - There is a unique constraint on table col A and user has specified ``if_conflicts='update'`` and ``target_conflict_columns=['A']``.
+
+    .. list-table:: Target
+       :widths: auto
+       :header-rows: 1
+
+       * - A
+         - B
+       * - 1
+         - 2
+       * - 3
+         - 4
+
+    .. list-table:: Source
+       :widths: auto
+       :header-rows: 1
+
+       * - A
+         - B
+       * - 8
+         - 2
+       * - 3
+         - 9
+
+
+    .. list-table:: post merge Target table
+       :widths: auto
+       :header-rows: 1
+
+       * - A
+         - B
+       * - 1
+         - 2
+       * - 3
+         - 9
+       * - 8
+         - 2
+
+#. **exception**
+    This option will simply raise an exception if there is any conflicts at the time of merging.

--- a/docs/astro/sql/operators/merge.rst
+++ b/docs/astro/sql/operators/merge.rst
@@ -7,7 +7,7 @@ merge operator
 When to use the ``merge`` operator
 ----------------------------------
 
-Merge operator is used when you expect some conflicts while merging two tables due to underline constraints. If you don't expect any conflicts you can use :ref:`append_operator`. There are two common cases when merging tables.
+Unlike the :ref:`append_operator`, which expects data to be unique and conflict free, the Merge operator allows users to add data with conflict resolution techniques like `ignore` and `update`.
 
 Prerequisite
 ------------

--- a/docs/astro/sql/operators/merge.rst
+++ b/docs/astro/sql/operators/merge.rst
@@ -7,7 +7,7 @@ merge operator
 When to use the ``merge`` operator
 ----------------------------------
 
-Unlike the :ref:`append_operator`, which expects data to be unique and conflict free, the Merge operator allows users to add data with conflict resolution techniques like `ignore` and `update`.
+Unlike the :ref:`append_operator`, which expects data to be unique and conflict free, the Merge operator allows users to add data with conflict resolution techniques like ``ignore`` and ``update``.
 
 Prerequisite
 ------------

--- a/docs/astro/sql/operators/merge.rst
+++ b/docs/astro/sql/operators/merge.rst
@@ -29,9 +29,12 @@ Merge operator internally runs different SQL queries based on the databases and 
    * - SQLite
      - Yes
 
+Users can create and add constraints on table by passing ``columns`` parameter to :ref:`load_file`. Refer :ref:`custom_schema` section for details.
 
-Schema
-------
+.. literalinclude:: ../../../../example_dags/example_merge.py
+   :language: python
+   :start-after: [START merge_load_file_with_primary_key_example]
+   :end-before: [END merge_load_file_with_primary_key_example]
 
 When tables have the same schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -5,7 +5,7 @@ Concepts
 .. _table:
 
 Tables
-~~~~~~~
+------
 
 Tables represent the location and, optionally, the column types of a SQL Database table. They are used in most Astro SDK tasks and decorators.
 
@@ -38,7 +38,7 @@ There are two types of tables:
 
 
 How load_file Works
-~~~~~~~~~~~~~~~~~~~
+-------------------
 .. to edit figure below refer - https://lucid.app/lucidchart/d52867aa-62b4-4aa8-a6ff-7abd3ffc8ece/edit?viewport_loc=-200%2C-117%2C2597%2C1294%2C0_0&invitationId=inv_b313e94c-eda2-4ece-a801-396764d12b46#
 .. figure:: /images/defaultPath.png
 
@@ -54,7 +54,7 @@ This is the default way of loading data into a table. There are performance bott
 
 
 Improving bottlenecks by using native transfer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. to edit figure below refer - https://lucid.app/lucidchart/d52867aa-62b4-4aa8-a6ff-7abd3ffc8ece/edit?viewport_loc=-200%2C-117%2C2597%2C1294%2C0_0&invitationId=inv_b313e94c-eda2-4ece-a801-396764d12b46#
 .. figure:: /images/nativePath.png
 

--- a/example_dags/example_append.py
+++ b/example_dags/example_append.py
@@ -31,7 +31,7 @@ with dag:
         output_table=Table(conn_id="postgres_conn"),
     )
     load_append = aql.load_file(
-        input_file=File(path=DATA_DIR + "/homes2.csv"),
+        input_file=File(path=DATA_DIR + "homes2.csv"),
         output_table=Table(conn_id="postgres_conn"),
     )
     # [START append_example]

--- a/example_dags/example_merge.py
+++ b/example_dags/example_merge.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 from airflow.models import DAG
 from pandas import DataFrame
+from sqlalchemy import Column, types
 
 from astro import sql as aql
 from astro.files import File
@@ -37,18 +38,28 @@ def my_df_func(input_df: DataFrame):
 
 
 with dag:
+    # [START merge_load_file_with_primary_key_example]
     target_table_1 = aql.load_file(
         input_file=File(DATA_DIR + "sample.csv"),
         output_table=Table(
             conn_id="bigquery",
             metadata=Metadata(schema="first_table_schema"),
+            columns=[
+                Column(name="id", type_=types.Integer, primary_key=True),
+                Column(name="name", type_=types.String),
+            ],
         ),
     )
+    # [END merge_load_file_with_primary_key_example]
     target_table_2 = aql.load_file(
         input_file=File(DATA_DIR + "sample.csv"),
         output_table=Table(
             conn_id="bigquery",
             metadata=Metadata(schema="first_table_schema"),
+            columns=[
+                Column(name="id", type_=types.Integer, primary_key=True),
+                Column(name="name", type_=types.String),
+            ],
         ),
     )
     source_table = aql.load_file(

--- a/example_dags/example_merge.py
+++ b/example_dags/example_merge.py
@@ -1,0 +1,61 @@
+import pathlib
+from datetime import datetime, timedelta
+
+from airflow.models import DAG
+from pandas import DataFrame
+
+from astro import sql as aql
+from astro.files import File
+from astro.sql.table import Metadata, Table
+
+CWD = pathlib.Path(__file__).parent
+
+default_args = {
+    "owner": "airflow",
+    "retries": 1,
+    "retry_delay": 0,
+}
+
+dag = DAG(
+    dag_id="example_amazon_s3_postgres",
+    start_date=datetime(2019, 1, 1),
+    max_active_runs=3,
+    schedule_interval=timedelta(minutes=30),
+    default_args=default_args,
+)
+
+
+@aql.transform
+def sample_create_table(input_table: Table):
+    return "SELECT * FROM {{input_table}} LIMIT 10"
+
+
+@aql.dataframe(columns_names_capitalization="original")
+def my_df_func(input_df: DataFrame):
+    print(input_df)
+
+
+with dag:
+    target_table = aql.load_file(
+        input_file=File(str(pathlib.Path(CWD.parent.parent, "data/sample.csv"))),
+        output_table=Table(
+            conn_id="bigquery",
+            metadata=Metadata(schema="first_table_schema"),
+        ),
+    )
+    source_table = aql.load_file(
+        input_file=File(str(pathlib.Path(CWD.parent.parent, "data/sample_part2.csv"))),
+        output_table=Table(
+            conn_id="bigquery",
+            metadata=Metadata(schema="second_table_schema"),
+        ),
+    )
+    # [START merge_example]
+    aql.merge(
+        target_table=target_table,
+        source_table=source_table,
+        target_conflict_columns=["id"],
+        columns={"id": "id", "name": "name"},
+        if_conflicts="update",
+    )
+    # [END merge_example]

--- a/example_dags/example_sqlite_load_transform.py
+++ b/example_dags/example_sqlite_load_transform.py
@@ -1,16 +1,18 @@
+import time
 from datetime import datetime
 
 from airflow import DAG
 
 from astro import sql as aql
 from astro.files import File
+from astro.sql import drop_table
 from astro.sql.table import Table
 
 START_DATE = datetime(2000, 1, 1)
 
 
 @aql.transform()
-def top_five_animations(input_table: Table):
+def get_top_five_animations(input_table: Table):
     return """
         SELECT Title, Rating
         FROM {{input_table}}
@@ -19,6 +21,8 @@ def top_five_animations(input_table: Table):
         LIMIT 5;
     """
 
+
+imdb_movies_name = "imdb_movies" + str(int(time.time()))
 
 with DAG(
     "example_sqlite_load_transform",
@@ -32,14 +36,21 @@ with DAG(
             path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb.csv"
         ),
         task_id="load_csv",
-        output_table=Table(name="imdb_movies", conn_id="sqlite_default"),
+        output_table=Table(name=imdb_movies_name, conn_id="sqlite_default"),
     )
 
-    top_five_animations(
+    top_five_animations = get_top_five_animations(
         input_table=imdb_movies,
         output_table=Table(
             name="top_animation",
             conn_id="sqlite_default",
         ),
     )
+    # Note - Using persistent table just to showcase drop_table operator.
+    # [START drop_table_example]
+    truncate_results = drop_table(
+        table=Table(name=imdb_movies_name, conn_id="sqlite_default")
+    )
+    # [END drop_table_example]
+    truncate_results.set_upstream(top_five_animations)
     aql.cleanup()

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -477,7 +477,10 @@ class BaseDatabase(ABC):
         :param table: Astro Table to be converted to SQLAlchemy table instance
         """
         return SqlaTable(
-            table.name, table.sqlalchemy_metadata, autoload_with=self.sqlalchemy_engine
+            table.name,
+            table.sqlalchemy_metadata,
+            autoload_with=self.sqlalchemy_engine,
+            extend_existing=True,
         )
 
     # ---------------------------------------------------------

--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -244,8 +244,8 @@ def dataframe(
     conn_id: str = "",
     database: Optional[str] = None,
     schema: Optional[str] = None,
-    task_id: Optional[str] = None,
     columns_names_capitalization: ColumnCapitalization = "lower",
+    **kwargs: Any,
 ) -> Callable[..., pd.DataFrame]:
     """
     This decorator will allow users to write python functions while treating SQL tables as dataframes
@@ -253,18 +253,18 @@ def dataframe(
     This decorator allows a user to run python functions in Airflow but with the huge benefit that SQL tables
     will automatically be turned into dataframes and resulting dataframes can automatically used in astro.sql functions
     """
-    param_map = {
-        "conn_id": conn_id,
-        "database": database,
-        "schema": schema,
-        "columns_names_capitalization": columns_names_capitalization,
-    }
-    if task_id:
-        param_map["task_id"] = task_id
+    kwargs.update(
+        {
+            "conn_id": conn_id,
+            "database": database,
+            "schema": schema,
+            "columns_names_capitalization": columns_names_capitalization,
+        }
+    )
     decorated_function: Callable[..., pd.DataFrame] = task_decorator_factory(
         python_callable=python_callable,
         multiple_outputs=multiple_outputs,
         decorated_operator_class=DataframeOperator,  # type: ignore
-        **param_map,
+        **kwargs,
     )
     return decorated_function

--- a/src/astro/sql/operators/dataframe.py
+++ b/src/astro/sql/operators/dataframe.py
@@ -2,9 +2,9 @@ import inspect
 from typing import Callable, Dict, Optional, Tuple, Union
 
 import pandas as pd
-from airflow.configuration import conf
 from airflow.decorators.base import DecoratedOperator
 
+from astro import settings
 from astro.constants import ColumnCapitalization
 from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
@@ -149,10 +149,9 @@ class DataframeOperator(DecoratedOperator):
             )
             return self.output_table
         else:
-            if conf.get(
-                "core", "xcom_backend"
-            ) == "airflow.models.xcom.BaseXCom" and not conf.getboolean(
-                "astro_sdk", "dataframe_allow_unsafe_storage"
+            if (
+                not settings.IS_CUSTOM_XCOM_BACKEND
+                and not settings.ALLOW_UNSAFE_DF_STORAGE
             ):
                 raise IllegalLoadToDatabaseException()
             return pandas_dataframe

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict, Optional, Union
 
 import pandas as pd
-from airflow.configuration import conf
 from airflow.models import BaseOperator
 from airflow.models.xcom_arg import XComArg
 
+from astro import settings
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
 from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
@@ -74,10 +74,9 @@ class LoadFile(BaseOperator):
         if self.output_table:
             return self.load_data_to_table(input_file)
         else:
-            if conf.get(
-                "core", "xcom_backend"
-            ) == "airflow.models.xcom.BaseXCom" and not conf.getboolean(
-                "astro_sdk", "dataframe_allow_unsafe_storage"
+            if (
+                not settings.IS_CUSTOM_XCOM_BACKEND
+                and not settings.ALLOW_UNSAFE_DF_STORAGE
             ):
                 raise IllegalLoadToDatabaseException()
             return self.load_data_to_dataframe(input_file)

--- a/tests/sql/operators/test_dataframe.py
+++ b/tests/sql/operators/test_dataframe.py
@@ -267,3 +267,20 @@ def test_columns_names_capitalization(sample_dag):
     cols.sort()
     assert cols[1].islower()
     assert cols[0].isupper()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"task_id": "task1", "queue": "new_1"}, {"queue": "new_2", "owner": "astro-sdk"}],
+)
+def test_pass_kwargs_to_base_operator(kwargs):
+    """Test that kwargs passed to decorator are passed to BaseOperator"""
+
+    @aql.dataframe(**kwargs)
+    def sample_df_1():  # skipcq: PY-D0003
+        return pandas.DataFrame(
+            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
+        )
+
+    task1 = sample_df_1()
+    assert all(getattr(task1.operator, k) == v for k, v in kwargs.items())

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -9,6 +9,7 @@ Run test:
     python3 -m unittest tests.operators.test_load_file.TestLoadFile.test_aql_local_file_to_postgres
 
 """
+import importlib
 import os
 import pathlib
 from unittest import mock
@@ -68,11 +69,14 @@ def test_load_file_with_http_path_file(sample_dag, database_table_fixture):
     assert df.shape == (3, 9)
 
 
-@pytest.mark.integration
 @mock.patch.dict(
     os.environ, {"AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE": "False"}
 )
 def test_unsafe_loading_of_dataframe(sample_dag):
+    from astro import settings
+
+    importlib.reload(settings)
+
     with pytest.raises(IllegalLoadToDatabaseException):
         load_file(
             input_file=File(

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -34,6 +34,7 @@ def session():
         "example_dynamic_map_task",
         "example_append",
         "example_load_file",
+        "example_merge_bigquery",
     ],
 )
 def test_example_dag(session, dag_id):


### PR DESCRIPTION
# Description
## What is the current behavior?
In the past, we had a tutorial which illustrated how to use each of our operators/decorators:
https://github.com/astronomer/astro-sdk/blob/be6280df00ccff0d7a1c0dfb099b2065303dbe88/REFERENCE.md

closes: #591 

## What is the new behavior?
Have a reference page per operator/decorator similar to
https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/operators/ecs.html#howto-operator-ecsoperator

In which we reference parts of an (automated tested) example DAG which illustrates the usage of that operator/decorator.

Many of these use cases already exist in our example DAGs - we should reference them.

merge
    with conflicts (what options the user has)
    without conflicts

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Extended the README / documentation, if necessary
