### PR TITLE
Use lazy evaluated Type Annotations from PEP 563

### DIFF
--- a/src/astro/constants.py
+++ b/src/astro/constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from enum import Enum
 

--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 from abc import ABC
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import pandas as pd
 import sqlalchemy
@@ -46,8 +48,8 @@ class BaseDatabase(ABC):
     #   the col names generated is 'a.b'. char '.' maybe an illegal char in some db's col name.
     # Contains the illegal char and there replacement, where the value in
     # illegal_column_name_chars[0] will be replaced by value in illegal_column_name_chars_replacement[0]
-    illegal_column_name_chars: List[str] = []
-    illegal_column_name_chars_replacement: List[str] = []
+    illegal_column_name_chars: list[str] = []
+    illegal_column_name_chars_replacement: list[str] = []
     NATIVE_LOAD_EXCEPTIONS: Any = DatabaseCustomError
     DEFAULT_SCHEMA = SCHEMA
 
@@ -78,8 +80,8 @@ class BaseDatabase(ABC):
 
     def run_sql(
         self,
-        sql_statement: Union[str, ClauseElement],
-        parameters: Optional[dict] = None,
+        sql_statement: str | ClauseElement,
+        parameters: dict | None = None,
     ):
         """
         Return the results to running a SQL statement.
@@ -113,7 +115,7 @@ class BaseDatabase(ABC):
     # Table metadata
     # ---------------------------------------------------------
     @staticmethod
-    def get_merge_initialization_query(parameters: Tuple) -> str:
+    def get_merge_initialization_query(parameters: tuple) -> str:
         """
         Handles database-specific logic to handle constraints, keeping
         it agnostic to database.
@@ -183,8 +185,8 @@ class BaseDatabase(ABC):
     def create_table_using_schema_autodetection(
         self,
         table: Table,
-        file: Optional[File] = None,
-        dataframe: Optional[pd.DataFrame] = None,
+        file: File | None = None,
+        dataframe: pd.DataFrame | None = None,
         columns_names_capitalization: ColumnCapitalization = "lower",  # skipcq
     ) -> None:
         """
@@ -219,8 +221,8 @@ class BaseDatabase(ABC):
     def create_table(
         self,
         table: Table,
-        file: Optional[File] = None,
-        dataframe: Optional[pd.DataFrame] = None,
+        file: File | None = None,
+        dataframe: pd.DataFrame | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
     ) -> None:
         """
@@ -244,7 +246,7 @@ class BaseDatabase(ABC):
         self,
         statement: str,
         target_table: Table,
-        parameters: Optional[dict] = None,
+        parameters: dict | None = None,
     ) -> None:
         """
         Export the result rows of a query statement into another table.
@@ -277,13 +279,13 @@ class BaseDatabase(ABC):
         self,
         input_file: File,
         output_table: Table,
-        normalize_config: Optional[Dict] = None,
+        normalize_config: dict | None = None,
         if_exists: LoadExistStrategy = "replace",
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         use_native_support: bool = True,
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
-        enable_native_fallback: Optional[bool] = True,
+        enable_native_fallback: bool | None = True,
         **kwargs,
     ):
         """
@@ -345,8 +347,8 @@ class BaseDatabase(ABC):
         source_file: File,
         target_table: Table,
         if_exists: LoadExistStrategy = "replace",
-        native_support_kwargs: Optional[Dict] = None,
-        enable_native_fallback: Optional[bool] = True,
+        native_support_kwargs: dict | None = None,
+        enable_native_fallback: bool | None = True,
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         **kwargs,
     ):
@@ -411,7 +413,7 @@ class BaseDatabase(ABC):
         self,
         source_table: Table,
         target_table: Table,
-        source_to_target_columns_map: Dict[str, str],
+        source_to_target_columns_map: dict[str, str],
     ) -> None:
         """
         Append the source table rows into a destination table.
@@ -424,8 +426,8 @@ class BaseDatabase(ABC):
         target_table_sqla = self.get_sqla_table(target_table)
         source_table_sqla = self.get_sqla_table(source_table)
 
-        target_columns: List[ColumnClause]
-        source_columns: List[ColumnClause]
+        target_columns: list[ColumnClause]
+        source_columns: list[ColumnClause]
 
         if not source_to_target_columns_map:
             target_columns = [column(col) for col in target_table_sqla.c.keys()]
@@ -448,8 +450,8 @@ class BaseDatabase(ABC):
         self,
         source_table: Table,
         target_table: Table,
-        source_to_target_columns_map: Dict[str, str],
-        target_conflict_columns: List[str],
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
     ) -> None:
         """
@@ -520,7 +522,7 @@ class BaseDatabase(ABC):
     # Schema Management
     # ---------------------------------------------------------
 
-    def create_schema_if_needed(self, schema: Optional[str]) -> None:
+    def create_schema_if_needed(self, schema: str | None) -> None:
         """
         This function checks if the expected schema exists in the database. If the schema does not exist,
         it will attempt to create it.
@@ -547,7 +549,7 @@ class BaseDatabase(ABC):
 
     def get_sqlalchemy_template_table_identifier_and_parameter(
         self, table: Table, jinja_table_identifier: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """
         During the conversion from a Jinja-templated SQL query to a SQLAlchemy query, there is the need to
         convert a Jinja table identifier to a safe SQLAlchemy-compatible table identifier.
@@ -590,7 +592,7 @@ class BaseDatabase(ABC):
         source_file: File,
         target_table: Table,
         if_exists: LoadExistStrategy = "replace",
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         """

--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -1,6 +1,8 @@
 """Google BigQuery table implementation."""
+from __future__ import annotations
+
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import pandas as pd
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
@@ -72,8 +74,8 @@ class BigqueryDatabase(BaseDatabase):
         FileLocation.LOCAL: "load_local_file_to_table",
     }
 
-    illegal_column_name_chars: List[str] = ["."]
-    illegal_column_name_chars_replacement: List[str] = ["_"]
+    illegal_column_name_chars: list[str] = ["."]
+    illegal_column_name_chars_replacement: list[str] = ["_"]
     NATIVE_LOAD_EXCEPTIONS: Any = (
         GoogleNotFound,
         ClientError,
@@ -132,7 +134,7 @@ class BigqueryDatabase(BaseDatabase):
         return True
 
     @staticmethod
-    def get_merge_initialization_query(parameters: Tuple) -> str:
+    def get_merge_initialization_query(parameters: tuple) -> str:
         """
         Handles database-specific logic to handle constraints
         for BigQuery. The only constraint that BigQuery supports
