### PR TITLE
Fix ReadTheDocs for Python SDK

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,11 +7,11 @@ build:
 
 # Build from the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: python-sdk/docs/conf.py
 
 python:
   install:
     - method: pip
-      path: .
+      path: python-sdk
       extra_requirements:
         - doc


### PR DESCRIPTION

## What is the current behavior?

Currently the docs are broken for "main" as shown in https://readthedocs.org/projects/astro-sdk-python/builds/

## Changes
`.readthedocs.yaml` should be at the root of repo - https://docs.readthedocs.io/en/stable/config-file/index.html