### PR TITLE
Move `DatabaseCustomError` to `astro/exceptions.py`

### DIFF
--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -18,19 +18,10 @@ from astro.constants import (
     LoadExistStrategy,
     MergeConflictStrategy,
 )
-from astro.exceptions import NonExistentTableException
+from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import Metadata, Table
-
-
-class DatabaseCustomError(ValueError, AttributeError):
-    """
-    Inappropriate argument value (of correct type) or attribute
-    not found while running query. while running query
-    """
-
-    pass
 
 
 class BaseDatabase(ABC):

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -44,7 +44,8 @@ from astro.constants import (
     LoadExistStrategy,
     MergeConflictStrategy,
 )
-from astro.databases.base import BaseDatabase, DatabaseCustomError
+from astro.databases.base import BaseDatabase
+from astro.exceptions import DatabaseCustomError
 from astro.files import File
 from astro.settings import BIGQUERY_SCHEMA
 from astro.sql.table import Metadata, Table

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -31,7 +31,8 @@ from astro.constants import (
     LoadExistStrategy,
     MergeConflictStrategy,
 )
-from astro.databases.base import BaseDatabase, DatabaseCustomError
+from astro.databases.base import BaseDatabase
+from astro.exceptions import DatabaseCustomError
 from astro.files import File
 from astro.settings import SNOWFLAKE_SCHEMA
 from astro.sql.table import Metadata, Table

--- a/src/astro/exceptions.py
+++ b/src/astro/exceptions.py
@@ -1,8 +1,6 @@
 class NonExistentTableException(Exception):
     """Raised if an operation expected a SQL table to exist, but it does not exist"""
 
-    pass
-
 
 class IllegalLoadToDatabaseException(Exception):
     def __init__(self):
@@ -15,3 +13,10 @@ class IllegalLoadToDatabaseException(Exception):
             "knowing the risks. "
         )
         super().__init__(self.message)
+
+
+class DatabaseCustomError(ValueError, AttributeError):
+    """
+    Inappropriate argument value (of correct type) or attribute
+    not found while running query. while running query
+    """

--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -15,9 +15,8 @@ from google.cloud.bigquery_datatransfer_v1.types import (
 
 from astro.constants import Database
 from astro.databases import create_database
-from astro.databases.base import DatabaseCustomError
 from astro.databases.google.bigquery import BigqueryDatabase, S3ToBigqueryDataTransfer
-from astro.exceptions import NonExistentTableException
+from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table

--- a/tests/databases/test_snowflake.py
+++ b/tests/databases/test_snowflake.py
@@ -11,9 +11,8 @@ from sqlalchemy.exc import ProgrammingError
 
 from astro.constants import Database, FileLocation, FileType
 from astro.databases import create_database
-from astro.databases.base import DatabaseCustomError
 from astro.databases.snowflake import SnowflakeDatabase, SnowflakeStage
-from astro.exceptions import NonExistentTableException
+from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File
 from astro.settings import (
     SCHEMA,


### PR DESCRIPTION
Looks like we already had a custom exceptions file with 2 custom exceptions. So just making it consistent and moving `DatabaseCustomError` to this file