@@ -167,8 +169,8 @@ class BigqueryDatabase(BaseDatabase):
         self,
         source_table: Table,
         target_table: Table,
-        source_to_target_columns_map: Dict[str, str],
-        target_conflict_columns: List[str],
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
     ) -> None:
         """
@@ -221,7 +223,7 @@ class BigqueryDatabase(BaseDatabase):
         source_file: File,
         target_table: Table,
         if_exists: LoadExistStrategy = "replace",
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         """
@@ -254,7 +256,7 @@ class BigqueryDatabase(BaseDatabase):
         source_file: File,
         target_table: Table,
         if_exists: LoadExistStrategy = "replace",
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         """
@@ -299,7 +301,7 @@ class BigqueryDatabase(BaseDatabase):
         self,
         source_file: File,
         target_table: Table,
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         """
@@ -344,7 +346,7 @@ class BigqueryDatabase(BaseDatabase):
         source_file: File,
         target_table: Table,
         if_exists: LoadExistStrategy = "replace",
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         """Transfer data from local to bigquery"""
@@ -400,7 +402,7 @@ class S3ToBigqueryDataTransfer:
         source_file: File,
         project_id: str,
         poll_duration: int = 1,
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         self.client = BiqQueryDataTransferServiceHook(gcp_conn_id=target_table.conn_id)

--- a/src/astro/databases/postgres.py
+++ b/src/astro/databases/postgres.py
@@ -1,7 +1,8 @@
 """Postgres database implementation."""
+from __future__ import annotations
+
 import io
 from contextlib import closing
-from typing import Dict, List
 
 import pandas as pd
 import sqlalchemy
@@ -23,8 +24,8 @@ class PostgresDatabase(BaseDatabase):
     """
 
     DEFAULT_SCHEMA = POSTGRES_SCHEMA
-    illegal_column_name_chars: List[str] = ["."]
-    illegal_column_name_chars_replacement: List[str] = ["_"]
+    illegal_column_name_chars: list[str] = ["."]
+    illegal_column_name_chars_replacement: list[str] = ["_"]
 
     def __init__(self, conn_id: str = DEFAULT_CONN_ID):
         super().__init__(conn_id)
@@ -137,8 +138,8 @@ class PostgresDatabase(BaseDatabase):
         self,
         source_table: Table,
         target_table: Table,
-        source_to_target_columns_map: Dict[str, str],
-        target_conflict_columns: List[str],
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
     ) -> None:
         """

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -1,10 +1,12 @@
 """Snowflake database implementation."""
+from __future__ import annotations
+
 import logging
 import os
 import random
 import string
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
@@ -220,7 +222,7 @@ class SnowflakeDatabase(BaseDatabase):
 
     @staticmethod
     def _create_stage_auth_sub_statement(
-        file: File, storage_integration: Optional[str] = None
+        file: File, storage_integration: str | None = None
     ) -> str:
         """
         Create authentication-related line for the Snowflake CREATE STAGE.
@@ -255,8 +257,8 @@ class SnowflakeDatabase(BaseDatabase):
     def create_stage(
         self,
         file: File,
-        storage_integration: Optional[str] = None,
-        metadata: Optional[Metadata] = None,
+        storage_integration: str | None = None,
+        metadata: Metadata | None = None,
     ) -> SnowflakeStage:
         """
         Creates a new named external stage to use for loading data from files into Snowflake
@@ -334,8 +336,8 @@ class SnowflakeDatabase(BaseDatabase):
     def create_table_using_schema_autodetection(
         self,
         table: Table,
-        file: Optional[File] = None,
-        dataframe: Optional[pd.DataFrame] = None,
+        file: File | None = None,
+        dataframe: pd.DataFrame | None = None,
         columns_names_capitalization: ColumnCapitalization = "lower",
     ) -> None:
         """
@@ -383,7 +385,7 @@ class SnowflakeDatabase(BaseDatabase):
         source_file: File,
         target_table: Table,
         if_exists: LoadExistStrategy = "replace",
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         """
@@ -458,7 +460,7 @@ class SnowflakeDatabase(BaseDatabase):
 
     def get_sqlalchemy_template_table_identifier_and_parameter(
         self, table: Table, jinja_table_identifier: str
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """
         During the conversion from a Jinja-templated SQL query to a SQLAlchemy query, there is the need to
         convert a Jinja table identifier to a safe SQLAlchemy-compatible table identifier.
@@ -517,8 +519,8 @@ class SnowflakeDatabase(BaseDatabase):
         self,
         source_table: Table,
         target_table: Table,
-        source_to_target_columns_map: Dict[str, str],
-        target_conflict_columns: List[str],
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
     ) -> None:
         """
@@ -544,8 +546,8 @@ class SnowflakeDatabase(BaseDatabase):
         self,
         source_table: Table,
         target_table: Table,
-        source_to_target_columns_map: Dict[str, str],
-        target_conflict_columns: List[str],
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
     ):
         """Build the SQL statement for Merge operation"""

--- a/src/astro/databases/sqlite.py
+++ b/src/astro/databases/sqlite.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple
+from __future__ import annotations
 
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from sqlalchemy import MetaData as SqlaMetaData
@@ -64,7 +64,7 @@ class SqliteDatabase(BaseDatabase):
         table.conn_id = table.conn_id or self.conn_id
         return table
 
-    def create_schema_if_needed(self, schema: Optional[str]) -> None:
+    def create_schema_if_needed(self, schema: str | None) -> None:
         """
         Since SQLite does not have schemas, we do not need to set a schema here.
         """
@@ -76,7 +76,7 @@ class SqliteDatabase(BaseDatabase):
         return False
 
     @staticmethod
