### PR TITLE
Consolidate doc requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,3 @@ build:
 # Build from the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-
-# Explicitly set the version of Python and its requirements
-python:
-  install:
-    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-sphinx-autoapi
-sphinx-rtd-theme
-myst-parser

--- a/noxfile.py
+++ b/noxfile.py
@@ -97,13 +97,7 @@ def build(session: nox.Session) -> None:
 @nox.session(python="3.9")
 def build_docs(session: nox.Session) -> None:
     """Build release artifacts."""
-    session.install("sphinx")
-    session.install("sphinx-view")
-    session.install("sphinx-autoapi")
-    session.install("sphinx-rtd-theme")
-    session.install("myst-parser")
-    # session.install("-e", ".[google]")
-
+    session.install("-e", ".[doc]")
     session.chdir("./docs")
     session.run("make", "html")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ all = [
     "s3fs"
 ]
 doc = [
-    "myst-parser",
+    "myst-parser>=0.17",
     "sphinx>=4.4.0",
     "sphinx-autoapi",
     "sphinx-rtd-theme"


### PR DESCRIPTION
Currently, we have 2-3 places where we put the requirements for docs, this PR consolidates it into `pyproject.toml`