### PR TITLE
Make the operator names consistent

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,7 +53,7 @@ Internals:
 * Added sphinx documentation for readthedocs [#276](https://github.com/astronomer/astro-sdk/issues/276) [#472](https://github.com/astronomer/astro-sdk/issues/472)
 
 Enhancement:
-* Fail LoadFile operator when input_file does not exist [#467](https://github.com/astronomer/astro-sdk/issues/467)
+* Fail LoadFileOperator operator when input_file does not exist [#467](https://github.com/astronomer/astro-sdk/issues/467)
 * Create scripts to launch benchmark testing to Google cloud [#432](https://github.com/astronomer/astro-sdk/pull/496)
 * Bump Google Provider for google extra [#294](https://github.com/astronomer/astro-sdk/pull/294)
 

--- a/src/astro/sql/operators/cleanup.py
+++ b/src/astro/sql/operators/cleanup.py
@@ -13,7 +13,7 @@ from airflow.utils.state import State
 from astro.databases import create_database
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 from astro.sql.operators.dataframe import DataframeOperator
-from astro.sql.operators.load_file import LoadFile
+from astro.sql.operators.load_file import LoadFileOperator
 from astro.sql.table import Table
 
 
@@ -200,7 +200,7 @@ class CleanupOperator(BaseOperator):
         res = []
         for task in tasks:
             if isinstance(
-                task, (DataframeOperator, BaseSQLDecoratedOperator, LoadFile)
+                task, (DataframeOperator, BaseSQLDecoratedOperator, LoadFileOperator)
             ):
                 try:
                     t = task.output.resolve(context)

--- a/src/astro/sql/operators/export_file.py
+++ b/src/astro/sql/operators/export_file.py
@@ -11,7 +11,7 @@ from astro.sql.table import Table
 from astro.utils.task_id_helper import get_task_id
 
 
-class ExportFile(BaseOperator):
+class ExportFileOperator(BaseOperator):
     """Write SQL table to csv/parquet on local/S3/GCS.
 
     :param input_data: Table to convert to file
@@ -65,7 +65,7 @@ def export_file(
     task_id: Optional[str] = None,
     **kwargs: Any,
 ) -> XComArg:
-    """Convert ExportFile into a function. Returns XComArg.
+    """Convert ExportFileOperator into a function. Returns XComArg.
 
     Returns an XComArg object of type File which matches the output_file parameter.
 
@@ -95,7 +95,7 @@ def export_file(
         task_id if task_id is not None else get_task_id("export_file", output_file.path)
     )
 
-    return ExportFile(
+    return ExportFileOperator(
         task_id=task_id,
         output_file=output_file,
         input_data=input_data,

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -13,7 +13,7 @@ from astro.sql.table import Table
 from astro.utils.task_id_helper import get_task_id
 
 
-class LoadFile(BaseOperator):
+class LoadFileOperator(BaseOperator):
     """Load S3/local file into either a database or a pandas dataframe
 
     :param input_file: File path and conn_id for object stores
@@ -212,7 +212,7 @@ def load_file(
     # contain chars like - ?, * etc. Which are not acceptable as task id.
     task_id = task_id if task_id is not None else get_task_id("load_file", "")
 
-    return LoadFile(
+    return LoadFileOperator(
         task_id=task_id,
         input_file=input_file,
         output_table=output_table,


### PR DESCRIPTION
`LoadFile` and `ExportFile` didn't have operator suffix. While it is not needed, I thought it would be good to make them consistent.