-    def get_merge_initialization_query(parameters: Tuple) -> str:
+    def get_merge_initialization_query(parameters: tuple) -> str:
         """
         Handles database-specific logic to handle index for Sqlite.
         """
@@ -86,8 +86,8 @@ class SqliteDatabase(BaseDatabase):
         self,
         source_table: Table,
         target_table: Table,
-        source_to_target_columns_map: Dict[str, str],
-        target_conflict_columns: List[str],
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
     ) -> None:
         """

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import io
-from typing import List, Optional, Union
 
 import pandas as pd
 import smart_open
@@ -20,9 +21,9 @@ class File:
     def __init__(
         self,
         path: str,
-        conn_id: Optional[str] = None,
-        filetype: Union[FileType, None] = None,
-        normalize_config: Optional[dict] = None,
+        conn_id: str | None = None,
+        filetype: FileType | None = None,
+        normalize_config: dict | None = None,
     ):
         """Init file object which represent a single file in local/object stores
 
@@ -41,7 +42,7 @@ class File:
         return self.location.path
 
     @property
-    def conn_id(self) -> Optional[str]:
+    def conn_id(self) -> str | None:
         return self.location.conn_id
 
     @property
@@ -125,10 +126,10 @@ class File:
 
 def resolve_file_path_pattern(
     path_pattern: str,
-    conn_id: Optional[str] = None,
-    filetype: Union[FileType, None] = None,
-    normalize_config: Optional[dict] = None,
-) -> List[File]:
+    conn_id: str | None = None,
+    filetype: FileType | None = None,
+    normalize_config: dict | None = None,
+) -> list[File]:
     """get file objects by resolving path_pattern from local/object stores
     path_pattern can be
     1. local location - glob pattern

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -5,7 +5,7 @@ import io
 import pandas as pd
 import smart_open
 
-from astro.constants import FileType
+from astro import constants
 from astro.files.locations import create_file_location
 from astro.files.locations.base import BaseFileLocation
 from astro.files.types import create_file_type
@@ -22,7 +22,7 @@ class File:
         self,
         path: str,
         conn_id: str | None = None,
-        filetype: FileType | None = None,
+        filetype: constants.FileType | None = None,
         normalize_config: dict | None = None,
     ):
         """Init file object which represent a single file in local/object stores
@@ -57,11 +57,11 @@ class File:
 
     def is_binary(self) -> bool:
         """
-        Return a FileType given the filepath. Uses a naive strategy, using the file extension.
+        Return a constants.FileType given the filepath. Uses a naive strategy, using the file extension.
 
         :return: True or False
         """
-        result: bool = self.type.name == FileType.PARQUET
+        result: bool = self.type.name == constants.FileType.PARQUET
         return result
 
     def create_from_dataframe(self, df: pd.DataFrame) -> None:
@@ -127,7 +127,7 @@ class File:
 def resolve_file_path_pattern(
     path_pattern: str,
     conn_id: str | None = None,
-    filetype: FileType | None = None,
+    filetype: constants.FileType | None = None,
     normalize_config: dict | None = None,
 ) -> list[File]:
     """get file objects by resolving path_pattern from local/object stores

--- a/src/astro/files/locations/amazon/s3.py
+++ b/src/astro/files/locations/amazon/s3.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import os
-from typing import Dict, List, Tuple
 from urllib.parse import urlparse, urlunparse
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -18,12 +19,12 @@ class S3Location(BaseFileLocation):
         return S3Hook(aws_conn_id=self.conn_id) if self.conn_id else S3Hook()
 
     @staticmethod
-    def _parse_s3_env_var() -> Tuple[str, str]:
+    def _parse_s3_env_var() -> tuple[str, str]:
         """Return S3 ID/KEY pair from environment vars"""
         return os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]
 
     @property
-    def transport_params(self) -> Dict:
+    def transport_params(self) -> dict:
         """Structure s3fs credentials from Airflow connection.
         s3fs enables pandas to write to s3
         """
@@ -31,7 +32,7 @@ class S3Location(BaseFileLocation):
         return {"client": session.client("s3")}
 
     @property
-    def paths(self) -> List[str]:
+    def paths(self) -> list[str]:
         """Resolve S3 file paths with prefix"""
         url = urlparse(self.path)
         bucket_name = url.netloc

--- a/src/astro/files/locations/base.py
+++ b/src/astro/files/locations/base.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import glob
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import smart_open
@@ -15,7 +16,7 @@ class BaseFileLocation(ABC):
 
     template_fields = ("path", "conn_id")
 
-    def __init__(self, path: str, conn_id: Optional[str] = None):
+    def __init__(self, path: str, conn_id: str | None = None):
         """
         Manages and provide interface for the operation for all the supported locations.
 
