### PR TITLE
Install doc requirements for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,10 @@ build:
 # Build from the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc


### PR DESCRIPTION

This PR adds the doc requirements for ReadTheDocs. I faced this when releasing 1.0.1 with Ankit and Utkarsh.

I can verify that this works