### PR TITLE
Allow passing a dict to `Table.metadata`

### DIFF
--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -46,7 +46,11 @@ class Table:
     # Some ideas: TableRef, TableMetadata, TableData, TableDataset
     conn_id: str = field(default="")
     _name: str = field(default="")
-    metadata: Metadata = field(factory=Metadata)
+    # Setting converter allows passing a dictionary to metadata arg
+    metadata: Metadata = field(
+        factory=Metadata,
+        converter=lambda val: Metadata(**val) if isinstance(val, dict) else val,
+    )
     columns: list[Column] = field(factory=list)
     temp: bool = field(default=False)
 

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -57,3 +57,19 @@ def test_table_name_with_temp_prefix():
 def test_is_empty_metadata(metadata, expected_is_empty):
     """Check that is_empty returns"""
     assert metadata.is_empty() == expected_is_empty
+
+
+@pytest.mark.parametrize(
+    "metadata,expected_metadata",
+    [
+        (
+            {"schema": "test", "database": "db1"},
+            Metadata(schema="test", database="db1"),
+        ),
+        (Metadata(schema="test"), Metadata(schema="test")),
+    ],
+)
+def test_metadata_converter(metadata, expected_metadata):
+    """Test you can pass a dict to metadata param"""
+    table = Table(metadata=metadata)
+    assert table.metadata == expected_metadata


### PR DESCRIPTION
This will allow passing a dict to `Table.metadata`:

```python
In [5]: Table("xyz", metadata={'schema': "das", 'database': "dsa"})
Out[5]: Table(conn_id='xyz', _name='', metadata=Metadata(schema='das', database='dsa'), columns=[], temp=True)
```

This is needed for serialization and de-serialization of the Table class in Airflow as Airflow 2.4 serializes the Dataset classes to json/dict for lineage

part of https://github.com/astronomer/astro-sdk/issues/611

