### PR TITLE
Run tests on release branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,12 @@
 name: Build and test astro
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ 'main', 'release-**' ]
   pull_request:
-    branches: [ 'main' ]
+    branches: [ 'main', 'release-**' ]
   # Run on PRs from forks
   pull_request_target:
-    branches: [ 'main' ]
+    branches: [ 'main', 'release-**' ]
     types: ['labeled']
 jobs:
   Markdown-link-check:


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, our tests don't run on PRs that are not from the main, even if it is a release branch because of

https://github.com/astronomer/astro-sdk/blob/main/.github/workflows/ci.yaml#L2-L10

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
close: #672 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Add CI/CD triggers on release branches


## Does this introduce a breaking change?


### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