@@ -23,7 +24,7 @@ class BaseFileLocation(ABC):
         :param conn_id: Airflow connection ID
         """
         self.path: str = path
-        self.conn_id: Optional[str] = conn_id
+        self.conn_id: str | None = conn_id
 
     @property
     def hook(self):
@@ -37,12 +38,12 @@ class BaseFileLocation(ABC):
 
     @property
     @abstractmethod
-    def paths(self) -> List[str]:
+    def paths(self) -> list[str]:
         """Resolve patterns in path"""
         raise NotImplementedError
 
     @property
-    def transport_params(self) -> Union[Dict, None]:  # skipcq: PYL-R0201
+    def transport_params(self) -> dict | None:  # skipcq: PYL-R0201
         """Get credentials required by smart open to access files"""
         return None
 

--- a/src/astro/files/locations/google/gcs.py
+++ b/src/astro/files/locations/google/gcs.py
@@ -1,4 +1,5 @@
-from typing import Dict, List
+from __future__ import annotations
+
 from urllib.parse import urlparse, urlunparse
 
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
@@ -17,13 +18,13 @@ class GCSLocation(BaseFileLocation):
         return GCSHook(gcp_conn_id=self.conn_id) if self.conn_id else GCSHook()
 
     @property
-    def transport_params(self) -> Dict:
+    def transport_params(self) -> dict:
         """get GCS credentials for storage"""
         client = self.hook.get_conn()
         return {"client": client}
 
     @property
-    def paths(self) -> List[str]:
+    def paths(self) -> list[str]:
         """Resolve GS file paths with prefix"""
         url = urlparse(self.path)
         bucket_name = url.netloc

--- a/src/astro/files/locations/http.py
+++ b/src/astro/files/locations/http.py
@@ -1,4 +1,4 @@
-from typing import List
+from __future__ import annotations
 
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
@@ -10,7 +10,7 @@ class HTTPLocation(BaseFileLocation):
     location_type = FileLocation.HTTP
 
     @property
-    def paths(self) -> List[str]:
+    def paths(self) -> list[str]:
         """Resolve patterns in path"""
         return [self.path]
 

--- a/src/astro/files/locations/local.py
+++ b/src/astro/files/locations/local.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import glob
 import os
 import pathlib
-from typing import List
 from urllib.parse import urlparse
 
 from astro.constants import FileLocation
@@ -14,7 +15,7 @@ class LocalLocation(BaseFileLocation):
     location_type = FileLocation.LOCAL
 
     @property
-    def paths(self) -> List[str]:
+    def paths(self) -> list[str]:
         """Resolve local filepath"""
         url = urlparse(self.path)
         path_object = pathlib.Path(url.path)

--- a/src/astro/files/types/__init__.py
+++ b/src/astro/files/types/__init__.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import pathlib
-from typing import Dict, Optional, Type, Union
 
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
@@ -11,11 +12,11 @@ from astro.files.types.parquet import ParquetFileType
 
 def create_file_type(
     path: str,
-    filetype: Union[FileTypeConstants, None] = None,
-    normalize_config: Optional[dict] = None,
+    filetype: FileTypeConstants | None = None,
+    normalize_config: dict | None = None,
 ) -> FileType:
     """Factory method to create FileType super objects based on the file extension in path or filetype specified."""
-    filetype_to_class: Dict[FileTypeConstants, Type[FileType]] = {
+    filetype_to_class: dict[FileTypeConstants, type[FileType]] = {
         FileTypeConstants.CSV: CSVFileType,
         FileTypeConstants.JSON: JSONFileType,
         FileTypeConstants.NDJSON: NDJSONFileType,
@@ -32,7 +33,7 @@ def create_file_type(
         )
 
 
-def get_filetype(filepath: Union[str, pathlib.PosixPath]) -> FileTypeConstants:
+def get_filetype(filepath: str | pathlib.PosixPath) -> FileTypeConstants:
     """
     Return a FileType given the filepath. Uses a naive strategy, using the file extension.
 

--- a/src/astro/files/types/base.py
+++ b/src/astro/files/types/base.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import io
 from abc import ABC, abstractmethod
-from typing import Optional
 
 import pandas as pd
 
@@ -8,7 +9,7 @@ import pandas as pd
 class FileType(ABC):
     """Abstract File type class, meant to be the interface to all client code for all supported file types"""
 
-    def __init__(self, path: str, normalize_config: Optional[dict] = None):
+    def __init__(self, path: str, normalize_config: dict | None = None):
         self.path = path
         self.normalize_config = normalize_config
 

--- a/src/astro/files/types/csv.py
+++ b/src/astro/files/types/csv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 
 import pandas as pd

--- a/src/astro/files/types/json.py
+++ b/src/astro/files/types/json.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 
 import pandas as pd
@@ -14,7 +16,7 @@ class JSONFileType(FileType):
         self,
         stream: io.TextIOWrapper,
         columns_names_capitalization="original",
-        **kwargs
+        **kwargs,
     ) -> pd.DataFrame:
         """read json file from one of the supported locations and return dataframe
 

--- a/src/astro/files/types/ndjson.py
+++ b/src/astro/files/types/ndjson.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import io
 import json
-from typing import Optional
 
 import pandas as pd
 
@@ -42,7 +43,7 @@ class NDJSONFileType(FileType):
 
     @staticmethod
     def flatten(
-        normalize_config: Optional[dict], stream: io.TextIOWrapper, **kwargs
+        normalize_config: dict | None, stream: io.TextIOWrapper, **kwargs
     ) -> pd.DataFrame:
         """
         Flatten the nested ndjson/json.

--- a/src/astro/files/types/parquet.py
+++ b/src/astro/files/types/parquet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 
 import pandas as pd

--- a/src/astro/sql/operators/append.py
+++ b/src/astro/sql/operators/append.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.xcom_arg import XComArg
 
 from astro.databases import create_database
 from astro.sql.table import Table
-
-if TYPE_CHECKING:
-    from airflow.models.xcom_arg import XComArg
 
 
 class AppendOperator(BaseOperator):

--- a/src/astro/sql/operators/append.py
+++ b/src/astro/sql/operators/append.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.baseoperator import BaseOperator
@@ -8,8 +10,6 @@ from astro.sql.table import Table
 
 if TYPE_CHECKING:
     from airflow.models.xcom_arg import XComArg
-
-APPEND_COLUMN_TYPE = Optional[Union[List[str], Tuple[str], Dict[str, str]]]
 
 
 class AppendOperator(BaseOperator):
@@ -30,7 +30,7 @@ class AppendOperator(BaseOperator):
         self,
         source_table: Table,
         target_table: Table,
-        columns: APPEND_COLUMN_TYPE = None,
+        columns: list[str] | tuple[str] | dict[str, str] | None = None,
         task_id: str = "",
         **kwargs: Any,
     ) -> None:
