### PR TITLE
Avoid loading whole file into memory with load_operator for schema detection

### DIFF
--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -79,7 +79,7 @@ class File:
         """Read file from all supported location and convert them into dataframes."""
         mode = "rb" if self.is_binary() else "r"
         with smart_open.open(
-                self.path, mode=mode, transport_params=self.location.transport_params
+            self.path, mode=mode, transport_params=self.location.transport_params
         ) as stream:
             return self.type.export_to_dataframe(stream, **kwargs)
 

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -4,7 +4,7 @@ import io
 
 import pandas as pd
 import smart_open
-from attrs import define
+from attr import define
 
 from astro import constants
 from astro.files.locations import create_file_location

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -75,38 +75,13 @@ class File:
         ) as stream:
             self.type.create_from_dataframe(stream=stream, df=df)
 
-    def _convert_remote_file_to_byte_stream(self) -> io.IOBase:
-        """
-        Read file from all supported location and convert them into a buffer that can be streamed into other data
-        structures.
-
-        Due to noted issues with using smart_open with pandas (like
-        https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
-        before exporting to a dataframe. We've found a sizable speed improvement with this optimizat
-
-        Returns: an io object that can be streamed into a dataframe (or other object)
-
-        """
-        mode = "rb" if self.is_binary() else "r"
-        remote_obj_buffer = io.BytesIO() if self.is_binary() else io.StringIO()
-        with smart_open.open(
-            self.path, mode=mode, transport_params=self.location.transport_params
-        ) as stream:
-            remote_obj_buffer.write(stream.read())
-        remote_obj_buffer.seek(0)
-        return remote_obj_buffer
-
     def export_to_dataframe(self, **kwargs) -> pd.DataFrame:
-        """Read file from all supported location and convert them into dataframes.
-
-        Due to noted issues with using smart_open with pandas (like
-        https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
-        before exporting to a dataframe. We've found a sizable speed improvement with this optimization.
-        """
-
-        return self.type.export_to_dataframe(
-            self._convert_remote_file_to_byte_stream(), **kwargs
-        )
+        """Read file from all supported location and convert them into dataframes."""
+        mode = "rb" if self.is_binary() else "r"
+        with smart_open.open(
+                self.path, mode=mode, transport_params=self.location.transport_params
+        ) as stream:
+            return self.type.export_to_dataframe(stream, **kwargs)
 
     def exists(self) -> bool:
         """Check if the file exists or not"""

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 import string
 
-from attrs import define, field, fields_dict
+from attr import define, field, fields_dict
 from sqlalchemy import Column, MetaData
 
 MAX_TABLE_NAME_LENGTH = 62

--- a/python-sdk/tests/benchmark/Dockerfile
+++ b/python-sdk/tests/benchmark/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 
 # Install Astro SDK dependencies
 
-COPY . .
+COPY python-sdk/ .
 # We need to update pip as only newer versions of pip allow installing in edit mode for pyproject.toml projects. For more info: https://peps.python.org/pep-0660/
 RUN pip install --upgrade pip
 RUN pip install -e .[all]
@@ -40,13 +40,13 @@ ENV AIRFLOW__CORE__ENABLE_XCOM_PICKLING=True
 
 RUN mkdir -p $AIRFLOW_HOME
 WORKDIR $AIRFLOW_HOME
-COPY . .
+COPY python-sdk/ .
 
 
-COPY tests/benchmark/dags $AIRFLOW_HOME/dags
-COPY tests/benchmark/run.sh $AIRFLOW_HOME/
-COPY tests/benchmark/run.py $AIRFLOW_HOME/
-COPY tests/benchmark/config.json $AIRFLOW_HOME/config.json
+COPY python-sdk/tests/benchmark/dags $AIRFLOW_HOME/dags
+COPY python-sdk/tests/benchmark/run.sh $AIRFLOW_HOME/
+COPY python-sdk/tests/benchmark/run.py $AIRFLOW_HOME/
+COPY python-sdk/tests/benchmark/config.json $AIRFLOW_HOME/config.json
 
 # Debian Bullseye is shipped with Python 3.9
 # Upgrade built-in pip

