### PR TITLE
Add Apache Airflow to PyPI classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,13 @@ keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: Apache Software License",
+    "Topic :: Database",
+    "Framework :: Apache Airflow",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Topic :: Database",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This will show Python SDK when filtering with Apache Airflow as Framework in classifier

<img width="369" alt="image" src="https://user-images.githubusercontent.com/8811558/185630805-d996eae5-1313-47d8-9f83-5f1f92e14474.png">

https://pypi.org/search/?q=&o=&c=Framework+%3A%3A+Apache+Airflow