@@ -63,9 +63,9 @@ def append(
     *,
     source_table: Table,
     target_table: Table,
-    columns: APPEND_COLUMN_TYPE = None,
+    columns: list[str] | tuple[str] | dict[str, str] | None = None,
     **kwargs: Any,
-) -> "XComArg":
+) -> XComArg:
     """
     Append the source table rows into a destination table.
 

--- a/src/astro/sql/operators/base_decorator.py
+++ b/src/astro/sql/operators/base_decorator.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import inspect
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any
 
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
@@ -19,16 +21,16 @@ class BaseSQLDecoratedOperator(DecoratedOperator):
 
     def __init__(
         self,
-        conn_id: Optional[str] = None,
-        parameters: Optional[dict] = None,
-        handler: Optional[Function] = None,
-        database: Optional[str] = None,
-        schema: Optional[str] = None,
+        conn_id: str | None = None,
+        parameters: dict | None = None,
+        handler: Function | None = None,
+        database: str | None = None,
+        schema: str | None = None,
         sql: str = "",
         **kwargs: Any,
     ):
         self.kwargs = kwargs or {}
-        self.op_kwargs: Dict = self.kwargs.get("op_kwargs") or {}
+        self.op_kwargs: dict = self.kwargs.get("op_kwargs") or {}
         self.output_table: Table = self.op_kwargs.pop("output_table", Table())
         self.handler = self.op_kwargs.pop("handler", handler)
         self.conn_id = self.op_kwargs.pop("conn_id", conn_id)
@@ -36,12 +38,12 @@ class BaseSQLDecoratedOperator(DecoratedOperator):
         self.parameters = parameters or {}
         self.database = self.op_kwargs.pop("database", database)
         self.schema = self.op_kwargs.pop("schema", schema)
-        self.op_args: Dict[str, Union[Table, pd.DataFrame]] = {}
+        self.op_args: dict[str, Table | pd.DataFrame] = {}
         super().__init__(
             **kwargs,
         )
 
-    def execute(self, context: Dict) -> None:
+    def execute(self, context: dict) -> None:
         first_table = find_first_table(
             op_args=self.op_args,  # type: ignore
             op_kwargs=self.op_kwargs,
@@ -112,7 +114,7 @@ class BaseSQLDecoratedOperator(DecoratedOperator):
             with open(self.sql) as file:
                 self.sql = file.read().replace("\n", " ")
 
-    def move_function_params_into_sql_params(self, context: Dict) -> None:
+    def move_function_params_into_sql_params(self, context: dict) -> None:
         """
         Pulls values from the function op_args and op_kwargs and places them into
         parameters for SQLAlchemy to parse
@@ -130,7 +132,7 @@ class BaseSQLDecoratedOperator(DecoratedOperator):
                 k: self.render_template(v, context) for k, v in self.parameters.items()  # type: ignore
             }
 
-    def translate_jinja_to_sqlalchemy_template(self, context: Dict) -> None:
+    def translate_jinja_to_sqlalchemy_template(self, context: dict) -> None:
         """
         This function handles all jinja templating to ensure that the SQL statement is ready for
         processing by SQLAlchemy. We use the database object here as different databases will have
@@ -168,8 +170,8 @@ class BaseSQLDecoratedOperator(DecoratedOperator):
 
 
 def load_op_arg_dataframes_into_sql(
-    conn_id: str, op_args: Tuple, target_table: Table
-) -> Tuple:
+    conn_id: str, op_args: tuple, target_table: Table
+) -> tuple:
     """
     Identify dataframes in op_args and load them to the table.
 
@@ -195,8 +197,8 @@ def load_op_arg_dataframes_into_sql(
 
 
 def load_op_kwarg_dataframes_into_sql(
-    conn_id: str, op_kwargs: Dict, target_table: Table
-) -> Dict:
+    conn_id: str, op_kwargs: dict, target_table: Table
+) -> dict:
     """
     Identify dataframes in op_kwargs and load them to a table.
 

--- a/src/astro/sql/operators/cleanup.py
+++ b/src/astro/sql/operators/cleanup.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import time
 from datetime import timedelta
-from typing import Any, List, Optional
+from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.exceptions import AirflowException
@@ -17,7 +19,7 @@ from astro.sql.operators.load_file import LoadFileOperator
 from astro.sql.table import Table
 
 
-def filter_for_temp_tables(task_outputs: List[Any]) -> List[Table]:
+def filter_for_temp_tables(task_outputs: list[Any]) -> list[Table]:
     return [t for t in task_outputs if isinstance(t, Table) and t.temp]
 
 
@@ -50,7 +52,7 @@ class CleanupOperator(BaseOperator):
     def __init__(
         self,
         *,
-        tables_to_cleanup: Optional[List[Table]] = None,
+        tables_to_cleanup: list[Table] | None = None,
         task_id: str = "",
         retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
@@ -85,7 +87,7 @@ class CleanupOperator(BaseOperator):
         self.log.info("Dropping table %s", table.name)
         db.drop_table(table)
 
-    def _is_dag_running(self, task_instances: List[TaskInstance]) -> bool:
+    def _is_dag_running(self, task_instances: list[TaskInstance]) -> bool:
         """
         Given a list of task instances, determine whether the DAG (minus the current cleanup task) is still
         running.
@@ -162,7 +164,7 @@ class CleanupOperator(BaseOperator):
         return executor in ["SequentialExecutor", "DebugExecutor"]
 
     @staticmethod
-    def _get_executor_from_job_id(job_id: int) -> Optional[str]:
+    def _get_executor_from_job_id(job_id: int) -> str | None:
         from airflow.jobs.base_job import BaseJob
         from airflow.utils.session import create_session
 
@@ -170,7 +172,7 @@ class CleanupOperator(BaseOperator):
             job = session.get(BaseJob, job_id)
         return job.executor_class if job else None
 
-    def get_all_task_outputs(self, context: Context) -> List[Table]:
+    def get_all_task_outputs(self, context: Context) -> list[Table]:
         """
         In the scenario where we are not given a list of tasks to follow, we will want to gather all temporary tables
         To prevent scenarios where we grab objects that are not tables, we try to only follow up on SQL operators or
@@ -184,8 +186,8 @@ class CleanupOperator(BaseOperator):
         return task_outputs
 
     def resolve_tables_from_tasks(
-        self, tasks: List[BaseOperator], context: Context
-    ) -> List[Table]:
+        self, tasks: list[BaseOperator], context: Context
+    ) -> list[Table]:
         """
         For the moment, these are the only two classes that create temporary tables.
         This function allows us to only resolve xcom for those objects
@@ -215,9 +217,7 @@ class CleanupOperator(BaseOperator):
         return res
 
 
