### PR TITLE
Use exc_info for exception logging

### DIFF
--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -378,8 +378,8 @@ class BaseDatabase(ABC):
                 **kwargs,
             )
         # Catching NATIVE_LOAD_EXCEPTIONS for fallback
-        except self.NATIVE_LOAD_EXCEPTIONS as exe:  # skipcq: PYL-W0703
-            logging.warning(exe)
+        except self.NATIVE_LOAD_EXCEPTIONS:  # skipcq: PYL-W0703
+            logging.warning("Loading files failed with Native Support. Falling back to Pandas-based load", exc_info=True)
             if enable_native_fallback:
                 self.load_pandas_dataframe_to_table(
                     source_file.export_to_dataframe(),

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -379,7 +379,10 @@ class BaseDatabase(ABC):
             )
         # Catching NATIVE_LOAD_EXCEPTIONS for fallback
         except self.NATIVE_LOAD_EXCEPTIONS:  # skipcq: PYL-W0703
-            logging.warning("Loading files failed with Native Support. Falling back to Pandas-based load", exc_info=True)
+            logging.warning(
+                "Loading files failed with Native Support. Falling back to Pandas-based load",
+                exc_info=True,
+            )
             if enable_native_fallback:
                 self.load_pandas_dataframe_to_table(
                     source_file.export_to_dataframe(),

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -335,7 +335,6 @@ class BigqueryDatabase(BaseDatabase):
         try:
             return str(self.hook.project_id)
         except AttributeError as exe:
-            logging.warning(exe)
             raise DatabaseCustomError(
                 f"conn_id {target_table.conn_id} has no project id"
             ) from exe

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -1,5 +1,4 @@
 """Google BigQuery table implementation."""
-import logging
 import time
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -423,7 +423,6 @@ class SnowflakeDatabase(BaseDatabase):
         try:
             self.hook.run(sql_statement)
         except (ValueError, AttributeError) as exe:
-            logging.warning(exe)
             raise DatabaseCustomError from exe
         self.drop_stage(stage)
 


### PR DESCRIPTION
# Description
## What is the current behavior?

Exceptions are currently being printed in `logging.warning` without `exc_info`.

related: #638

## What is the new behavior?

Use exc_info for exception logging

## Does this introduce a breaking change?

No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