--- a/python-sdk/tests/benchmark/Makefile
+++ b/python-sdk/tests/benchmark/Makefile
@@ -9,55 +9,55 @@ CONTAINER_REGISTRY=gcr.io/$(GCP_PROJECT)/$(APP)
 
 check_google_credentials:
 ifndef GOOGLE_APPLICATION_CREDENTIALS
-    @echo "The GOOGLE_APPLICATION_CREDENTIALS environment variable is missing."
-    exit 1
+	@echo "The GOOGLE_APPLICATION_CREDENTIALS environment variable is missing."
+	exit 1
 endif
 
 clean:
-    @echo "Deleting unnecessary files"
-    @find . | grep -E "(/__pycache__$|\.pyc$|\.pyo$\)" | xargs rm -rf
-    @rm -f unittests.cfg
-    @rm -f unittests.db
-    @rm -f webserver_config.py
-    @rm -f ../../unittests.cfg
-    @rm -f ../../unittests.db
-    @rm -f ../../airflow.cfg
-    @rm -f ../../airflow.db
+	@echo "Deleting unnecessary files"
+	@find . | grep -E "(/__pycache__$|\.pyc$|\.pyo$\)" | xargs rm -rf
+	@rm -f unittests.cfg
+	@rm -f unittests.db
+	@rm -f webserver_config.py
+	@rm -f ../../unittests.cfg
+	@rm -f ../../unittests.db
+	@rm -f ../../airflow.cfg
+	@rm -f ../../airflow.db
 
 # Takes approximately 7min
 setup_gke:
-    @cd infrastructure/terraform && \
-        terraform init && \
-        terraform apply
+	@cd infrastructure/terraform && \
+		terraform init && \
+		terraform apply
 
 container:
-    @echo "Building and pushing container $(CONTAINER_REGISTRY)"
-    @gcloud auth configure-docker
-    @docker build --build-arg=GIT_HASH=$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):latest -f ./Dockerfile  ../../
-    @docker push $(CONTAINER_REGISTRY)
+	@echo "Building and pushing container $(CONTAINER_REGISTRY)"
+	@gcloud auth configure-docker
+	@docker build --build-arg=GIT_HASH=$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):latest -f ./Dockerfile  ../../../
+	@docker push $(CONTAINER_REGISTRY)
 
 local: check_google_credentials
-    @echo "Building and pushing container $(CONTAINER_REGISTRY)"
-    @gcloud auth configure-docker
-    @docker build -t benchmark -f ./Dockerfile  ../../ --build-arg=GIT_HASH=`git rev-parse --short HEAD`
-    @mkdir -p /tmp/docker
-    @sudo chmod a+rwx /tmp/docker/
-    @docker run -it \
-           -v /tmp/docker:/tmp:rw     \
-           -v ${GOOGLE_APPLICATION_CREDENTIALS}:/tmp/gcp.json:ro \
-        -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp.json \
-           benchmark
-    @rm -rf astro-sdk
+	@echo "Building and pushing container $(CONTAINER_REGISTRY)"
+#	@gcloud auth configure-docker
+	@docker build -t benchmark -f ./Dockerfile  ../../../ --build-arg=GIT_HASH=`git rev-parse --short HEAD`
+	@mkdir -p /tmp/docker
+	@sudo chmod a+rwx /tmp/docker/
+	@docker run -it \
+		   -v /tmp/docker:/tmp:rw     \
+		   -v ${GOOGLE_APPLICATION_CREDENTIALS}:/tmp/gcp.json:ro \
+		-e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp.json \
+		   benchmark
+	@rm -rf astro-sdk
 
 run_job:
