### PR TITLE
Add missing filetype argument to "resolve_file_path_pattern" function

### DIFF
--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -308,6 +308,7 @@ class BaseDatabase(ABC):
             input_file.path,
             input_file.conn_id,
             normalize_config=normalize_config,
+            filetype=input_file.type.name,
         )
         self.create_schema_if_needed(output_table.metadata.schema)
         if if_exists == "replace" or not self.table_exists(output_table):


### PR DESCRIPTION
# Description
## What is the current behavior?
When passing the pattern to the load_file operator the filetype is not considered by the pattern resolution function.

closes: #722 

## What is the new behavior?
Pass the new param

## Does this introduce a breaking change?
No

### Checklist
- [X] Created tests that fail without the change (if possible)
- [X] Extended the README / documentation, if necessary