-def cleanup(
-    tables_to_cleanup: Optional[List[Table]] = None, **kwargs
-) -> CleanupOperator:
+def cleanup(tables_to_cleanup: list[Table] | None = None, **kwargs) -> CleanupOperator:
     """
     Clean up temporary tables once either the DAG or upstream tasks are done
 

--- a/src/astro/sql/operators/dataframe.py
+++ b/src/astro/sql/operators/dataframe.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import inspect
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable
 
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
@@ -35,10 +37,10 @@ def _get_dataframe(
 
 
 def load_op_arg_table_into_dataframe(
-    op_args: Tuple,
+    op_args: tuple,
     python_callable: Callable,
     columns_names_capitalization: ColumnCapitalization,
-) -> Tuple:
+) -> tuple:
     """For dataframe based functions, takes any Table objects from the op_args
     and converts them into local dataframes that can be handled in the python context"""
     full_spec = inspect.getfullargspec(python_callable)
@@ -62,10 +64,10 @@ def load_op_arg_table_into_dataframe(
 
 
 def load_op_kwarg_table_into_dataframe(
-    op_kwargs: Dict,
+    op_kwargs: dict,
     python_callable: Callable,
     columns_names_capitalization: ColumnCapitalization,
-) -> Dict:
+) -> dict:
     """For dataframe based functions, takes any Table objects from the op_kwargs
     and converts them into local dataframes that can be handled in the python context"""
     param_types = inspect.signature(python_callable).parameters
@@ -98,9 +100,9 @@ class DataframeOperator(DecoratedOperator):
 
     def __init__(
         self,
-        conn_id: Optional[str] = None,
-        database: Optional[str] = None,
-        schema: Optional[str] = None,
+        conn_id: str | None = None,
+        database: str | None = None,
+        schema: str | None = None,
         columns_names_capitalization: ColumnCapitalization = "lower",
         **kwargs,
     ):
@@ -109,9 +111,9 @@ class DataframeOperator(DecoratedOperator):
         self.schema = schema
         self.parameters = None
         self.kwargs = kwargs or {}
-        self.op_kwargs: Dict = self.kwargs.get("op_kwargs") or {}
+        self.op_kwargs: dict = self.kwargs.get("op_kwargs") or {}
         if self.op_kwargs.get("output_table"):
-            self.output_table: Optional[Table] = self.op_kwargs.pop("output_table")
+            self.output_table: Table | None = self.op_kwargs.pop("output_table")
         else:
             self.output_table = None
         self.op_args = self.kwargs.get("op_args", ())  # type: ignore
@@ -121,7 +123,7 @@ class DataframeOperator(DecoratedOperator):
             **kwargs,
         )
 
-    def execute(self, context: Dict) -> Union[Table, pd.DataFrame]:
+    def execute(self, context: dict) -> Table | pd.DataFrame:
         first_table = find_first_table(
             op_args=self.op_args,  # type: ignore
             op_kwargs=self.op_kwargs,
@@ -164,11 +166,11 @@ class DataframeOperator(DecoratedOperator):
 
 
 def dataframe(
-    python_callable: Optional[Callable] = None,
-    multiple_outputs: Optional[bool] = None,
+    python_callable: Callable | None = None,
+    multiple_outputs: bool | None = None,
     conn_id: str = "",
-    database: Optional[str] = None,
-    schema: Optional[str] = None,
+    database: str | None = None,
+    schema: str | None = None,
     columns_names_capitalization: ColumnCapitalization = "lower",
     **kwargs: Any,
 ) -> TaskDecorator:

--- a/src/astro/sql/operators/drop.py
+++ b/src/astro/sql/operators/drop.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models import BaseOperator
@@ -28,7 +30,7 @@ class DropTableOperator(BaseOperator):
             **kwargs,
         )
 
-    def execute(self, context: Dict) -> Table:  # skipcq: PYL-W0613
+    def execute(self, context: dict) -> Table:  # skipcq: PYL-W0613
         """Method run when the Airflow runner calls the operator."""
         database = create_database(self.table.conn_id)
         self.table = database.populate_table_metadata(self.table)
@@ -39,7 +41,7 @@ class DropTableOperator(BaseOperator):
 def drop_table(
     table: Table,
     **kwargs: Any,
-) -> "XComArg":
+) -> XComArg:
     """
     Drops a table.
 

--- a/src/astro/sql/operators/drop.py
+++ b/src/astro/sql/operators/drop.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models import BaseOperator
+from airflow.models.xcom_arg import XComArg
 
 from astro.databases import create_database
 from astro.sql.table import Table
-
-if TYPE_CHECKING:
-    from airflow.models.xcom_arg import XComArg
 
 
 class DropTableOperator(BaseOperator):

