### PR TITLE
Fix the CI badge and deadlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Contributors](https://img.shields.io/github/contributors/astronomer/astro-sdk)](https://github.com/astronomer/astro-sdk)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/astronomer/astro-sdk)](https://github.com/astronomer/astro-sdk)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/astronomer/astro-sdk/main.svg)](https://results.pre-commit.ci/latest/github/astronomer/astro-sdk/main)
-[![CI](https://github.com/astronomer/astro-sdk/actions/workflows/ci.yaml/badge.svg)](https://github.com/astronomer/astro-sdk)
+[![CI](https://github.com/astronomer/astro-sdk/actions/workflows/ci-python-sdk.yaml/badge.svg)](https://github.com/astronomer/astro-sdk)
 [![codecov](https://codecov.io/gh/astronomer/astro-sdk/branch/main/graph/badge.svg?token=MI4SSE50Q6)](https://codecov.io/gh/astronomer/astro-sdk)
 
 **Astro Python SDK** is a Python SDK for rapid development of extract, transform, and load workflows in [Apache Airflow](https://airflow.apache.org/). It allows you to express your workflows as a set of data dependencies without having to worry about ordering and tasks. The Astro Python SDK is maintained by [Astronomer](https://astronomer.io).

--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -12,7 +12,7 @@
 [![Contributors](https://img.shields.io/github/contributors/astronomer/astro-sdk)](https://github.com/astronomer/astro-sdk)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/astronomer/astro-sdk)](https://github.com/astronomer/astro-sdk)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/astronomer/astro-sdk/main.svg)](https://results.pre-commit.ci/latest/github/astronomer/astro-sdk/main)
-[![CI](https://github.com/astronomer/astro-sdk/actions/workflows/ci.yaml/badge.svg)](https://github.com/astronomer/astro-sdk)
+[![CI](https://github.com/astronomer/astro-sdk/actions/workflows/ci-python-sdk.yaml/badge.svg)](https://github.com/astronomer/astro-sdk)
 [![codecov](https://codecov.io/gh/astronomer/astro-sdk/branch/main/graph/badge.svg?token=MI4SSE50Q6)](https://codecov.io/gh/astronomer/astro-sdk)
 
 **Astro Python SDK** is a Python SDK for rapid development of extract, transform, and load workflows in [Apache Airflow](https://airflow.apache.org/). It allows you to express your workflows as a set of data dependencies without having to worry about ordering and tasks. The Astro Python SDK is maintained by [Astronomer](https://astronomer.io).

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -27,7 +27,7 @@ branch from main (please use `git cherry-pick -x <commit id>` to retain
 git commit hashes and messages). Depending on the fix there might be some git conflicts to resolve. If you run into conflicts, please
 resolve said conflicts, run `git add .`, and then `git cherry-pick --continue` to continue the merge.
 
-After cherry-picking all needed fixes, follow the instructions to [create a release from the release branch](https://github.com/astronomer/astro-sdk/blob/main/docs/development/RELEASE.md#Creating a release from the release branch)
+After cherry-picking all needed fixes, follow the instructions to [create a release from the release branch](https://github.com/astronomer/astro-sdk/blob/main/python-sdk/docs/development/RELEASE.md#Creating a release from the release branch)
 
 ## Handling minor releases
 ### When should I create a minor release?
@@ -43,7 +43,7 @@ major release.
 
 To create a minor release, first create a new release branch based on main under the new minor release number.
 If we are currently releasing from `release-0.6` then you should create the branch `release-0.7`. Since this branch is
-pulled directly from main, there is nothing for you to cherry-pick. Simply follow the following instructions to [create a release from the release branch](https://github.com/astronomer/astro-sdk/blob/main/docs/development/RELEASE.md#creating-a-release-from-the-release-branch)
+pulled directly from main, there is nothing for you to cherry-pick. Simply follow the following instructions to [create a release from the release branch](https://github.com/astronomer/astro-sdk/blob/main/python-sdk/docs/development/RELEASE.md#creating-a-release-from-the-release-branch)
 
 # Handling Major releases
 
@@ -55,7 +55,7 @@ ample time with deprecation warnings and migration steps before removing a featu
 
 ## Creating a major release
 
-The instructions for creating a major release are identical for those of [creating a minor release](https://github.com/astronomer/astro-sdk/blob/main/docs/development/RELEASE.md#creating-a-minor-release).
+The instructions for creating a major release are identical for those of [creating a minor release](https://github.com/astronomer/astro-sdk/blob/main/python-sdk/docs/development/RELEASE.md#creating-a-minor-release).
 
 # Creating a release from the release branch
 

--- a/python-sdk/tests/benchmark/README.md
+++ b/python-sdk/tests/benchmark/README.md
@@ -188,7 +188,7 @@ To publish the results to bigquery table, we need to create an environment varia
 
 ## Analyze the results
 
-[analyse.py](https://github.com/astronomer/astro-sdk/blob/main/tests/benchmark/analyse.py) takes local file path or GCS file path for ndjson file.
+[analyse.py](analyse.py) takes local file path or GCS file path for ndjson file.
 
 After running the benchmark, it is possible to run an analysis script using:
 


### PR DESCRIPTION
Fix the CI badge link.

There is a dead link to the CI badge in the project README and the Markdown checker is failing:

https://github.com/astronomer/astro-sdk/runs/8111269456?check_suite_focus=true

<img width="925" alt="Screenshot 2022-08-31 at 11 25 29" src="https://user-images.githubusercontent.com/272048/187657914-6d71a763-f255-478e-9ca8-b13480598e42.png">
<img width="931" alt="Screenshot 2022-08-31 at 11 25 42" src="https://user-images.githubusercontent.com/272048/187657919-304f9b8c-5109-4bff-b03a-b962ba3e84e6.png">
