### PR TITLE
Create a transform_file operator

### DIFF
--- a/src/astro/sql/__init__.py
+++ b/src/astro/sql/__init__.py
@@ -6,5 +6,5 @@ from astro.sql.operators.export_file import ExportFileOperator, export_file
 from astro.sql.operators.load_file import LoadFileOperator, load_file
 from astro.sql.operators.merge import MergeOperator, merge
 from astro.sql.operators.raw_sql import RawSQLOperator, run_raw_sql
-from astro.sql.operators.transform import TransformOperator, transform
+from astro.sql.operators.transform import TransformOperator, transform, transform_file
 from astro.sql.table import Metadata, Table

--- a/src/astro/sql/operators/base_decorator.py
+++ b/src/astro/sql/operators/base_decorator.py
@@ -109,8 +109,8 @@ class BaseSQLDecoratedOperator(DecoratedOperator):
                 self.sql, self.parameters = returned_value
             else:
                 self.sql = returned_value
-                self.parameters = {}
-        elif self.sql.endswith(".sql"):
+                self.parameters = self.parameters or {}
+        if self.sql.endswith(".sql"):
             with open(self.sql) as file:
                 self.sql = file.read().replace("\n", " ")
 

--- a/src/astro/sql/operators/transform.py
+++ b/src/astro/sql/operators/transform.py
@@ -107,7 +107,7 @@ def transform_file(
     database: Optional[str] = None,
     schema: Optional[str] = None,
     **kwargs: Any,
-) -> "XComArg":
+) -> XComArg:
     """
     :param file_path: File path for the SQL file you would like to parse. Can be an absolute path, or you can use a
         relative path if the `template_searchpath` variable is set in your DAG

--- a/src/astro/sql/operators/transform.py
+++ b/src/astro/sql/operators/transform.py
@@ -103,9 +103,9 @@ def transform(
 def transform_file(
     file_path: str,
     conn_id: str = "",
-    parameters: Optional[Union[Mapping, Iterable]] = None,
-    database: Optional[str] = None,
-    schema: Optional[str] = None,
+    parameters: Mapping | Iterable | None = None,
+    database: str | None = None,
+    schema: str | None = None,
     **kwargs: Any,
 ) -> XComArg:
     """

