### PR TITLE
Re-order docs sections

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -72,7 +72,7 @@ This is a faster way for datasets of larger size as there is only one network ca
 .. _templating:
 
 Templating
-~~~~~~~~~~
+----------
 Templating is a powerful concept in Airflow to pass dynamic information into task instances at runtime. Templating in Airflow works exactly the same as templating with Jinja in Python: define your to-be-evaluated code between double curly braces, and the expression will be evaluated at runtime.
 
 The parameter list passed to the decorated function is also added to the context which is used to render template. For example:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,19 +15,21 @@ Welcome to astro-sdk-python's documentation!
 
 .. toctree::
    :maxdepth: 2
-   :caption: Developing Astro SDK
-   :glob:
+   :caption: Guides
+   :titlesonly:
 
-   development/*
-
-   Astro Enhancement Proposals <aep/index>
+   concepts.rst
+   operators.rst
 
 .. toctree::
    :maxdepth: 1
-   :caption: API Reference
+   :caption: Reference
    :glob:
 
    autoapi/*
+   configurations.rst
+   supported_databases.rst
+   supported_file.rst
 
 .. toctree::
    :maxdepth: 1
@@ -37,29 +39,13 @@ Welcome to astro-sdk-python's documentation!
    CHANGELOG.md
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Operators
+   :maxdepth: 2
+   :caption: Developing Astro SDK
    :glob:
 
-   astro/sql/operators/*
-   astro/files/operators/*
+   development/*
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Concepts
-   :glob:
-
-   concepts.rst
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Reference
-   :glob:
-
-   configurations.rst
-   supported_databases.rst
-   supported_file.rst
-
+   Astro Enhancement Proposals <aep/index>
 
 Indices and Tables
 ==================

--- a/docs/operators.rst
+++ b/docs/operators.rst
@@ -1,0 +1,9 @@
+=========
+Operators
+=========
+
+.. toctree::
+   :glob:
+
+   astro/sql/operators/*
+   astro/files/operators/*


### PR DESCRIPTION
This reorders doc sections and groups similar sections.

- Moves dev docs at the end to focus on Concepts and Guides
- Moves references to second last

**Before**:
<img width="529" alt="image" src="https://user-images.githubusercontent.com/8811558/185463753-5fb39a82-d952-407e-9f64-15b5738f3b90.png">


**After**:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/8811558/185463688-a5ee561c-93e6-4780-ad97-950eeae6a9ce.png">

