### PR TITLE
Provide Google Cloud Credentials env var for bigquery

### DIFF
--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -108,7 +108,8 @@ class BigqueryDatabase(BaseDatabase):
     def sqlalchemy_engine(self) -> Engine:
         """Return SQAlchemy engine."""
         uri = self.hook.get_uri()
-        return create_engine(uri)
+        with self.hook.provide_gcp_credential_file_as_context():
+            return create_engine(uri)
 
     @property
     def default_metadata(self) -> Metadata:

--- a/tests/databases/test_bigquery.py
+++ b/tests/databases/test_bigquery.py
@@ -48,13 +48,17 @@ def test_create_database(conn_id):
     ],
     ids=SUPPORTED_CONN_IDS,
 )
-def test_bigquery_sqlalchemy_engine(conn_id, expected_uri):
+@mock.patch(
+    "astro.databases.google.bigquery.BigQueryHook.provide_gcp_credential_file_as_context"
+)
+def test_bigquery_sqlalchemy_engine(mock_credentials, conn_id, expected_uri):
     """Test getting a bigquery based sqla engine."""
     database = BigqueryDatabase(conn_id)
     engine = database.sqlalchemy_engine
     assert isinstance(engine, sqlalchemy.engine.base.Engine)
     url = urlparse(str(engine.url))
     assert url.geturl() == expected_uri
+    mock_credentials.assert_called_once_with()
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we have to define the env var `GOOGLE_APPLICATION_CREDENTIALS` to be able to load data to bigquery.

related: #603
closes: #685 

## What is the new behavior?

With the new change, it is no longer required as it now automatically creates the env var under the hood.

## Does this introduce a breaking change?

No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
