### PR TITLE
Bugfix: Pass operator kwargs to dataframe decorator

### DIFF
--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -244,8 +244,8 @@ def dataframe(
     conn_id: str = "",
     database: Optional[str] = None,
     schema: Optional[str] = None,
-    task_id: Optional[str] = None,
     columns_names_capitalization: ColumnCapitalization = "lower",
+    **kwargs: Any,
 ) -> Callable[..., pd.DataFrame]:
     """
     This decorator will allow users to write python functions while treating SQL tables as dataframes
@@ -253,18 +253,18 @@ def dataframe(
     This decorator allows a user to run python functions in Airflow but with the huge benefit that SQL tables
     will automatically be turned into dataframes and resulting dataframes can automatically used in astro.sql functions
     """
-    param_map = {
-        "conn_id": conn_id,
-        "database": database,
-        "schema": schema,
-        "columns_names_capitalization": columns_names_capitalization,
-    }
-    if task_id:
-        param_map["task_id"] = task_id
+    kwargs.update(
+        {
+            "conn_id": conn_id,
+            "database": database,
+            "schema": schema,
+            "columns_names_capitalization": columns_names_capitalization,
+        }
+    )
     decorated_function: Callable[..., pd.DataFrame] = task_decorator_factory(
         python_callable=python_callable,
         multiple_outputs=multiple_outputs,
         decorated_operator_class=DataframeOperator,  # type: ignore
-        **param_map,
+        **kwargs,
     )
     return decorated_function

--- a/tests/sql/operators/test_dataframe.py
+++ b/tests/sql/operators/test_dataframe.py
@@ -267,3 +267,20 @@ def test_columns_names_capitalization(sample_dag):
     cols.sort()
     assert cols[1].islower()
     assert cols[0].isupper()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"task_id": "task1", "queue": "new_1"}, {"queue": "new_2", "owner": "astro-sdk"}],
+)
+def test_pass_kwargs_to_base_operator(kwargs):
+    """Test that kwargs passed to decorator are passed to BaseOperator"""
+
+    @aql.dataframe(**kwargs)
+    def sample_df_1():  # skipcq: PY-D0003
+        return pandas.DataFrame(
+            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
+        )
+
+    task1 = sample_df_1()
+    assert all(getattr(task1.operator, k) == v for k, v in kwargs.items())


### PR DESCRIPTION
closes https://github.com/astronomer/astro-sdk/issues/630

Before you run the following, it will error out with "TypeError: dataframe() got an unexpected keyword argument 'queue'
":

```
@aql.dataframe(queue="python-tasks")
```

With the changes in the PR, it should now work fine, I have added test that covers it


