### PR TITLE
Make default operator task_ids consistent

### DIFF
--- a/src/astro/sql/operators/cleanup.py
+++ b/src/astro/sql/operators/cleanup.py
@@ -59,7 +59,7 @@ class CleanupOperator(BaseOperator):
     ):
         self.tables_to_cleanup = tables_to_cleanup or []
         self.run_immediately = run_sync_mode
-        task_id = task_id or get_unique_task_id("_cleanup")
+        task_id = task_id or get_unique_task_id("cleanup")
 
         super().__init__(
             task_id=task_id, retries=retries, retry_delay=retry_delay, **kwargs

--- a/src/astro/sql/operators/drop.py
+++ b/src/astro/sql/operators/drop.py
@@ -22,7 +22,7 @@ class DropTableOperator(BaseOperator):
         **kwargs,
     ):
         self.table = table
-        task_id = task_id or get_unique_task_id("_drop")
+        task_id = task_id or get_unique_task_id("drop")
         super().__init__(
             task_id=task_id,
             **kwargs,

--- a/src/astro/sql/operators/export_file.py
+++ b/src/astro/sql/operators/export_file.py
@@ -91,7 +91,7 @@ def export_file(
     :param task_id: task id, optional
     """
 
-    task_id = task_id if task_id is not None else get_unique_task_id("export_file")
+    task_id = task_id or get_unique_task_id("export_file")
 
     return ExportFileOperator(
         task_id=task_id,

--- a/src/astro/sql/operators/export_file.py
+++ b/src/astro/sql/operators/export_file.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, Union
 
 import pandas as pd
+from airflow.decorators.base import get_unique_task_id
 from airflow.models import BaseOperator
 from airflow.models.xcom_arg import XComArg
 
@@ -8,7 +9,6 @@ from astro.constants import ExportExistsStrategy
 from astro.databases import create_database
 from astro.files import File
 from astro.sql.table import Table
-from astro.utils.task_id_helper import get_task_id
 
 
 class ExportFileOperator(BaseOperator):
@@ -91,9 +91,7 @@ def export_file(
     :param task_id: task id, optional
     """
 
-    task_id = (
-        task_id if task_id is not None else get_task_id("export_file", output_file.path)
-    )
+    task_id = task_id if task_id is not None else get_unique_task_id("export_file")
 
     return ExportFileOperator(
         task_id=task_id,

--- a/src/astro/sql/operators/load_file.py
+++ b/src/astro/sql/operators/load_file.py
@@ -6,13 +6,14 @@ from airflow.models import BaseOperator
 if TYPE_CHECKING:
     from airflow.models.xcom_arg import XComArg
 
+from airflow.decorators.base import get_unique_task_id
+
 from astro import settings
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
 from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.sql.table import Table
-from astro.utils.task_id_helper import get_task_id
 
 
 class LoadFileOperator(BaseOperator):
@@ -211,7 +212,7 @@ def load_file(
 
     # Note - using path for task id is causing issues as it's a pattern and
     # contain chars like - ?, * etc. Which are not acceptable as task id.
-    task_id = task_id if task_id is not None else get_task_id("load_file", "")
+    task_id = task_id if task_id is not None else get_unique_task_id("load_file")
 
     return LoadFileOperator(
         task_id=task_id,

--- a/src/astro/sql/operators/merge.py
+++ b/src/astro/sql/operators/merge.py
@@ -51,7 +51,7 @@ class MergeOperator(BaseOperator):
             )
         self.columns = columns or {}
         self.if_conflicts = if_conflicts
-        task_id = task_id or get_unique_task_id("_merge")
+        task_id = task_id or get_unique_task_id("merge")
 
         super().__init__(task_id=task_id, **kwargs)
 

--- a/tests/sql/operators/test_export_file.py
+++ b/tests/sql/operators/test_export_file.py
@@ -325,9 +325,9 @@ def test_unique_task_id_for_same_path(
     test_utils.run_dag(sample_dag)
 
     assert tasks[0].operator.task_id != tasks[1].operator.task_id
-    assert tasks[0].operator.task_id == f"export_file_{file_name.replace('.', '_')}"
-    assert tasks[1].operator.task_id == f"export_file_{file_name.replace('.', '_')}__1"
-    assert tasks[2].operator.task_id == f"export_file_{file_name.replace('.', '_')}__2"
+    assert tasks[0].operator.task_id == "export_file"
+    assert tasks[1].operator.task_id == "export_file__1"
+    assert tasks[2].operator.task_id == "export_file__2"
     assert tasks[3].operator.task_id == "task_id"
 
     os.remove(OUTPUT_FILE_PATH)

--- a/tests/sql/operators/test_load_file.py
+++ b/tests/sql/operators/test_load_file.py
@@ -228,8 +228,8 @@ def test_unique_task_id_for_same_path(sample_dag):
     test_utils.run_dag(sample_dag)
 
     assert tasks[0].operator.task_id != tasks[1].operator.task_id
-    assert tasks[1].operator.task_id == "load_file___1"
-    assert tasks[2].operator.task_id == "load_file___2"
+    assert tasks[1].operator.task_id == "load_file__1"
+    assert tasks[2].operator.task_id == "load_file__2"
     assert tasks[3].operator.task_id == "task_id"
 
 

--- a/tests/sql/operators/utils.py
+++ b/tests/sql/operators/utils.py
@@ -71,12 +71,12 @@ def run_dag(dag: DAG, account_for_cleanup_failure=False):
             raise b
         failed_tasks = b.ti_status.failed
 
-        if len(failed_tasks) != 1 or list(failed_tasks)[0].task_id != "_cleanup":
+        if len(failed_tasks) != 1 or list(failed_tasks)[0].task_id != "cleanup":
             raise b
         ti_key = list(failed_tasks)[0]
 
         # Cleanup now that everything is done
-        ti = TaskInstance(task=dag.get_task("_cleanup"), run_id=ti_key.run_id)
+        ti = TaskInstance(task=dag.get_task("cleanup"), run_id=ti_key.run_id)
         ti = ti.task.execute({"ti": ti, "dag_run": ti.get_dagrun()})
 
 


### PR DESCRIPTION
# Description
## What is the current behavior?
At the moment, if the user does not define `task_id`, we are naming tasks inconsistently across different operators and decorators. Some are prefixed or suffixed with `_`, others are not.


closes: #579

## What is the new behavior?
* By default, name based on the functionality, without `_`, eg. `load_file` 
* If the name is already used by another task, suffix with `_` and a unique identifier - used `get_unique_task_id` which always generates a unique task id for tasks.

## Does this introduce a breaking change?
Nope

### Checklist
- [x] Created tests that fail without the change