-    @gcloud container clusters get-credentials astro-sdk --zone us-central1-a --project ${GCP_PROJECT}
-    @kubectl apply -f infrastructure/kubernetes/namespace.yaml
-    @kubectl apply -f infrastructure/kubernetes/postgres.yaml
-    @kubectl apply -f infrastructure/kubernetes/postgres_svc.yaml
-    @kubectl create -f infrastructure/kubernetes/job.yaml
+	@gcloud container clusters get-credentials astro-sdk --zone us-central1-a --project ${GCP_PROJECT}
+	@kubectl apply -f infrastructure/kubernetes/namespace.yaml
+	@kubectl apply -f infrastructure/kubernetes/postgres.yaml
+	@kubectl apply -f infrastructure/kubernetes/postgres_svc.yaml
+	@kubectl create -f infrastructure/kubernetes/job.yaml
 
 # Takes approximately 2min
 teardown_gke:
-    @cd infrastructure/terraform && \
-        terraform init && \
-        terraform apply -destroy
+	@cd infrastructure/terraform && \
+		terraform init && \
+		terraform apply -destroy

--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -1,47 +1,13 @@
 {
   "databases": [
     {
-      "name": "snowflake",
+      "name": "redshift",
       "params": {
-        "conn_id": "snowflake_conn"
-      }
-    },
-    {
-      "name": "postgres",
-      "params": {
-        "conn_id": "postgres_conn_benchmark",
-        "metadata": {
-          "database": "postgres"
-        }
-      }
-    },
-    {
-      "name": "bigquery",
-      "params": {
-        "conn_id": "bigquery",
-        "metadata": {
-          "database": "bigquery"
-        }
+        "conn_id": "redshift_conn"
       }
     }
   ],
   "datasets": [
-    {
-      "conn_id": "bigquery",
-      "file_type": "parquet",
-      "name": "ten_kb",
-      "path": "gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.parquet",
-      "rows": 160,
-      "size": "10 KB"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "csv",
-      "name": "hundred_kb",
-      "path": "gs://astro-sdk/benchmark/trimmed/tate_britain/artist_data_100kb.csv",
-      "rows": 748,
-      "size": "100 KB"
-    },
     {
       "conn_id": "bigquery",
       "file_type": "csv",
@@ -49,30 +15,6 @@
       "path": "gs://astro-sdk/benchmark/trimmed/imdb/title_ratings_10mb.csv",
       "rows": 600000,
       "size": "10M"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "ndjson",
-      "name": "one_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/stackoverflow/stackoverflow_posts_1g.ndjson",
-      "rows": 940000,
-      "size": "1G"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "ndjson",
-      "name": "five_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/pypi/",
-      "rows": 7530243,
-      "size": "5G"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "ndjson",
-      "name": "ten_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/github/github-archive/",
-      "rows": 1263685,
-      "size": "10G"
     }
   ]
 }

--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -9,12 +9,68 @@
   ],
   "datasets": [
     {
-      "conn_id": "bigquery",
+      "conn_id": "aws_conn",
+      "file_type": "csv",
+      "name": "ten_kb",
+      "path": "s3://astro-sdk-test/benchmark/fake_data/10_kb.csv",
+      "rows": 160,
+      "size": "10 KB"
+    },
+    {
+      "conn_id": "aws_conn",
+      "file_type": "csv",
+      "name": "hundred_kb",
+      "path": "s3://astro-sdk-test/benchmark/fake_data/100_kb.csv",
+      "rows": 748,
+      "size": "100 KB"
+    },
+    {
+      "conn_id": "aws_conn",
+      "file_type": "csv",
+      "name": "one_mb",
+      "path": "s3://astro-sdk-test/benchmark/fake_data/1_mb.csv",
+      "rows": 748,
+      "size": "100 KB"
+    },
+    {
+      "conn_id": "aws_conn",
       "file_type": "csv",
       "name": "ten_mb",
-      "path": "gs://astro-sdk/benchmark/trimmed/imdb/title_ratings_10mb.csv",
+      "path": "s3://astro-sdk-test/benchmark/fake_data/10_mb.csv",
       "rows": 600000,
       "size": "10M"
+    },
+    {
+      "conn_id": "aws_conn",
+      "file_type": "csv",
+      "name": "hundred_mb",
+      "path": "s3://astro-sdk-test/benchmark/fake_data/100_mb.csv",
+      "rows": 600000,
+      "size": "100M"
+    },
+    {
+      "conn_id": "aws_conn",
+      "file_type": "csv",
+      "name": "one_gb",
+      "path": "s3://astro-sdk-test/benchmark/fake_data/1_gb.csv",
+      "rows": 940000,
+      "size": "1G"
+    },
+    {
+      "conn_id": "aws_conn",
+      "file_type": "csv",
+      "name": "five_gb",
+      "path": "s3://astro-sdk-test/benchmark/fake_data/5_gb.csv",
+      "rows": 7530243,
+      "size": "5G"
+    },
+    {
+      "conn_id": "aws_conn",
+      "file_type": "csv",
+      "name": "ten_gb",
+      "path": "s3://astro-sdk-test/benchmark/fake_data/10_gb.csv",
+      "rows": 1263685,
+      "size": "10G"
     }
   ]
 }

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -67,7 +67,7 @@ def create_dag(database_name, table_args, dataset):
                 "IGNOREHEADER": 1,
                 "REGION": "us-east-1",
                 "IAM_ROLE": "arn:aws:iam::633294268925:role/redshift-s3-readonly",