--- a/src/astro/sql/operators/export_file.py
+++ b/src/astro/sql/operators/export_file.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any
 
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
@@ -23,7 +25,7 @@ class ExportFileOperator(BaseOperator):
 
     def __init__(
         self,
-        input_data: Union[Table, pd.DataFrame],
+        input_data: Table | pd.DataFrame,
         output_file: File,
         if_exists: ExportExistsStrategy = "exception",
         **kwargs,
@@ -59,12 +61,12 @@ class ExportFileOperator(BaseOperator):
 
 
 def export_file(
-    input_data: Union[Table, pd.DataFrame],
+    input_data: Table | pd.DataFrame,
     output_file: File,
     if_exists: ExportExistsStrategy = "exception",
-    task_id: Optional[str] = None,
+    task_id: str | None = None,
     **kwargs: Any,
-) -> "XComArg":
+) -> XComArg:
     """Convert ExportFileOperator into a function. Returns XComArg.
 
     Returns an XComArg object of type File which matches the output_file parameter.

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 import pandas as pd
+from airflow.decorators.base import get_unique_task_id
 from airflow.models import BaseOperator
 from airflow.models.xcom_arg import XComArg
-
-from airflow.decorators.base import get_unique_task_id
 
 from astro import settings
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 from airflow.models import BaseOperator
@@ -39,14 +41,14 @@ class LoadFileOperator(BaseOperator):
     def __init__(
         self,
         input_file: File,
-        output_table: Optional[Table] = None,
+        output_table: Table | None = None,
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         if_exists: LoadExistStrategy = "replace",
         ndjson_normalize_sep: str = "_",
         use_native_support: bool = True,
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
-        enable_native_fallback: Optional[bool] = True,
+        enable_native_fallback: bool | None = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -56,13 +58,13 @@ class LoadFileOperator(BaseOperator):
         self.kwargs = kwargs
         self.if_exists = if_exists
         self.ndjson_normalize_sep = ndjson_normalize_sep
-        self.normalize_config: Dict[str, str] = {}
+        self.normalize_config: dict[str, str] = {}
         self.use_native_support = use_native_support
-        self.native_support_kwargs: Dict[str, Any] = native_support_kwargs or {}
+        self.native_support_kwargs: dict[str, Any] = native_support_kwargs or {}
         self.columns_names_capitalization = columns_names_capitalization
         self.enable_native_fallback = enable_native_fallback
 
-    def execute(self, context: Any) -> Union[Table, pd.DataFrame]:  # skipcq: PYL-W0613
+    def execute(self, context: Any) -> Table | pd.DataFrame:  # skipcq: PYL-W0613
         """
         Load an existing dataset from a supported file into a SQL table or a Dataframe.
         """
@@ -71,7 +73,7 @@ class LoadFileOperator(BaseOperator):
 
         return self.load_data(input_file=self.input_file)
 
-    def load_data(self, input_file: File) -> Union[Table, pd.DataFrame]:
+    def load_data(self, input_file: File) -> Table | pd.DataFrame:
 
         self.log.info("Loading %s into %s ...", self.input_file.path, self.output_table)
         if self.output_table:
@@ -113,7 +115,7 @@ class LoadFileOperator(BaseOperator):
         self.log.info("Completed loading the data into %s.", self.output_table)
         return self.output_table
 
-    def load_data_to_dataframe(self, input_file: File) -> Optional[pd.DataFrame]:
+    def load_data_to_dataframe(self, input_file: File) -> pd.DataFrame | None:
         """
         Loads csv/parquet file from local/S3/GCS with Pandas. Returns dataframe as no
         SQL table was specified
@@ -144,7 +146,7 @@ class LoadFileOperator(BaseOperator):
     def _populate_normalize_config(
         database: BaseDatabase,
         ndjson_normalize_sep: str = "_",
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """
         Validate pandas json_normalize() parameter for databases, since default params result in
         invalid column name. Default parameter result in the columns name containing '.' char.
@@ -165,7 +167,7 @@ class LoadFileOperator(BaseOperator):
             else:
                 return str(char)
 
-        normalize_config: Dict[str, Any] = {
+        normalize_config: dict[str, Any] = {
             "meta_prefix": ndjson_normalize_sep,
             "record_prefix": ndjson_normalize_sep,
             "sep": ndjson_normalize_sep,
@@ -185,16 +187,16 @@ class LoadFileOperator(BaseOperator):
 
 def load_file(
     input_file: File,
-    output_table: Optional[Table] = None,
-    task_id: Optional[str] = None,
+    output_table: Table | None = None,
+    task_id: str | None = None,
     if_exists: LoadExistStrategy = "replace",
     ndjson_normalize_sep: str = "_",
     use_native_support: bool = True,
-    native_support_kwargs: Optional[Dict] = None,
+    native_support_kwargs: dict | None = None,
     columns_names_capitalization: ColumnCapitalization = "original",
-    enable_native_fallback: Optional[bool] = True,
+    enable_native_fallback: bool | None = True,
     **kwargs: Any,
-) -> "XComArg":
+) -> XComArg:
     """Load a file or bucket into either a SQL table or a pandas dataframe.
 
     :param input_file: File path and conn_id for object stores

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pandas as pd
 from airflow.models import BaseOperator
-
-if TYPE_CHECKING:
-    from airflow.models.xcom_arg import XComArg
+from airflow.models.xcom_arg import XComArg
 
 from airflow.decorators.base import get_unique_task_id
 

--- a/src/astro/sql/operators/merge.py
+++ b/src/astro/sql/operators/merge.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.baseoperator import BaseOperator
@@ -9,8 +11,6 @@ from astro.sql.table import Table
 
 if TYPE_CHECKING:
     from airflow.models.xcom_arg import XComArg
-
-MERGE_COLUMN_TYPE = Union[List[str], Tuple[str], Dict[str, str]]
 
 
 class MergeOperator(BaseOperator):
@@ -34,9 +34,9 @@ class MergeOperator(BaseOperator):
         *,
         target_table: Table,
         source_table: Table,
-        columns: MERGE_COLUMN_TYPE,
+        columns: list[str] | tuple[str] | dict[str, str],
         if_conflicts: MergeConflictStrategy,
-        target_conflict_columns: List[str],
+        target_conflict_columns: list[str],
         task_id: str = "",
         **kwargs: Any,
     ):
@@ -74,11 +74,11 @@ def merge(
     *,
     target_table: Table,
     source_table: Table,
-    columns: MERGE_COLUMN_TYPE,
-    target_conflict_columns: List[str],
+    columns: list[str] | tuple[str] | dict[str, str],
+    target_conflict_columns: list[str],
     if_conflicts: MergeConflictStrategy,
     **kwargs: Any,
-) -> "XComArg":
+) -> XComArg:
     """
     Merge the source table rows into a destination table.
 

--- a/src/astro/sql/operators/merge.py
+++ b/src/astro/sql/operators/merge.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.xcom_arg import XComArg
 
 from astro.constants import MergeConflictStrategy
 from astro.databases import create_database
 from astro.sql.table import Table
-
-if TYPE_CHECKING:
-    from airflow.models.xcom_arg import XComArg
 
 
 class MergeOperator(BaseOperator):

--- a/src/astro/sql/operators/raw_sql.py
+++ b/src/astro/sql/operators/raw_sql.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Union
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, Callable
 
 try:
     from airflow.decorators.base import TaskDecorator, task_decorator_factory
@@ -18,7 +21,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
     and on the SQL statement/function declared by the user.
     """
 
