### PR TITLE
Add dev dags,logs and plugins to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,6 @@ python-sdk/docs/logs/
 python-sdk/docs/webserver_config.py
 python-sdk/docs/autoapi/
 
-dev/dags
-dev/logs
-dev/plugins
+**/dev/dags
+**/dev/logs
+**/dev/plugins


### PR DESCRIPTION
Since we moved to mono-repo this were not added to gitignore causing files to show in git
