### PR TITLE
Rename project from astro-sdk to astro-sdk-python

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ with open("../src/astro/__init__.py") as f:
         if "__version__" in current_line:
             __version__ = current_line.split(" ")[-1]
 
-project = "astro-sdk"
+project = "astro-sdk-python"
 copyright = "2022, Astronomer inc."  # noqa
 author = "Astronomer inc."
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root ``toctree`` directive.
 
-Welcome to astro-sdk's documentation!
-=====================================
+Welcome to astro-sdk-python's documentation!
+============================================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
# Description
## What is the current behavior?
Rename astro-sdk to astro-sdk-python for Readthedocs

closes: #654

## What is the new behavior?
Renamed the project to `astro-sdk-python`

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Extended the README / documentation, if necessary
