### PR TITLE
[WIP] Update `get_file_list` to accept File object

### DIFF
--- a/example_dags/example_dynamic_task_template.py
+++ b/example_dags/example_dynamic_task_template.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from airflow import DAG
 
 from astro import sql as aql
-from astro.files import get_file_list, File
+from astro.files import File, get_file_list
 from astro.sql.operators.load_file import LoadFileOperator as LoadFile
 from astro.sql.table import Metadata, Table
 

--- a/example_dags/example_dynamic_task_template.py
+++ b/example_dags/example_dynamic_task_template.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from airflow import DAG
 
 from astro import sql as aql
-from astro.files import get_file_list
+from astro.files import get_file_list, File
 from astro.sql.operators.load_file import LoadFileOperator as LoadFile
 from astro.sql.table import Metadata, Table
 
@@ -36,7 +36,7 @@ with DAG(
             conn_id=ASTRO_GCP_CONN_ID,
         ),
         use_native_support=True,
-    ).expand(input_file=get_file_list(path=GCS_BUCKET, conn_id=ASTRO_GCP_CONN_ID))
+    ).expand(input_file=get_file_list(File(path=GCS_BUCKET, conn_id=ASTRO_GCP_CONN_ID)))
 
     # [END howto_operator_get_file_list]
     aql.cleanup()

--- a/src/astro/files/__init__.py
+++ b/src/astro/files/__init__.py
@@ -18,7 +18,7 @@ def check_if_connection_exists(conn_id: str) -> bool:
     return True
 
 
-def get_file_list(path: str, conn_id: str, **kwargs) -> XComArg:
+def get_file_list(file: File, **kwargs) -> XComArg:
     """
     List the file path from the filesystem storage based on given path pattern
 
@@ -26,11 +26,9 @@ def get_file_list(path: str, conn_id: str, **kwargs) -> XComArg:
 
     Supported file pattern: :ref:`file_pattern`
 
-    :param conn_id: Airflow connection id
-    :param path: Path pattern to the file in the filesystem/Object stores
+    :param file: File object a reference to file path pattern and Airflow connection ID
     """
     return ListFileOperator(
-        path=path,
-        conn_id=conn_id,
+        file=file,
         **kwargs,
     ).output

--- a/src/astro/files/operators/files.py
+++ b/src/astro/files/operators/files.py
@@ -12,22 +12,18 @@ class ListFileOperator(BaseOperator):
     """List the file available at path and storage
 
     :param task_id: The task id for uniquely identify a task in a DAG
-    :param path: A path pattern for which you want to get a list of file
-    :param conn_id: connection id for the services
+    :param file: File object a reference to file path pattern and Airflow connection ID
     """
 
-    template_fields = ("path", "conn_id")
-
-    def __init__(self, path: str, conn_id: str, task_id: str = "", **kwargs):
+    def __init__(self, file: File, task_id: str = "", **kwargs):
         task_id = task_id or get_unique_task_id(
             "get_file_list", dag=kwargs.get("dag"), task_group=kwargs.get("task_group")
         )
-        self.path = path
-        self.conn_id = conn_id
+        self.file = file
         super().__init__(task_id=task_id, **kwargs)
 
     def execute(self, context: Context) -> Any:  # skipcq: PYL-W0613
-        location = create_file_location(self.path, self.conn_id)
+        location = create_file_location(self.file.path, self.file.conn_id)
         # Get list of files excluding folders
         return [
             File(path=path, conn_id=location.conn_id)

--- a/tests/files/operators/test_files.py
+++ b/tests/files/operators/test_files.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from airflow.models.connection import Connection
 
+from astro.files import File
 from astro.files.operators.files import ListFileOperator
 
 
@@ -11,7 +12,7 @@ def test_get_file_list_execute_local():
     CWD = pathlib.Path(__file__).parent
     LOCAL_FILEPATH = f"{CWD}/../../example_dags/data/"
 
-    op = ListFileOperator(task_id="task_id", conn_id="conn_id", path=LOCAL_FILEPATH)
+    op = ListFileOperator(task_id="task_id", file=File(conn_id="conn_id", path=LOCAL_FILEPATH))
     actual = op.execute(None)
     assert actual == [str(file) for file in pathlib.Path(LOCAL_FILEPATH).rglob("*")]
 

--- a/tests/files/operators/test_files.py
+++ b/tests/files/operators/test_files.py
@@ -12,7 +12,9 @@ def test_get_file_list_execute_local():
     CWD = pathlib.Path(__file__).parent
     LOCAL_FILEPATH = f"{CWD}/../../example_dags/data/"
 
-    op = ListFileOperator(task_id="task_id", file=File(conn_id="conn_id", path=LOCAL_FILEPATH))
+    op = ListFileOperator(
+        task_id="task_id", file=File(conn_id="conn_id", path=LOCAL_FILEPATH)
+    )
     actual = op.execute(None)
     assert actual == [str(file) for file in pathlib.Path(LOCAL_FILEPATH).rglob("*")]
 

--- a/tests/files/test_file.py
+++ b/tests/files/test_file.py
@@ -231,11 +231,11 @@ def test_get_file_list():
     """Assert that get_file_list handle kwargs correctly"""
     dag = DAG(dag_id="dag1", start_date=datetime(2022, 1, 1))
 
-    resp = get_file_list(path="path", conn_id="conn", dag=dag)
+    resp = get_file_list(file=File(path="path", conn_id="conn"), dag=dag)
     assert resp.operator.task_id == "get_file_list"
 
-    resp = get_file_list(path="path", conn_id="conn", dag=dag)
+    resp = get_file_list(file=File(path="path", conn_id="conn"), dag=dag)
     assert resp.operator.task_id != "get_file_list"
 
-    resp = get_file_list(path="path", conn_id="conn", task_id="test")
+    resp = get_file_list(file=File(path="path", conn_id="conn"), task_id="test")
     assert resp.operator.task_id == "test"


### PR DESCRIPTION
Update `get_file_list` to accept File object instead of `path` and `conn_id` this would make the public interface more consistent.

depend on: https://github.com/astronomer/astro-sdk/issues/749
 