### PR TITLE
Add getting-started dag to example dags

### DIFF
--- a/example_dags/astro_orders.py
+++ b/example_dags/astro_orders.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+
+from airflow.models import DAG
+from pandas import DataFrame
+
+from astro import sql as aql
+from astro.files import File
+from astro.sql.table import Table
+
+S3_FILE_PATH = "s3://tmp9"
+S3_CONN_ID = "aws_default"
+SNOWFLAKE_CONN_ID = "snowflake_conn"
+SNOWFLAKE_ORDERS = "orders_table"
+SNOWFLAKE_FILTERED_ORDERS = "filtered_table"
+SNOWFLAKE_JOINED = "joined_table"
+SNOWFLAKE_CUSTOMERS = "customers_table"
+SNOWFLAKE_REPORTING = "reporting_table"
+
+
+@aql.transform
+def filter_orders(input_table: Table):
+    return "SELECT * FROM {{input_table}} WHERE amount > 150"
+
+
+@aql.transform
+def join_orders_customers(filtered_orders_table: Table, customers_table: Table):
+    return """SELECT c.customer_id, customer_name, order_id, purchase_date, amount, type
+    FROM {{filtered_orders_table}} f JOIN {{customers_table}} c
+    ON f.customer_id = c.customer_id"""
+
+
+@aql.dataframe
+def transform_dataframe(df: DataFrame):
+    purchase_dates = df.loc[:, "purchase_date"]
+    print("purchase dates:", purchase_dates)
+    return purchase_dates
+
+
+dag = DAG(
+    dag_id="astro_orders",
+    start_date=datetime(2019, 1, 1),
+    schedule_interval="@daily",
+    catchup=False,
+)
+
+with dag:
+    # Extract a file with a header from S3 into a temporary Table, referenced by the
+    # variable `orders_data`
+    orders_data = aql.load_file(
+        # data file needs to have a header row
+        input_file=File(
+            path=S3_FILE_PATH + "/orders_data_header.csv", conn_id=S3_CONN_ID
+        ),
+        output_table=Table(conn_id=SNOWFLAKE_CONN_ID),
+    )
+
+    # Create a Table object for customer data in our Snowflake database
+    customers_table = Table(
+        name=SNOWFLAKE_CUSTOMERS,
+        conn_id=SNOWFLAKE_CONN_ID,
+    )
+
+    # Filter the orders data and then join with the customer table,
+    # saving the output into a temporary table referenced by the Table instance `joined_data`
+    joined_data = join_orders_customers(filter_orders(orders_data), customers_table)
+
+    # Merge the joined data into our reporting table, based on the order_id .
+    # If there's a conflict in the customer_id or customer_name then use the ones from
+    # the joined data
+    reporting_table = aql.merge(
+        target_table=Table(
+            name=SNOWFLAKE_REPORTING,
+            conn_id=SNOWFLAKE_CONN_ID,
+        ),
+        source_table=joined_data,
+        target_conflict_columns=["order_id"],
+        columns=["customer_id", "customer_name"],
+        if_conflicts="update",
+    )
+
+    purchase_dates = transform_dataframe(reporting_table)
+
+    # Delete temporary and unnamed tables created by `load_file` and `transform`, in this example
+    # both `orders_data` and `joined_data`
+    aql.cleanup()

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -61,6 +61,7 @@ def session():
         "example_load_file",
         "example_transform",
         "example_merge_bigquery",
+        "astro_orders",
     ],
 )
 def test_example_dag(session, dag_id):


### PR DESCRIPTION
# Description
## What is the current behavior?
Right now we have to manually check for the breaking changes in dag listed in https://github.com/astronomer/astro-sdk/blob/main/docs/getting-started/GETTING_STARTED.md

closes: #664 


## What is the new behavior?
Add 'astro_orders' das as part of example dags so we don't have to manually check for breaking changes.

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests that fail without the change (if possible)
