### PR TITLE
Add section explaining table metadata

### DIFF
--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -37,7 +37,7 @@ There are two types of tables:
 Metadata
 ~~~~~~~~~
 Metadata is used to give additional information to access a SQL Table.
-For example, a user can detail the Snowflake schema and database for a table, whereas a BigQuery user can specify the namespace and dataset. Although these parameters can change name depending on the database, we have normalised the `Metadata` class to name their schema and database.
+For example, a user can detail the Snowflake schema and database for a table, whereas a BigQuery user can specify the namespace and dataset. Although these parameters can change name depending on the database, we have normalised the ``Metadata`` class to name their schema and database.
 
 .. literalinclude:: ../example_dags/example_amazon_s3_snowflake_transform.py
    :language: python

--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -42,7 +42,7 @@ For example, a user can detail the Snowflake schema and database for a table, wh
 .. literalinclude:: ../example_dags/example_amazon_s3_snowflake_transform.py
    :language: python
    :start-after: [START metadata_example_snowflake]
-   :end-before: [END metadata_example_1]
+   :end-before: [END metadata_example_snowflake]
 
 
 

--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -36,7 +36,7 @@ There are two types of tables:
 
 Metadata
 ~~~~~~~~~
-Metadata is used in tables to pass additional information to access a SQL Table, which will be database specific.
+Metadata is used to give additional information to access a SQL Table.
 For example we can have multiple tables in different schema or database, we can pass metadata object while defining table to pass this information.
 
 .. literalinclude:: ../example_dags/example_amazon_s3_snowflake_transform.py

--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -35,7 +35,7 @@ There are two types of tables:
            :end-before: [END temp_table_example]
 
 Metadata
-~~~~~~~~~
+~~~~~~~~
 Metadata is used to give additional information to access a SQL Table.
 For example, a user can detail the Snowflake schema and database for a table, whereas a BigQuery user can specify the namespace and dataset. Although these parameters can change name depending on the database, we have normalised the :class:`~astro.sql.table.Metadata` class to name their schema and database.
 

--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -34,6 +34,18 @@ There are two types of tables:
            :start-after: [START temp_table_example]
            :end-before: [END temp_table_example]
 
+Metadata
+~~~~~~~~~
+Metadata is used in tables to pass additional information to access a SQL Table, which will be database specific.
+For example we can have multiple tables in different schema or database, we can pass metadata object while defining table to pass this information.
+
+.. literalinclude:: ../example_dags/example_amazon_s3_snowflake_transform.py
+   :language: python
+   :start-after: [START metadata_example_1]
+   :end-before: [END metadata_example_1]
+
+
+
 .. _load_file_working:
 
 

--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -41,7 +41,7 @@ For example, a user can detail the Snowflake schema and database for a table, wh
 
 .. literalinclude:: ../example_dags/example_amazon_s3_snowflake_transform.py
    :language: python
-   :start-after: [START metadata_example_1]
+   :start-after: [START metadata_example_snowflake]
    :end-before: [END metadata_example_1]
 
 

--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -37,7 +37,7 @@ There are two types of tables:
 Metadata
 ~~~~~~~~~
 Metadata is used to give additional information to access a SQL Table.
-For example we can have multiple tables in different schema or database, we can pass metadata object while defining table to pass this information.
+For example, a user can detail the Snowflake schema and database for a table, whereas a BigQuery user can specify the namespace and dataset. Although these parameters can change name depending on the database, we have normalised the `Metadata` class to name their schema and database.
 
 .. literalinclude:: ../example_dags/example_amazon_s3_snowflake_transform.py
    :language: python

--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -37,7 +37,7 @@ There are two types of tables:
 Metadata
 ~~~~~~~~~
 Metadata is used to give additional information to access a SQL Table.
-For example, a user can detail the Snowflake schema and database for a table, whereas a BigQuery user can specify the namespace and dataset. Although these parameters can change name depending on the database, we have normalised the ``Metadata`` class to name their schema and database.
+For example, a user can detail the Snowflake schema and database for a table, whereas a BigQuery user can specify the namespace and dataset. Although these parameters can change name depending on the database, we have normalised the :class:`~astro.sql.table.Metadata` class to name their schema and database.
 
 .. literalinclude:: ../example_dags/example_amazon_s3_snowflake_transform.py
    :language: python

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -61,6 +61,7 @@ def example_amazon_s3_snowflake_transform():
         ),
         conn_id="snowflake_conn",
     )
+    # [START metadata_example_1]
     input_table_2 = Table(
         name="ADOPTION_CENTER_2",
         metadata=Metadata(
@@ -69,6 +70,7 @@ def example_amazon_s3_snowflake_transform():
         ),
         conn_id="snowflake_conn",
     )
+    # [END metadata_example_1]
 
     temp_table_1 = aql.load_file(
         input_file=File(path=f"{s3_bucket}/ADOPTION_CENTER_1_unquoted.csv"),

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -70,7 +70,7 @@ def example_amazon_s3_snowflake_transform():
         ),
         conn_id="snowflake_conn",
     )
-    # [END metadata_example_1]
+    # [END metadata_example_snowflake]
 
     temp_table_1 = aql.load_file(
         input_file=File(path=f"{s3_bucket}/ADOPTION_CENTER_1_unquoted.csv"),

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -61,7 +61,7 @@ def example_amazon_s3_snowflake_transform():
         ),
         conn_id="snowflake_conn",
     )
-    # [START metadata_example_1]
+    # [START metadata_example_snowflake]
     input_table_2 = Table(
         name="ADOPTION_CENTER_2",
         metadata=Metadata(


### PR DESCRIPTION
# Description
## What is the current behavior?
Some of the examples are in https://astro-sdk-python.readthedocs.io/en/stable/astro/sql/operators/load_file.htm. use the metadata parameter when creating a Table, but AFAICT we don't explain what that does.

closes: #767

## What is the new behavior?
Added section in docs explaining the usage of Metadata.

## Does this introduce a breaking change?
No

### Checklist
- [X] Created tests that fail without the change (if possible)
- [X] Extended the README/documentation, if necessary
