### PR TITLE
Limit Google Protobuf for compatibility with bigquery client 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ tests = [
     "sqlalchemy-stubs"  # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
 ]
 google = [
-    "protobuf==3.20.*",
+    "protobuf<=3.20.*",
     "apache-airflow-providers-google>=6.4.0",
     "sqlalchemy-bigquery>=1.3.0",
     "smart-open[gcs]>=5.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ tests = [
     "sqlalchemy-stubs"  # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
 ]
 google = [
-    "protobuf<=3.20.*",
+    "protobuf<=3.20",
     "apache-airflow-providers-google>=6.4.0",
     "sqlalchemy-bigquery>=1.3.0",
     "smart-open[gcs]>=5.2.1"
@@ -74,6 +74,7 @@ all = [
     "apache-airflow-providers-google>=6.4.0",
     "apache-airflow-providers-postgres",
     "apache-airflow-providers-snowflake",
+    "protobuf<=3.20",
     "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]",
     "snowflake-sqlalchemy>=1.2.0,<=1.2.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ tests = [
     "sqlalchemy-stubs"  # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
 ]
 google = [
+    "protobuf==3.20.*",
     "apache-airflow-providers-google>=6.4.0",
     "sqlalchemy-bigquery>=1.3.0",
     "smart-open[gcs]>=5.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ tests = [
     "sqlalchemy-stubs"  # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
 ]
 google = [
-    "protobuf<=3.20",
+    "protobuf<=3.20", # Google bigquery client require protobuf <= 3.20.0. We can remove the limitation when this limitation is removed
     "apache-airflow-providers-google>=6.4.0",
     "sqlalchemy-bigquery>=1.3.0",
     "smart-open[gcs]>=5.2.1"
@@ -79,7 +79,8 @@ all = [
     "snowflake-connector-python[pandas]",
     "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
     "sqlalchemy-bigquery>=1.3.0",
-    "s3fs"
+    "s3fs",
+    "protobuf<=3.20", # Google bigquery client require protobuf <= 3.20.0. We can remove the limitation when this limitation is removed
 ]
 doc = [
     "myst-parser>=0.17",


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The Biquery client does not work well with protobuf > 3.20.0

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #742 
Also fixed in https://github.com/apache/airflow/pull/25886


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Limit `protobuf<=3.20.*` in pyproject.toml

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
