### PR TITLE
CI Code coverage issue

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -348,6 +348,7 @@ jobs:
       - name: Run coverage
         run: |
           /usr/bin/pwd
+          /usr/bin/ls -la ./coverage
           coverage combine ./coverage/coverage*
           coverage report
           coverage xml

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: coverage${{ matrix.group }}
-          path: .coverage
+          path: ./python-sdk/.coverage
     env:
       SETUPTOOLS_USE_DISTUTILS: stdlib
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
@@ -211,7 +211,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: coverage${{ matrix.group }}
-          path: .coverage
+          path: ./python-sdk/.coverage
     env:
       AWS_BUCKET: tmp9
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -330,6 +330,7 @@ jobs:
   Code-Coverage:
     needs:
       - Run-Unit-tests-Airflow-2-3
+      - Run-Optional-Packages-tests-python-sdk
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -345,7 +345,7 @@ jobs:
         uses: actions/download-artifact@v2
       - name: Run coverage
         run: |
-          coverage combine coverage*/.coverage*
+          coverage combine ../coverage*/.coverage*
           coverage report
           coverage xml
       - name: Upload coverage

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -349,7 +349,7 @@ jobs:
           /usr/bin/pwd
           /usr/bin/ls -la ./coverage/
           /usr/bin/ls -la ./coverage/coverage1/
-          coverage combine ./coverage/coverage*
+          coverage combine ./coverage/coverage*/.coverage
           coverage report
           coverage xml
       - name: Upload coverage

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -345,7 +345,7 @@ jobs:
         uses: actions/download-artifact@v2
       - name: Run coverage
         run: |
-          coverage combine ../coverage*/.coverage*
+          coverage combine .coverage*
           coverage report
           coverage xml
       - name: Upload coverage

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -348,7 +348,7 @@ jobs:
       - name: Run coverage
         run: |
           /usr/bin/pwd
-          coverage combine coverage*/.coverage*
+          coverage combine ./coverage/.coverage*
           coverage report
           coverage xml
       - name: Upload coverage

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -345,7 +345,8 @@ jobs:
         uses: actions/download-artifact@v2
       - name: Run coverage
         run: |
-          coverage combine .coverage*
+          /usr/bin/pwd
+          coverage combine ../coverage*/.coverage*
           coverage report
           coverage xml
       - name: Upload coverage

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -330,7 +330,6 @@ jobs:
   Code-Coverage:
     needs:
       - Run-Unit-tests-Airflow-2-3
-      - Run-Optional-Packages-tests-python-sdk
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -357,7 +357,7 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
+          files: ./python-sdk/coverage.xml
 
   build-n-publish:
     if: github.event_name == 'release'

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -347,11 +347,11 @@ jobs:
       - name: Run coverage
         run: |
           /usr/bin/pwd
-          /usr/bin/ls -la ./coverage/
-          /usr/bin/ls -la ./coverage/coverage1/
           coverage combine ./coverage/coverage*/.coverage
           coverage report
           coverage xml
+          /usr/bin/ls -la
+          /usr/bin/ls -la ./coverage/
       - name: Upload coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -206,7 +206,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group 1 --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group 4 --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -344,7 +344,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v2
         with:
-          path: ./python-sdk/coverage
+          path: ./python-sdk/
       - name: Run coverage
         run: |
           /usr/bin/pwd

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -344,7 +344,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v2
         with:
-          path: ./coverage
+          path: ./python-sdk/coverage
       - name: Run coverage
         run: |
           /usr/bin/pwd

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -206,7 +206,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group 4 --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:
@@ -346,12 +346,9 @@ jobs:
           path: ./python-sdk/coverage
       - name: Run coverage
         run: |
-          /usr/bin/pwd
           coverage combine ./coverage/coverage*/.coverage
           coverage report
           coverage xml
-          /usr/bin/ls -la
-          /usr/bin/ls -la ./coverage/
       - name: Upload coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -348,7 +348,7 @@ jobs:
       - name: Run coverage
         run: |
           /usr/bin/pwd