--- a/src/astro/sql/operators/transform.py
+++ b/src/astro/sql/operators/transform.py
@@ -110,7 +110,7 @@ def transform_file(
 ) -> "XComArg":
     """
     :param file_path: File path for the SQL file you would like to parse. Can be an absolute path, or you can use a
-    relative path if the `template_searchpath` variable is set in your DAG
+        relative path if the `template_searchpath` variable is set in your DAG
     :param conn_id: Connection ID for the database you want to connect to. If you do not pass in a value for this object
         we can infer the connection ID from the first table passed into the python_callable function.
         (required if there are no table arguments)

--- a/src/astro/sql/operators/transform.py
+++ b/src/astro/sql/operators/transform.py
@@ -9,6 +9,8 @@ except ImportError:
     from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
+from airflow.models.xcom_arg import XComArg
+
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 
 
@@ -96,3 +98,41 @@ def transform(
         decorated_operator_class=TransformOperator,
         **kwargs,
     )
+
+
+def transform_file(
+    file_path: str,
+    conn_id: str = "",
+    parameters: Optional[Union[Mapping, Iterable]] = None,
+    database: Optional[str] = None,
+    schema: Optional[str] = None,
+    **kwargs: Any,
+) -> "XComArg":
+    """
+    :param file_path: File path for the SQL file you would like to parse. Can be an absolute path, or you can use a
+    relative path if the `template_searchpath` variable is set in your DAG
+    :param conn_id: Connection ID for the database you want to connect to. If you do not pass in a value for this object
+        we can infer the connection ID from the first table passed into the python_callable function.
+        (required if there are no table arguments)
+    :param parameters: parameters to pass into the SQL query
+    :param database: Database within the SQL instance you want to access. If left blank we will default to the
+        table.metatadata.database in the first Table passed to the function (required if there are no table arguments)
+    :param schema: Schema within the SQL instance you want to access. If left blank we will default to the
+        table.metatadata.schema in the first Table passed to the function (required if there are no table arguments)
+    :param kwargs: Any keyword arguments supported by the BaseOperator is supported (e.g ``queue``, ``owner``)
+    :return: Transform functions return a ``Table`` object that can be passed to future tasks.
+        This table will be either an auto-generated temporary table,
+        or will overwrite a table given in the `output_table` parameter.
+    """
+
+    @transform(
+        conn_id=conn_id,
+        parameters=parameters,
+        database=database,
+        schema=schema,
+        **kwargs,
+    )
+    def transform_file_func(file_path: str):
+        return file_path
+
+    return transform_file_func(file_path)

--- a/tests/sql/operators/transform/test.sql
+++ b/tests/sql/operators/transform/test.sql
@@ -1,0 +1,5 @@
+SELECT Title, Rating
+FROM {{ input_table }}
+WHERE Genre1=='Animation'
+ORDER BY Rating desc
+LIMIT 5;

--- a/tests/sql/operators/transform/test_transform.py
+++ b/tests/sql/operators/transform/test_transform.py
@@ -1,6 +1,5 @@
 import pathlib
 
-import pandas
 import pandas as pd
 import pytest
 from airflow.decorators import task
@@ -192,7 +191,7 @@ def test_transform_with_file(database_table_fixture, sample_dag):
     database, imdb_table = database_table_fixture
 
     @aql.dataframe
-    def validate(df: pandas.DataFrame):
+    def validate(df: pd.DataFrame):
         assert df.columns.tolist() == ["title", "rating"]
 
     with sample_dag:

--- a/tests/sql/operators/transform/test_transform.py
+++ b/tests/sql/operators/transform/test_transform.py
@@ -1,5 +1,6 @@
 import pathlib
 
+import pandas
 import pandas as pd
 import pytest
 from airflow.decorators import task
@@ -160,6 +161,47 @@ def test_transform_with_templated_table_name(database_table_fixture, sample_dag)
         target_table = Table(name="test_is_{{ ds_nodash }}", conn_id="sqlite_default")
 
         top_five_animations(input_table=imdb_table, output_table=target_table)
+    test_utils.run_dag(sample_dag)
+
+    expected_target_table = target_table.create_similar_table()
+    expected_target_table.name = "test_is_True"
+    database.drop_table(expected_target_table)
+    assert not database.table_exists(expected_target_table)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.SQLITE,
+            "file": File(
+                "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb.csv"
+            ),
+            "table": Table(name="imdb", conn_id="sqlite_default"),
+        }
+    ],
+    indirect=True,
+    ids=["sqlite"],
+)
+def test_transform_with_file(database_table_fixture, sample_dag):
+    """Test table creation via select statement in a SQL file"""
+    import pathlib
+
+    CWD = pathlib.Path(__file__).parent
+    database, imdb_table = database_table_fixture
+
+    @aql.dataframe
+    def validate(df: pandas.DataFrame):
+        assert df.columns.tolist() == ["title", "rating"]
+
+    with sample_dag:
+        target_table = Table(name="test_is_{{ ds_nodash }}", conn_id="sqlite_default")
+        table_from_query = aql.transform_file(
+            file_path=str(pathlib.Path(CWD).parents[0]) + "/transform/test.sql",
+            parameters={"input_table": imdb_table, "output_table": target_table},
+        )
+        validate(table_from_query)
     test_utils.run_dag(sample_dag)
 
     expected_target_table = target_table.create_similar_table()

--- a/tests/sql/operators/transform/test_transform.py
+++ b/tests/sql/operators/transform/test_transform.py
@@ -186,7 +186,7 @@ def test_transform_with_templated_table_name(database_table_fixture, sample_dag)
 )
 def test_transform_with_file(database_table_fixture, sample_dag):
     """Test table creation via select statement in a SQL file"""
-    import pathlib
+    import pathlib  # skipcq: PYL-W0404
 
     CWD = pathlib.Path(__file__).parent
     database, imdb_table = database_table_fixture


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently there is no clean way to run `aql.transform` with a SQL file instead of a python function. This is highly limiting as SQL developers would not want to craft complex queries inside of a python function.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?

The new behavior is that we will now have an `aql.transform_file` function that can be called at runtime in the DAG. This is not a decorator, but is instead a python function that returns a task (similar to operators like `drop` and `merge`).

Instead of using function parameters, users would instead insert tables via the `parameters` kwarg.

It would look like this

```python
import pathlib

CWD = pathlib.Path(__file__).parent

@aql.dataframe
def validate(df: pandas.DataFrame):
    assert df.columns.tolist() == ["title", "rating"]

with dag:
    target_table = Table(name="test_is_{{ ds_nodash }}", conn_id="sqlite_default")
    table_from_query = aql.transform_file(
        file_path=str(pathlib.Path(CWD).parents[0]) + "/transform/test.sql",
        parameters={"input_table": imdb_table, "output_table": target_table},
    )
    validate(table_from_query)
```

This function also offers a nice "less magic" endpoint for astro-sdk users who might not yet be comfortable with pytho decorators.

## Does this introduce a breaking change?

No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
