### PR TITLE
Add benchmarking result for Bigquery 10gb datasets

### DIFF
--- a/tests/benchmark/datasets.md
+++ b/tests/benchmark/datasets.md
@@ -20,6 +20,7 @@ Within `gs://astro-sdk/benchmark/`, there are two paths:
 | one_gb     | 1 GB   | ndjson  | 940,000   | 17 (*)  | stackoverflow/stackoverflow_posts_1g.ndjson | Stack Overflow posts sample |
 | five_gb    | 5 GB   | ndjson  | 7,530,243 | 7 (*)   | pypi/*                                      | PyPI downloads sample       |
 | ten_gb     | 10 GB  | ndjson  | 1,263,685 | 9 (*)   | github/github-archive/*                     | Github timeline sample      |
+| ten_gb     | 10 GB  | ndjson  | 9400000 | 17 (*)  | benchmark/trimmed/stackoverflow/output_file.ndjson                  | Github timeline sample      |
 (*) Nested JSON, this number represents just the root-level properties
 
 

--- a/tests/benchmark/results.md
+++ b/tests/benchmark/results.md
@@ -68,7 +68,7 @@ For Machine types: n2-standard-4
 | imdb/title_ratings_10mb.csv                                              | 10MB | 19.40  |
 | stackoverflow/stackoverflow_posts_1g.ndjson                              | 1GB  | 30.26  |
 | trimmed/pypi/*                                                           | 5GB  | 59.90  |
-| gs://astro-sdk/benchmark/trimmed/stackoverflow/10gb/ - 10 Files 1gb each | 10GB |11.88min|
+| gs://astro-sdk/benchmark/trimmed/stackoverflow/10gb/ - 10 Files 1gb each | 10GB |1.94min|
 
 
 

--- a/tests/benchmark/results.md
+++ b/tests/benchmark/results.md
@@ -68,7 +68,7 @@ For Machine types: n2-standard-4
 | imdb/title_ratings_10mb.csv                                              | 10MB | 19.40  |
 | stackoverflow/stackoverflow_posts_1g.ndjson                              | 1GB  | 30.26  |
 | trimmed/pypi/*                                                           | 5GB  | 59.90  |
-| gs://astro-sdk/benchmark/trimmed/stackoverflow/10gb/ - 10 Files 1gb each | 10GB |1.94min|
+| benchmark/trimmed/stackoverflow/output_file.ndjson | 10GB |1.94min|
 
 
 

--- a/tests/benchmark/results.md
+++ b/tests/benchmark/results.md
@@ -61,13 +61,15 @@ For Machine types: n2-standard-4
 
 #### Results post optimization to load files from GCS to Bigquery using BigqueryHook
 
-|Dataset                                    |Size | Duration(seconds)  |
-|-------------------------------------------|-----|--------------------|
-|covid_overview/covid_overview_10kb.csv     |10 KB| 13.57           |
-|tate_britain/artist_data_100kb.csv         |100KB| 16.10          |
-|imdb/title_ratings_10mb.csv                |10MB | 19.40         |
-|stackoverflow/stackoverflow_posts_1g.ndjson|1GB  | 30.26          |
-|trimmed/pypi/*                             |5GB  | 59.90          |
+| Dataset                                                                  | Size | Duration(seconds) |
+|--------------------------------------------------------------------------|------|--------|
+| covid_overview/covid_overview_10kb.csv                                   | 10 KB | 13.57  |
+| tate_britain/artist_data_100kb.csv                                       | 100KB | 16.10  |
+| imdb/title_ratings_10mb.csv                                              | 10MB | 19.40  |
+| stackoverflow/stackoverflow_posts_1g.ndjson                              | 1GB  | 30.26  |
+| trimmed/pypi/*                                                           | 5GB  | 59.90  |
+| gs://astro-sdk/benchmark/trimmed/stackoverflow/10gb/ - 10 Files 1gb each | 10GB |11.88min|
+
 
 
 ## Performance evaluation of loading datasets from GCS with Astro Python SDK 0.11.0 into Snowflake
@@ -176,12 +178,13 @@ Note - These results are generated manually, there is a issue added for the same
 ### Database S3 to Bigquery using native path
 Note - These results are generated manually, there is a issue added for the same [#574](https://github.com/astronomer/astro-sdk/issues/574)
 
-| database   | dataset    | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   |
-|:-----------|:-----------|:-------------|:-------------|:----------------|:------------------|
-| bigquery   | hundred_kb | 2.92min      | 56.57MB      | 41.94ms         | 35.83ms           |
-| bigquery   | one_gb     | 4.25min      | 66.32MB      | 54.88ms         | 48.01ms           |
-| bigquery   | ten_kb     | 2.9min       | 55.51MB      | 40.74ms         | 34.94ms           |
-| bigquery   | ten_mb     | 4.17min      | 57.6MB       | 46.64ms         | 46.83ms           |
+| database   | dataset     | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   |
+|:-----------|:------------|:-------------|:-------------|:----------------|:------------------|
+| bigquery   | hundred_kb  | 2.92min      | 56.57MB      | 41.94ms         | 35.83ms           |
+| bigquery   | one_gb      | 4.25min      | 66.32MB      | 54.88ms         | 48.01ms           |
+| bigquery   | ten_kb      | 2.9min       | 55.51MB      | 40.74ms         | 34.94ms           |
+| bigquery   | ten_mb      | 4.17min      | 57.6MB       | 46.64ms         | 46.83ms           |
+| bigquery   | ten_gb      | 56.68min     | 196.34MB     | 387.29ms        | 448.49ms          |
 
 ### Local to Bigquery using native path
 

--- a/tests/benchmark/results.md
+++ b/tests/benchmark/results.md
@@ -184,7 +184,7 @@ Note - These results are generated manually, there is a issue added for the same
 | bigquery   | one_gb      | 4.25min      | 66.32MB      | 54.88ms         | 48.01ms           |
 | bigquery   | ten_kb      | 2.9min       | 55.51MB      | 40.74ms         | 34.94ms           |
 | bigquery   | ten_mb      | 4.17min      | 57.6MB       | 46.64ms         | 46.83ms           |
-| bigquery   | ten_gb      | 56.68min     | 196.34MB     | 387.29ms        | 448.49ms          |
+| bigquery   | ten_gb      | 15.74min     | 180.74MB     | 208.2ms         | 155.44ms          |
 
 ### Local to Bigquery using native path
 


### PR DESCRIPTION
# Description
## What is the current behavior?
When running benchmarking for 10GB files we faced issues in loading and running benchmarking.

closes: #702

## What is the new behavior?
Added 10GB dataset benchmarking numbers. Added a new dataset that works with big queries.

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Extended the README/documentation, if necessary
