### PR TITLE
Make Table and Metadata class to attrs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         exclude: ^mk/.*\.mk$|^python-sdk/docs/Makefile|^python-sdk/Makefile$|^python-sdk/tests/benchmark/Makefile$
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
 
@@ -90,7 +90,7 @@ repos:
       rev: 'v0.971'
       hooks:
       -   id: mypy
-          additional_dependencies: [types-PyYAML]
+          additional_dependencies: [types-PyYAML, types-attrs]
           pass_filenames: false
           files: "^python-sdk/"
           entry: bash -c 'cd python-sdk && mypy "$@"' --

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 ---
+ci:
+  skip: [mypy]
 default_stages: [commit, push]
 default_language_version:
   # force all unspecified python hooks to run python3
@@ -89,11 +91,11 @@ repos:
   -   repo: https://github.com/pre-commit/mirrors-mypy
       rev: 'v0.971'
       hooks:
-      -   id: mypy
-          additional_dependencies: [types-PyYAML, types-attrs]
-          pass_filenames: false
-          files: "^python-sdk/"
-          entry: bash -c 'cd python-sdk && mypy "$@"' --
+      - id: mypy
+        additional_dependencies: [types-PyYAML, types-attrs]
+        pass_filenames: false
+        files: "^python-sdk/"
+        entry: bash -c 'cd python-sdk && mypy "$@"' --
       - id: mypy
         additional_dependencies: [ types-PyYAML ]
         pass_filenames: false

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -18,6 +18,7 @@ license = {file = "LICENSE"}
 requires-python = ">=3.7"
 dependencies = [
     "apache-airflow>=2.0",
+    "attrs",
     "pandas>=1.3.4,<2.0.0",  # Pinning it to <2.0.0 to avoid breaking changes
     "pyarrow",
     "python-frontmatter",

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -15,6 +15,11 @@ class File:  # skipcq: PYL-W1641
     """
     Handle all file operations, and abstract away the details related to location and file types.
     Intended to be used within library.
+
+    :param path: Path to a file in the filesystem/Object stores
+    :param conn_id: Airflow connection ID
+    :param filetype: constant to provide an explicit file type
+    :param normalize_config: parameters in dict format of pandas json_normalize() function.
     """
 
     template_fields = ("location",)
@@ -26,13 +31,6 @@ class File:  # skipcq: PYL-W1641
         filetype: constants.FileType | None = None,
         normalize_config: dict | None = None,
     ):
-        """Init file object which represent a single file in local/object stores
-
-        :param path: Path to a file in the filesystem/Object stores
-        :param conn_id: Airflow connection ID
-        :param filetype: constant to provide an explicit file type
-        :param normalize_config: parameters in dict format of pandas json_normalize() function.
-        """
         self.location: BaseFileLocation = create_file_location(path, conn_id)
         self.type = create_file_type(
             path=path, filetype=filetype, normalize_config=normalize_config

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -24,10 +24,8 @@ class Metadata:
     def is_empty(self) -> bool:
         """Check if all the fields are None."""
         return all(
-            [
-                getattr(self, field_name) is None
-                for field_name in fields_dict(self.__class__)
-            ]
+            getattr(self, field_name) is None
+            for field_name in fields_dict(self.__class__)
         )
 
 

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import random
 import string
-from dataclasses import dataclass, field, fields
 
+from attr import define, field, fields_dict
 from sqlalchemy import Column, MetaData
 
 MAX_TABLE_NAME_LENGTH = 62
 TEMP_PREFIX = "_tmp_"
 
 
-@dataclass
+@define
 class Metadata:
     """
     Contains additional information to access a SQL Table, which is very likely optional and, in some cases, may
@@ -23,11 +23,14 @@ class Metadata:
 
     def is_empty(self) -> bool:
         """Check if all the fields are None."""
-        values = [getattr(self, field.name) for field in fields(self)]
-        return values.count(None) == len(values)
+        li = [
+            getattr(self, field_name) is None
+            for field_name in fields_dict(self.__class__)
+        ]
+        return all(li)
 
 
-@dataclass
+@define
 class Table:
     """
     Withholds the information necessary to access a SQL Table.
@@ -42,16 +45,16 @@ class Table:
     # TODO: discuss alternative names to this class, since it contains metadata as opposed to be the
     # SQL table itself
     # Some ideas: TableRef, TableMetadata, TableData, TableDataset
-    conn_id: str = ""
-    name: str = ""
-    _name: str = field(init=False, repr=False, default="")
-    metadata: Metadata = field(default_factory=Metadata)
-    columns: list[Column] = field(default_factory=list)
-    temp: bool = False
+    conn_id: str = field(default="")
+    name: str = field(default="")
+    metadata: Metadata = field(factory=Metadata)
+    columns: list[Column] = field(factory=list)
+    temp: bool = field(default=False)
 
-    def __post_init__(self) -> None:
-        if not self._name or self._name.startswith("_tmp"):
+    def __attrs_post_init__(self) -> None:
+        if not self.name or self.name.startswith("_tmp"):
             self.temp = True
+            self.name = self._create_unique_table_name(TEMP_PREFIX)
 
     def _create_unique_table_name(self, prefix: str = "") -> str:
         """
@@ -88,22 +91,3 @@ class Table:
         else:
             alchemy_metadata = MetaData()
         return alchemy_metadata
-
-    @property  # type: ignore
-    def name(self) -> str:
-        """
-        Return either the user-defined name or auto-generate one.
-        :sphinx-autoapi-skip:
-        """
-        if self.temp and not self._name:
-            self._name = self._create_unique_table_name(TEMP_PREFIX)
-        return self._name
-
-    @name.setter
-    def name(self, value: str) -> None:
-        """
-        Set the table name. Once this happens, the table is no longer considered temporary.
-        """
-        if not isinstance(value, property) and value != self._name:
-            self._name = value
-            self.temp = False

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import string
 
-from attr import define, field, fields_dict
+from attrs import define, field, fields_dict
 from sqlalchemy import Column, MetaData
 
 MAX_TABLE_NAME_LENGTH = 62
@@ -23,11 +23,12 @@ class Metadata:
 
     def is_empty(self) -> bool:
         """Check if all the fields are None."""
-        li = [
-            getattr(self, field_name) is None
-            for field_name in fields_dict(self.__class__)
-        ]
-        return all(li)
+        return all(
+            [
+                getattr(self, field_name) is None
+                for field_name in fields_dict(self.__class__)
+            ]
+        )
 
 
 @define

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -1,4 +1,6 @@
-from astro.sql.table import Table
+import pytest
+
+from astro.sql.table import Metadata, Table
 
 
 def test_table_with_explicit_name():
@@ -43,3 +45,15 @@ def test_table_name_with_temp_prefix():
     """Check that the table is no longer considered temp when the name is set after initialization."""
     table = Table(conn_id="some_connection")
     assert table.name.startswith("_tmp_")
+
+
+@pytest.mark.parametrize(
+    "metadata,expected_is_empty",
+    [
+        (Metadata(), True),
+        (Metadata(schema="test"), False),
+    ],
+)
+def test_is_empty_metadata(metadata, expected_is_empty):
+    """Check that is_empty returns"""
+    assert metadata.is_empty() == expected_is_empty


### PR DESCRIPTION
part of https://github.com/astronomer/astro-sdk/issues/611

Since Airflow's Dataset object uses `attrs`, we need to convert Table and File object to attrs so we can inherit from Airflow's dataset in the following PRs.

This PR only updates Table and Metadata, I will do File in a follow-up PR

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