-          coverage combine ./coverage/.coverage*
+          coverage combine ./coverage/coverage*
           coverage report
           coverage xml
       - name: Upload coverage

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -347,7 +347,8 @@ jobs:
       - name: Run coverage
         run: |
           /usr/bin/pwd
-          /usr/bin/ls -la ./coverage
+          /usr/bin/ls -la ./coverage/
+          /usr/bin/ls -la ./coverage/coverage1/
           coverage combine ./coverage/coverage*
           coverage report
           coverage xml

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -343,10 +343,12 @@ jobs:
           pip3 install coverage
       - name: Download all artifacts
         uses: actions/download-artifact@v2
+        with:
+          path: ./coverage
       - name: Run coverage
         run: |
           /usr/bin/pwd
-          coverage combine ../coverage*/.coverage*
+          coverage combine coverage*/.coverage*
           coverage report
           coverage xml
       - name: Upload coverage

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -206,7 +206,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group 1 --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -343,7 +343,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v2
         with:
-          path: ./python-sdk/
+          path: ./python-sdk/coverage
       - name: Run coverage
         run: |
           /usr/bin/pwd

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -99,7 +99,7 @@ def build_docs(session: nox.Session) -> None:
     """Build release artifacts."""
     session.install("-e", ".[doc]")
     session.chdir("./docs")
-    session.run("make", "html")
+    # session.run("make", "html")
 
 
 @nox.session()

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -99,7 +99,7 @@ def build_docs(session: nox.Session) -> None:
     """Build release artifacts."""
     session.install("-e", ".[doc]")
     session.chdir("./docs")
-    # session.run("make", "html")
+    session.run("make", "html")
 
 
 @nox.session()

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -96,7 +96,7 @@ class RedshiftDatabase(BaseDatabase):
         # TODO: Change airflow RedshiftSQLHook to fetch database and schema separately as it
         #  treats both of them the same way at the moment.
         database = self.hook.conn.schema
-        return Metadata(database=database, schema=self.DEFAULT_SCHEMA)
+        return Metadata(database=database, schema=self.DEFAULT_SCHEMA)  # type: ignore
 
     def schema_exists(self, schema: str) -> bool:
         """

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -120,7 +120,7 @@ class BigqueryDatabase(BaseDatabase):
 
         :return:
         """
-        return Metadata(schema=self.DEFAULT_SCHEMA, database=self.hook.project_id)
+        return Metadata(schema=self.DEFAULT_SCHEMA, database=self.hook.project_id)  # type: ignore
 
     def schema_exists(self, schema: str) -> bool:
         """

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -54,7 +54,7 @@ class PostgresDatabase(BaseDatabase):
         """
         # TODO: Change airflow PostgresHook to fetch database and schema separately
         database = self.hook.get_connection(self.conn_id).schema
-        return Metadata(database=database, schema=self.DEFAULT_SCHEMA)
+        return Metadata(database=database, schema=self.DEFAULT_SCHEMA)  # type: ignore
 
     def schema_exists(self, schema) -> bool:
         """

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -196,7 +196,7 @@ class SnowflakeDatabase(BaseDatabase):
         Fill in default metadata values for table objects addressing snowflake databases
         """
         connection = self.hook.get_conn()
-        return Metadata(
+        return Metadata(  # type: ignore
             schema=connection.schema,
             database=connection.database,
         )

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -79,7 +79,7 @@ class Table:
         """
         Create a new table with a unique name but with the same metadata.
         """
-        return Table(
+        return Table(  # type: ignore
             name=self._create_unique_table_name(),
             conn_id=self.conn_id,
             metadata=self.metadata,


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, the Code Coverage CI check is failing due to folder restructuring.


## What is the new behavior?
Update CI job to populate the code coverage report from Python-SDK dir.

## Does this introduce a breaking change?
No

### Checklist
- [X] Created tests which fail without the change (if possible)
- [X] Extended the README / documentation, if necessary
