### PR TITLE
Release 0.11.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.1
+
+Bug fix:
+* Pass operator kwargs to dataframe decorator [#630](https://github.com/astronomer/astro-sdk/issues/630)
+
+
 ## 0.11.0
 
 Feature:

--- a/src/astro/__init__.py
+++ b/src/astro/__init__.py
@@ -1,6 +1,6 @@
 """A decorator that allows users to run SQL queries natively in Airflow."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 
 # The following line is an import work-around to avoid raising a circular dependency issue related to `create_database`


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, we are having the following bug in AstroSDK.

issue - https://github.com/astronomer/astro-sdk/issues/630

closes: #669 

## What is the new behavior?
Create a release with [commit](https://github.com/astronomer/astro-sdk/commit/2b9a3dd8fb8ad5f3e342619c986979592641b8a5) which is the fix for the issue.

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Bumped the version
- [X] Added change logs