-    def execute(self, context: Dict) -> Any:
+    def execute(self, context: dict) -> Any:
         super().execute(context)
 
         result = self.database_impl.run_sql(
@@ -31,12 +34,12 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
 
 
 def run_raw_sql(
-    python_callable: Optional[Callable] = None,
+    python_callable: Callable | None = None,
     conn_id: str = "",
-    parameters: Optional[Union[Mapping, Iterable]] = None,
-    database: Optional[str] = None,
-    schema: Optional[str] = None,
-    handler: Optional[Callable] = None,
+    parameters: Mapping | Iterable | None = None,
+    database: str | None = None,
+    schema: str | None = None,
+    handler: Callable | None = None,
     **kwargs: Any,
 ) -> TaskDecorator:
     """

--- a/src/astro/sql/operators/transform.py
+++ b/src/astro/sql/operators/transform.py
@@ -1,4 +1,7 @@
-from typing import Any, Callable, Dict, Iterable, Mapping, Optional, Union
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, Callable
 
 try:
     from airflow.decorators.base import TaskDecorator, task_decorator_factory
@@ -15,7 +18,7 @@ class TransformOperator(BaseSQLDecoratedOperator):
     the result into a SQL table.
     """
 
-    def execute(self, context: Dict):
+    def execute(self, context: dict):
         super().execute(context)
 
         self.database_impl.create_schema_if_needed(self.output_table.metadata.schema)
@@ -29,11 +32,11 @@ class TransformOperator(BaseSQLDecoratedOperator):
 
 
 def transform(
-    python_callable: Optional[Callable] = None,
+    python_callable: Callable | None = None,
     conn_id: str = "",
-    parameters: Optional[Union[Mapping, Iterable]] = None,
-    database: Optional[str] = None,
-    schema: Optional[str] = None,
+    parameters: Mapping | Iterable | None = None,
+    database: str | None = None,
+    schema: str | None = None,
     **kwargs: Any,
 ) -> TaskDecorator:
     """

--- a/src/astro/sql/table.py
+++ b/src/astro/sql/table.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import random
 import string
 from dataclasses import dataclass, field, fields
-from typing import List, Optional
 
 from sqlalchemy import Column, MetaData
 
@@ -17,8 +18,8 @@ class Metadata:
     """
 
     # This property is used by several databases, including: Postgres, Snowflake and BigQuery ("namespace")
-    schema: Optional[str] = None
-    database: Optional[str] = None
+    schema: str | None = None
+    database: str | None = None
 
     def is_empty(self) -> bool:
         """Check if all the fields are None."""
@@ -45,7 +46,7 @@ class Table:
     name: str = ""
     _name: str = field(init=False, repr=False, default="")
     metadata: Metadata = field(default_factory=Metadata)
-    columns: List[Column] = field(default_factory=list)
+    columns: list[Column] = field(default_factory=list)
     temp: bool = False
 
     def __post_init__(self) -> None:
@@ -69,7 +70,7 @@ class Table:
 
         return unique_id
 
-    def create_similar_table(self) -> "Table":
+    def create_similar_table(self) -> Table:
         """
         Create a new table with a unique name but with the same metadata.
         """

--- a/src/astro/utils/path.py
+++ b/src/astro/utils/path.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import pathlib
-from typing import Any, Dict
+from typing import Any
 
 
 def get_module_dot_notation(module_path: pathlib.Path) -> str:
@@ -18,7 +20,7 @@ def get_module_dot_notation(module_path: pathlib.Path) -> str:
 
 def get_dict_with_module_names_to_dot_notations(
     base_path: pathlib.Path,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """
     Given a directory, recursively identify which modules exist within it
     (ignoring __init__.py & base.py) and create a dictionary which has module names

--- a/src/astro/utils/table.py
+++ b/src/astro/utils/table.py
@@ -1,10 +1,10 @@
 import inspect
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Optional
 
 from astro.sql.table import Table
 
 
-def _pull_first_table_from_parameters(parameters: Dict) -> Optional[Table]:
+def _pull_first_table_from_parameters(parameters: dict) -> Optional[Table]:
     """
     When trying to "magically" determine the context of a decorator, we will try to find the first table.
     This function attempts this by checking parameters
@@ -25,7 +25,7 @@ def _pull_first_table_from_parameters(parameters: Dict) -> Optional[Table]:
 
 
 def _pull_first_table_from_op_kwargs(
-    op_kwargs: Dict, python_callable: Callable
+    op_kwargs: dict, python_callable: Callable
 ) -> Optional[Table]:
     """
     When trying to "magically" determine the context of a decorator, we will try to find the first table.
@@ -48,7 +48,7 @@ def _pull_first_table_from_op_kwargs(
     return first_table
 
 
-def _find_first_table_from_op_args(op_args: Tuple) -> Optional[Table]:
+def _find_first_table_from_op_args(op_args: tuple) -> Optional[Table]:
     """
     When trying to "magically" determine the context of a decorator, we will try to find the first table.
     This function attempts this by checking op_args
@@ -71,7 +71,7 @@ def _find_first_table_from_op_args(op_args: Tuple) -> Optional[Table]:
 
 
 def find_first_table(
-    op_args: Tuple, op_kwargs: Dict, python_callable: Callable, parameters: Dict
+    op_args: tuple, op_kwargs: dict, python_callable: Callable, parameters: dict
 ) -> Optional[Table]:
     """
     When we create our SQL operation, we run with the assumption that the first table given is the "main table".


### PR DESCRIPTION
Details: https://peps.python.org/pep-0563/ and https://discuss.python.org/t/type-annotations-pep-649-and-pep-563/11363/20

tl_dr: This PEP lazy evaluates Annotations so they are not evaluated at parse time and allows forward references as well.

This also includes https://peps.python.org/pep-0604/ which allows writing §typing.Union[int, str]` as `int | str` and includes https://peps.python.org/pep-0585/ which allows us to write `def f(x: List[str]) -> None` to `def f(x: list[str]) -> None`

