### PR TITLE
Skip folders while processing paths in load_file operator

### DIFF
--- a/src/astro/databases/base.py
+++ b/src/astro/databases/base.py
@@ -323,6 +323,11 @@ class BaseDatabase(ABC):
         # to use the native support to loading multiple files as opposed to iterating
         # here
         for file in input_files:
+
+            # Skip file object with folder paths
+            if file.path.endswith("/"):
+                continue
+
             if use_native_support and self.is_native_load_file_available(
                 source_file=file, target_table=output_table
             ):


### PR DESCRIPTION
# Description
## What is the current behavior?
When load_file is passed patterns paths of S3 the operator is falling.

closes: #733 

## What is the new behavior?
Added a check with skips the folder paths

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary
