### PR TITLE
Add example for loading from S3 and GCS via file patterns

### DIFF
--- a/docs/astro/sql/operators/load_file.rst
+++ b/docs/astro/sql/operators/load_file.rst
@@ -184,21 +184,21 @@ Patterns in file path
 
 ``load_file`` can resolve patterns in file path. There are three types of patterns supported based on the :ref:`file_location`
 
-#. **Local** - On local we support glob pattern - https://docs.python.org/3/library/glob.html
+#. **Local** - On local we support glob pattern - `glob doc <https://docs.python.org/3/library/glob.html>`_
 
     .. literalinclude:: ../../../../example_dags/example_load_file.py
        :language: python
        :start-after: [START load_file_example_10]
        :end-before: [END load_file_example_10]
 
-#. **S3** - prefix in file path - https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html
+#. **S3** - prefix in file path - `S3 doc <https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html>`_
 
     .. literalinclude:: ../../../../example_dags/example_load_file.py
        :language: python
        :start-after: [START load_file_example_11]
        :end-before: [END load_file_example_11]
 
-#. **GCS** - prefix in file path - https://cloud.google.com/storage/docs/listing-objects
+#. **GCS** - prefix in file path - `GCS doc <https://cloud.google.com/storage/docs/listing-objects>`_
 
     .. literalinclude:: ../../../../example_dags/example_load_file.py
        :language: python

--- a/docs/astro/sql/operators/load_file.rst
+++ b/docs/astro/sql/operators/load_file.rst
@@ -199,7 +199,7 @@ Load file can also resolve patterns in file path, there are three types of patte
        :start-after: [START load_file_example_11]
        :end-before: [END load_file_example_11]
 
-#. **GCS** - prefix and wildcard in file path - https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames
+#. **GCS** - prefix in file path - https://cloud.google.com/storage/docs/listing-objects
 
     .. literalinclude:: ../../../../example_dags/example_load_file.py
        :language: python

--- a/docs/astro/sql/operators/load_file.rst
+++ b/docs/astro/sql/operators/load_file.rst
@@ -186,13 +186,25 @@ Patterns in File path
 Load file can also resolve patterns in file path, there are three types of patterns supported by load file based on the :ref:`file_location`
 
 #. **Local** - On local we support glob pattern - https://docs.python.org/3/library/glob.html
-#. **S3** - prefix in file path - https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html
-#. **GCS** - prefix and wildcard in file path - https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames
 
     .. literalinclude:: ../../../../example_dags/example_load_file.py
        :language: python
        :start-after: [START load_file_example_10]
        :end-before: [END load_file_example_10]
+
+#. **S3** - prefix in file path - https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_11]
+       :end-before: [END load_file_example_11]
+
+#. **GCS** - prefix and wildcard in file path - https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_12]
+       :end-before: [END load_file_example_12]
 
 
 Inferring File Type

--- a/example_dags/example_load_file.py
+++ b/example_dags/example_load_file.py
@@ -128,4 +128,27 @@ with dag:
         ),
     )
     # [END load_file_example_10]
+
+    # [START load_file_example_11]
+    aql.load_file(
+        input_file=File(
+            "s3://astro-sdk/sample_pattern", conn_id="aws_conn", filetype=FileType.CSV
+        ),
+        output_table=Table(conn_id="bigquery", metadata=Metadata(schema="astro")),
+        use_native_support=False,
+    )
+    # [END load_file_example_11]
+
+    # [START load_file_example_12]
+    aql.load_file(
+        input_file=File(
+            "gs://astro-sdk/workspace/sample_pattern",
+            conn_id="bigquery",
+            filetype=FileType.CSV,
+        ),
+        output_table=Table(conn_id="bigquery", metadata=Metadata(schema="astro")),
+        use_native_support=False,
+    )
+    # [END load_file_example_12]
+
     aql.cleanup()


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, there are no examples provided for loading via patterns in S3 and GCS.

closes: #674

## What is the new behavior?
Add examples provided for loading via patterns in S3 and GCS.

## Does this introduce a breaking change?
Nope

### Checklist
- [X] All checks and tests in the CI should pass
- [X] Added example should be part of example dags