-            }
+            },
         )
         aql.cleanup([my_table])
 

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -62,6 +62,12 @@ def create_dag(database_name, table_args, dataset):
             task_id="load",
             output_table=table,
             chunk_size=chunk_size,
+            use_native_support=True,
+            native_support_kwargs={
+                "IGNOREHEADER": 1,
+                "REGION": "us-east-1",
+                "IAM_ROLE": "arn:aws:iam::633294268925:role/redshift-s3-readonly",
+            }
         )
         aql.cleanup([my_table])
 

--- a/python-sdk/tests/benchmark/run.sh
+++ b/python-sdk/tests/benchmark/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -x
 set -v
@@ -20,7 +20,7 @@ else
   connections_file="${benchmark_dir}/../../test-connections.yaml"
 fi
 
-git_revision="${GIT_REVISION:=`git rev-parse --short HEAD`}"
+#git_revision="${GIT_REVISION:=`git rev-parse --short HEAD`}"
 
 results_file=/tmp/results-`date -u +%FT%T`.ndjson
 
@@ -72,7 +72,7 @@ echo - Output: $(get_abs_filename $results_file)
       jq -r '.datasets[] | [.name] | @tsv' $config_path | while IFS=$'\t' read -r dataset; do
         for chunk_size in "${chunk_sizes_array[@]}"; do
           echo "$i $dataset $database $chunk_size"
-          ASTRO_CHUNKSIZE=$chunk_size python3 -W ignore $runner_path --dataset="$dataset" --database="$database" --revision $git_revision --chunk-size=$chunk_size 1>> $results_file
+          ASTRO_CHUNKSIZE=$chunk_size python3 -W ignore $runner_path --dataset="$dataset" --database="$database" --chunk-size=$chunk_size 1>> $results_file
           cat $results_file
 
           if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
@@ -82,7 +82,7 @@ echo - Output: $(get_abs_filename $results_file)
             gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
       fi
 
-          gsutil cp $results_file gs://${GCP_BUCKET}/benchmark/results/
+#          gsutil cp $results_file gs://${GCP_BUCKET}/benchmark/results/
           if command -v peekprof &> /dev/null; then
              # https://github.com/exapsy/peekprof
              peekprof -html "/tmp/$dataset-$database-$chunk_size.html" -refresh 1000ms -pid $! > /tmp/$dataset-$database-$chunk_size.csv


### PR DESCRIPTION
# Description
## What is the current behavior?
We're loading whole file into memory and converting it into a byte stream
for schema auto-detection. As a result, jobs with large files e.g. 5GB and
higher are getting killed.
Opening this for discussion if we really need to load the whole file into
memory and if not needed just return the stream so that pandas dataframe
can fetch only the initial rows of a file for schema auto-detection.


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #803 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Do not load whole file into memory but only return the stream.

## Does this introduce a breaking change?
No, tested with postgres and Redshift.