### PR TITLE
Remove pre-commit from GH Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,20 +9,6 @@ on:
     branches: [ 'main' ]
     types: ['labeled']
 jobs:
-  Pre-Commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.9'
-          architecture: 'x64'
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ hashFiles('pyproject.toml') }}
-      - uses: pre-commit/action@v2.0.3
-
   Markdown-link-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description
## What is the current behavior?

pre-commit already runs in pre-commit.ci hence we don't need it anymore in GitHub Actions.

closes: #645 

## What is the new behavior?

pre-commit only runs in pre-commit.ci

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
