### PR TITLE
Handle breaking changes for Snowflake provide version 3.2.0 and 3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ google = [
     "smart-open[gcs]>=5.2.1"
 ]
 snowflake = [
-    "apache-airflow-providers-snowflake==3.2.0",
+    "apache-airflow-providers-snowflake",
     "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
     "snowflake-connector-python[pandas]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ google = [
     "smart-open[gcs]>=5.2.1"
 ]
 snowflake = [
-    "apache-airflow-providers-snowflake",
+    "apache-airflow-providers-snowflake==3.2.0",
     "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
     "snowflake-connector-python[pandas]",
 ]

--- a/src/astro/databases/snowflake.py
+++ b/src/astro/databases/snowflake.py
@@ -511,6 +511,7 @@ class SnowflakeDatabase(BaseDatabase):
             for x in self.hook.run(
                 "SELECT SCHEMA_NAME from information_schema.schemata WHERE LOWER(SCHEMA_NAME) = %(schema_name)s;",
                 parameters={"schema_name": schema.lower()},
+                handler=lambda x: x,
             )
         ]
         return len(created_schemas) == 1


### PR DESCRIPTION
# Description
## What is the current behavior?
CI failing 
https://github.com/astronomer/astro-sdk/runs/7897173351?check_suite_focus=true
https://github.com/astronomer/astro-sdk/runs/7899645838?check_suite_focus=true

closes: #689


## What is the new behavior?
To handle breaking change in apache-airflow-providers-snowflake==3.2.0, we need to pass the handler param to get the rows. But in version apache-airflow-providers-snowflake==3.1.0 if we pass the handler, the provider raises an exception AttributeError 'sfid'. We added the Try Catch statement to handle the issue. 

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Created tests which fail without the change
