### PR TITLE
Expose S3 and GCS `delimiter` parameter for listing objects

### DIFF
--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -24,22 +24,24 @@ class File:
         conn_id: str | None = None,
         filetype: constants.FileType | None = None,
         normalize_config: dict | None = None,
+        delimiter: str | None = None
     ):
         """Init file object which represent a single file in local/object stores
 
         :param path: Path to a file in the filesystem/Object stores
         :param conn_id: Airflow connection ID
         :param filetype: constant to provide an explicit file type
-        :param normalize_config: parameters in dict format of pandas json_normalize() function.
+        :param normalize_config: parameters in dict format of pandas json_normalize() function
+        :param delimiter: the delimiter marks key hierarchy
         """
-        self.location: BaseFileLocation = create_file_location(path, conn_id)
+        self.location: BaseFileLocation = create_file_location(path, conn_id, delimiter)
         self.type = create_file_type(
             path=path, filetype=filetype, normalize_config=normalize_config
         )
 
     @property
     def path(self) -> str:
-        return self.location.path
+        return str(self.location.path)  # ToDo: look into typing issue
 
     @property
     def conn_id(self) -> str | None:
@@ -129,6 +131,7 @@ def resolve_file_path_pattern(
     conn_id: str | None = None,
     filetype: constants.FileType | None = None,
     normalize_config: dict | None = None,
+    delimiter: str | None = None
 ) -> list[File]:
     """get file objects by resolving path_pattern from local/object stores
     path_pattern can be
@@ -140,8 +143,9 @@ def resolve_file_path_pattern(
     :param conn_id: Airflow connection ID
     :param filetype: constant to provide an explicit file type
     :param normalize_config: parameters in dict format of pandas json_normalize() function
+    :param delimiter: the delimiter marks key hierarchy
     """
-    location = create_file_location(path_pattern, conn_id)
+    location = create_file_location(path_pattern, conn_id, delimiter)
     files = [
         File(
             path=path,

--- a/src/astro/files/base.py
+++ b/src/astro/files/base.py
@@ -24,7 +24,7 @@ class File:
         conn_id: str | None = None,
         filetype: constants.FileType | None = None,
         normalize_config: dict | None = None,
-        delimiter: str | None = None
+        delimiter: str | None = None,
     ):
         """Init file object which represent a single file in local/object stores
 
@@ -131,7 +131,7 @@ def resolve_file_path_pattern(
     conn_id: str | None = None,
     filetype: constants.FileType | None = None,
     normalize_config: dict | None = None,
-    delimiter: str | None = None
+    delimiter: str | None = None,
 ) -> list[File]:
     """get file objects by resolving path_pattern from local/object stores
     path_pattern can be

--- a/src/astro/files/locations/__init__.py
+++ b/src/astro/files/locations/__init__.py
@@ -13,7 +13,11 @@ DEFAULT_CONN_TYPE_TO_MODULE_PATH["https"] = DEFAULT_CONN_TYPE_TO_MODULE_PATH["ht
 DEFAULT_CONN_TYPE_TO_MODULE_PATH["gs"] = DEFAULT_CONN_TYPE_TO_MODULE_PATH["gcs"]
 
 
-def create_file_location(path: str, conn_id: Optional[str] = None) -> BaseFileLocation:
+def create_file_location(
+    path: str,
+    conn_id: Optional[str] = None,
+    delimiter: Optional[str] = None,
+) -> BaseFileLocation:
     """
     Location factory method to generate location class
     :param path: Path to a file in the filesystem/Object stores

--- a/src/astro/files/locations/amazon/s3.py
+++ b/src/astro/files/locations/amazon/s3.py
@@ -37,7 +37,9 @@ class S3Location(BaseFileLocation):
         url = urlparse(self.path)
         bucket_name = url.netloc
         prefix = url.path[1:]
-        prefixes = self.hook.list_keys(bucket_name=bucket_name, prefix=prefix)
+        prefixes = self.hook.list_keys(
+            bucket_name=bucket_name, prefix=prefix, delimiter=self.delimiter
+        )
         paths = [
             urlunparse((url.scheme, url.netloc, keys, "", "", "")) for keys in prefixes
         ]

--- a/src/astro/files/locations/base.py
+++ b/src/astro/files/locations/base.py
@@ -16,7 +16,7 @@ class BaseFileLocation(ABC):
 
     template_fields = ("path", "conn_id")
 
-    def __init__(self, path: str, conn_id: str | None = None):
+    def __init__(self, path: str, conn_id: str | None = None, delimiter: str | None = None):
         """
         Manages and provide interface for the operation for all the supported locations.
 
@@ -25,6 +25,7 @@ class BaseFileLocation(ABC):
         """
         self.path: str = path
         self.conn_id: str | None = conn_id
+        self.delimiter: str | None = delimiter
 
     @property
     def hook(self):

--- a/src/astro/files/locations/base.py
+++ b/src/astro/files/locations/base.py
@@ -16,7 +16,9 @@ class BaseFileLocation(ABC):
 
     template_fields = ("path", "conn_id")
 
-    def __init__(self, path: str, conn_id: str | None = None, delimiter: str | None = None):
+    def __init__(
+        self, path: str, conn_id: str | None = None, delimiter: str | None = None
+    ):
         """
         Manages and provide interface for the operation for all the supported locations.
 

--- a/src/astro/files/locations/google/gcs.py
+++ b/src/astro/files/locations/google/gcs.py
@@ -29,7 +29,9 @@ class GCSLocation(BaseFileLocation):
         url = urlparse(self.path)
         bucket_name = url.netloc
         prefix = url.path[1:]
-        prefixes = self.hook.list(bucket_name=bucket_name, prefix=prefix)
+        prefixes = self.hook.list(
+            bucket_name=bucket_name, prefix=prefix, delimiter=self.delimiter
+        )
         paths = [
             urlunparse((url.scheme, url.netloc, keys, "", "", "")) for keys in prefixes
         ]


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, we are not exposing the `delimiter` parameter for pattern resolution for S3 and GCS file locations. Which significantly limits the use of external files.


closes: #690 

## What is the new behavior?
Expose a `delimiter` which then is passed to the upstream API calls.

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Created tests that fail without the change (if possible)
