### PR TITLE
Fix the link for list of operators in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The following are some key functions available in the SDK:
 - `export_file`: export SQL table rows into a destination file
 - `dataframe`: export given SQL table into in-memory Pandas data-frame
 
-For a full list of available operators, see the [SDK reference documentation](https://astro-sdk-python.readthedocs.io/en/latest/astro/sql/operators/append.html).
+For a full list of available operators, see the [SDK reference documentation](https://astro-sdk-python.readthedocs.io/en/stable/operators.html).
 
 ## Documentation
 


### PR DESCRIPTION
We should point users to https://astro-sdk-python.readthedocs.io/en/stable/operators.html and not the "latest" docs. Those docs should be for dev only
