### PR TITLE
Doc: Fix installation version

### DIFF
--- a/python-sdk/docs/getting-started/GETTING_STARTED.md
+++ b/python-sdk/docs/getting-started/GETTING_STARTED.md
@@ -57,7 +57,7 @@ To complete this tutorial, you need:
 1. Install the Astro Python SDK. If you are using Apache Airflow, run the following command to install the Python SDK and additional packages packages required for working with AWS and Snowflake.
 
     ```shell
-    pip install 'astro-sdk-python[amazon,snowflake]>=1.02'
+    pip install 'astro-sdk-python[amazon,snowflake]>=1.0'
     ```
 
     If you are using the Astro CLI, you can install these packages by adding the following line to the `requirements.txt` file of your Astro project:


### PR DESCRIPTION
https://github.com/astronomer/astro-sdk/pull/746 had a typo which will raise the following error:

```
❯ pip install 'astro-sdk-python[amazon,snowflake]>=1.02'
ERROR: Could not find a version that satisfies the requirement astro-sdk-python[amazon,snowflake]>=1.02 (from versions: 0.8.3a1, 0.8.3, 0.8.4b1, 0.8.4b2, 0.8.4, 0.8.5b1, 0.8.5, 0.9.0b1, 0.9.0, 0.9.1, 0.9.2, 0.10.0, 0.11.0, 0.11.1, 1.0.0b1, 1.0.0, 1.0.1, 1.0.2)
ERROR: No matching distribution found for astro-sdk-python[amazon,snowflake]>=1.02
```

