### PR TITLE
Update query for getting bigquery table schema

### DIFF
--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -101,8 +101,8 @@ def test_bigquery_create_table_with_columns(database_table_fixture):
 
     # Looking for specific columns in INFORMATION_SCHEMA.COLUMNS as Bigquery can add/remove columns in the table.
     statement = (
-        f"SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM {table.metadata.schema}"
-        f".INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
+        f"SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE "
+        f"FROM {table.metadata.schema}.INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
     )
     response = database.run_sql(statement)
     assert response.first() is None

--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -99,7 +99,11 @@ def test_bigquery_create_table_with_columns(database_table_fixture):
     """Test table creation with columns data"""
     database, table = database_table_fixture
 
-    statement = f"SELECT * FROM {table.metadata.schema}.INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
+    # Looking for specific columns in INFORMATION_SCHEMA.COLUMNS as Bigquery can add/remove columns in the table.
+    statement = (
+        f"SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE FROM {table.metadata.schema}"
+        f".INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
+    )
     response = database.run_sql(statement)
     assert response.first() is None
 
@@ -112,36 +116,15 @@ def test_bigquery_create_table_with_columns(database_table_fixture):
         f"{table.metadata.schema}",
         f"{table.name}",
         "id",
-        1,
-        "NO",
         "INT64",
-        "NEVER",
-        None,
-        None,
-        "NO",
-        None,
-        "NO",
-        "NO",
-        None,
-        "NULL",
     )
+
     assert rows[1] == (
         "astronomer-dag-authoring",
         f"{table.metadata.schema}",
         f"{table.name}",
         "name",
-        2,
-        "NO",
         "STRING(60)",
-        "NEVER",
-        None,
-        None,
-        "NO",
-        None,
-        "NO",
-        "NO",
-        None,
-        "NULL",
     )
 
 


### PR DESCRIPTION
# Description
## What is the current behavior?
There is a failing test case in CI - test_bigquery_create_table_with_columns

Can be because of PR - https://github.com/astronomer/astro-sdk/pull/641#issuecomment-1214909847
Action run failure - https://github.com/astronomer/astro-sdk/runs/7830499547?check_suite_focus=true

Astro: 1.0.0b1

closes: #660

## What is the new behavior?
Bigquery added an extra col in the INFORMATION_SCHEMA.COLUMNS and the test broke in CI since we checked for the entire cols involved. Now we are only looking for specific columns, this should make the test more robust.

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Created tests that fail without the change (if possible)
