### PR TITLE
Update the file type in Data transfer job in S3 to BQ

### DIFF
--- a/src/astro/databases/google/bigquery.py
+++ b/src/astro/databases/google/bigquery.py
@@ -419,7 +419,12 @@ class S3ToBigqueryDataTransfer:
         aws = source_file.location.hook.get_credentials()
         self.s3_access_key = aws.access_key
         self.s3_secret_key = aws.secret_key
-        self.s3_file_type = NATIVE_PATHS_SUPPORTED_FILE_TYPES.get(source_file.type.name)
+        file_types_to_bigquery_format = {
+            FileType.CSV: "CSV",
+            FileType.NDJSON: "JSON",
+            FileType.PARQUET: "PARQUET",
+        }
+        self.s3_file_type = file_types_to_bigquery_format.get(source_file.type.name)
 
         self.project_id = project_id
         self.poll_duration = poll_duration


### PR DESCRIPTION
# Description
## What is the current behavior?
We are passing the wrong type for NDJSON file in the Data Transfer job which is created for S3 to Biquery.

closes: #724 

## What is the new behavior?
passed 'JSON' as filetype

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary
