### PR TITLE
Set inlets and outlets for operators

### DIFF
--- a/python-sdk/src/astro/airflow/datasets.py
+++ b/python-sdk/src/astro/airflow/datasets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 try:
     # Airflow >= 2.4
     from airflow.datasets import Dataset
@@ -7,3 +9,26 @@ except ImportError:
     # Airflow < 2.4
     Dataset = object
     DATASET_SUPPORT = False
+
+
+def kwargs_with_datasets(
+    kwargs: dict | None = None,
+    input_datasets: list[Dataset] | Dataset | None = None,
+    output_datasets: list[Dataset] | Dataset | None = None,
+):
+    """
+    Extract inlets and outlets from kwargs if users have passed it. If not, set input datasets as inlets and
+    set output dataset as outlets
+    """
+    kwargs = kwargs or {}
+    if "inlets" in kwargs or DATASET_SUPPORT and input_datasets:
+        inlets = kwargs.get("inlets", input_datasets)
+        inlets = inlets if isinstance(inlets, list) else [inlets]
+        kwargs.update({"inlets": inlets})
+
+    if "outlets" in kwargs or DATASET_SUPPORT and output_datasets:
+        outlets = kwargs.get("outlets", output_datasets)
+        outlets = outlets if isinstance(outlets, list) else [outlets]
+        kwargs.update({"outlets": outlets})
+
+    return kwargs

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -5,6 +5,7 @@ from typing import Any
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
+from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import Table
@@ -43,7 +44,12 @@ class AppendOperator(AstroSQLBaseOperator):
         self.columns = columns or {}
         task_id = task_id or get_unique_task_id("append_table")
 
-        super().__init__(task_id=task_id, **kwargs)
+        super().__init__(
+            task_id=task_id,
+            **kwargs_with_datasets(
+                kwargs=kwargs, input_datasets=source_table, output_datasets=target_table
+            ),
+        )
 
     def execute(self, context: dict) -> Table:  # skipcq: PYL-W0613
         db = create_database(self.target_table.conn_id)

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -8,6 +8,7 @@ from airflow.decorators.base import DecoratedOperator
 from airflow.exceptions import AirflowException
 from sqlalchemy.sql.functions import Function
 
+from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.sql.operators.upstream_task_mixin import UpstreamTaskMixin
@@ -49,7 +50,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         upstream_tasks = self.op_kwargs.pop("upstream_tasks", [])
         super().__init__(
             upstream_tasks=upstream_tasks,
-            **kwargs,
+            **kwargs_with_datasets(kwargs=kwargs, output_datasets=self.output_table),
         )
 
     def execute(self, context: dict) -> None:

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -6,6 +6,8 @@ from typing import Any, Callable
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
 
+from astro.airflow.datasets import kwargs_with_datasets
+
 try:
     from airflow.decorators.base import TaskDecorator, task_decorator_factory
 except ImportError:
@@ -125,7 +127,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
         upstream_tasks = self.op_kwargs.pop("upstream_tasks", [])
         super().__init__(
             upstream_tasks=upstream_tasks,
-            **kwargs,
+            **kwargs_with_datasets(kwargs=kwargs, output_datasets=self.output_table),
         )
 
     def execute(self, context: dict) -> Table | pd.DataFrame:

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -6,6 +6,7 @@ import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
+from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import ExportExistsStrategy
 from astro.databases import create_database
 from astro.files import File
@@ -30,11 +31,14 @@ class ExportFileOperator(AstroSQLBaseOperator):
         if_exists: ExportExistsStrategy = "exception",
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
         self.output_file = output_file
         self.input_data = input_data
         self.if_exists = if_exists
         self.kwargs = kwargs
+        datasets = {"output_datasets": self.output_file}
+        if isinstance(input_data, Table):
+            datasets["input_datasets"] = input_data
+        super().__init__(**kwargs_with_datasets(kwargs=kwargs, **datasets))
 
     def execute(self, context: dict) -> File:
         """Write SQL table to csv/parquet on local/S3/GCS.

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -7,6 +7,7 @@ from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
 from astro import settings
+from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
 from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
@@ -48,7 +49,13 @@ class LoadFileOperator(AstroSQLBaseOperator):
         enable_native_fallback: bool | None = True,
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__(
+            **kwargs_with_datasets(
+                kwargs=kwargs,
+                input_datasets=input_file,
+                output_datasets=output_table,
+            )
+        )
         self.output_table = output_table
         self.input_file = input_file
         self.chunk_size = chunk_size

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -5,6 +5,7 @@ from typing import Any
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
+from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import MergeConflictStrategy
 from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
@@ -50,8 +51,14 @@ class MergeOperator(AstroSQLBaseOperator):
         self.columns = columns or {}
         self.if_conflicts = if_conflicts
         task_id = task_id or get_unique_task_id("merge")
-
-        super().__init__(task_id=task_id, **kwargs)
+        super().__init__(
+            task_id=task_id,
+            **kwargs_with_datasets(
+                kwargs=kwargs,
+                input_datasets=source_table,
+                output_datasets=target_table,
+            ),
+        )
 
     def execute(self, context: dict) -> Table:
         db = create_database(self.target_table.conn_id)

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -54,8 +54,8 @@ class Table(Dataset):
     # TODO: discuss alternative names to this class, since it contains metadata as opposed to be the
     # SQL table itself
     # Some ideas: TableRef, TableMetadata, TableData, TableDataset
-    conn_id: str = field(default="")
     _name: str = field(default="")
+    conn_id: str = field(default="")
     # Setting converter allows passing a dictionary to metadata arg
     metadata: Metadata = field(
         factory=Metadata,

--- a/python-sdk/tests/airflow/test_datasets.py
+++ b/python-sdk/tests/airflow/test_datasets.py
@@ -1,0 +1,79 @@
+from unittest import mock
+
+import pytest
+
+from astro.airflow.datasets import kwargs_with_datasets
+from astro.sql.table import Table
+
+
+@pytest.mark.parametrize(
+    "kwargs,input_datasets,output_datasets,dataset_support,expected_kwargs",
+    [
+        (None, None, None, True, {}),
+        ({"task_id": "ex1"}, None, None, True, {"task_id": "ex1"}),
+        (
+            {"task_id": "ex1"},
+            Table("inlet", conn_id="con1"),
+            Table("outlet", conn_id="con2"),
+            True,
+            {
+                "task_id": "ex1",
+                "inlets": [Table("inlet", conn_id="con1")],
+                "outlets": [Table("outlet", conn_id="con2")],
+            },
+        ),
+        (
+            {
+                "task_id": "ex1",
+                "inlets": Table("inlet", conn_id="con1"),
+                "outlets": Table("outlet"),
+            },
+            Table("input_dataset"),
+            Table("output_dataset"),
+            True,
+            {
+                "task_id": "ex1",
+                "inlets": [Table("inlet", conn_id="con1")],
+                "outlets": [Table("outlet")],
+            },
+        ),
+        (None, None, None, False, {}),
+        ({"task_id": "ex1"}, None, None, False, {"task_id": "ex1"}),
+        (
+            {"task_id": "ex1"},
+            Table("inlet", conn_id="con1"),
+            Table("outlet", conn_id="con2"),
+            False,
+            {"task_id": "ex1"},
+        ),
+        (
+            {
+                "task_id": "ex1",
+                "inlets": Table("inlet", conn_id="con1"),
+                "outlets": Table("outlet", conn_id="con2"),
+            },
+            Table("input_dataset"),
+            Table("output_dataset"),
+            False,
+            {
+                "task_id": "ex1",
+                "inlets": [Table("inlet", conn_id="con1")],
+                "outlets": [Table("outlet", conn_id="con2")],
+            },
+        ),
+    ],
+)
+def test_kwargs_with_datasets(
+    kwargs, input_datasets, output_datasets, dataset_support, expected_kwargs
+):
+    """
+    Test that:
+      1. we can extract inlets and outlets from kwargs if users pass it
+      2. passed input_datasets and output_datasets are correctly set as inlets/outlets and passed to kwargs
+      3. if dataset is not support (Airflow <2.4), we do not set inlets/outlets unless user specifies it
+    """
+    with mock.patch("astro.airflow.datasets.DATASET_SUPPORT", new=dataset_support):
+        assert (
+            kwargs_with_datasets(kwargs, input_datasets, output_datasets)
+            == expected_kwargs
+        )

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -21,6 +21,7 @@ from airflow.exceptions import BackfillUnfinished
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
 import astro.sql as aql
+from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import SUPPORTED_FILE_TYPES, Database
 from astro.files import File
 from astro.settings import SCHEMA
@@ -436,3 +437,33 @@ def test_populate_table_metadata(sample_dag, database_table_fixture):
         validate(test_table)
 
     test_utils.run_dag(sample_dag)
+
+
+@pytest.mark.skipif(
+    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
+)
+def test_inlets_outlets_supported_ds():
+    """Test Datasets are set as inlets and outlets"""
+    input_data = Table("test_name")
+    output_file = File("gs://bucket/object.csv")
+    task = aql.export_file(
+        input_data=input_data,
+        output_file=output_file,
+    )
+    assert task.operator.inlets == [input_data]
+    assert task.operator.outlets == [output_file]
+
+
+@pytest.mark.skipif(
+    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
+)
+def test_inlets_outlets_non_supported_ds():
+    """Test inlets and outlets are not set if Datasets are not supported"""
+    input_data = Table("test_name")
+    output_file = File("gs://bucket/object.csv")
+    task = aql.export_file(
+        input_data=input_data,
+        output_file=output_file,
+    )
+    assert task.operator.inlets == []
+    assert task.operator.outlets == []

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -22,6 +22,7 @@ from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from pandas.testing import assert_frame_equal
 
 from astro import sql as aql
+from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database, FileType
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.files import File
@@ -1048,3 +1049,33 @@ def test_aql_load_column_name_mixed_case_json_file_to_dbs(
 
     df = db.export_table_to_pandas_dataframe(test_table)
     assert df.shape == (2, 2)
+
+
+@pytest.mark.skipif(
+    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
+)
+def test_inlets_outlets_supported_ds():
+    """Test Datasets are set as inlets and outlets"""
+    input_file = File("gs://bucket/object.csv")
+    output_table = Table("test_name")
+    task = aql.load_file(
+        input_file=input_file,
+        output_table=output_table,
+    )
+    assert task.operator.inlets == [input_file]
+    assert task.operator.outlets == [output_table]
+
+
+@pytest.mark.skipif(
+    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
+)
+def test_inlets_outlets_non_supported_ds():
+    """Test inlets and outlets are not set if Datasets are not supported"""
+    input_file = File("gs://bucket/object.csv")
+    output_table = Table("test_name")
+    task = aql.load_file(
+        input_file=input_file,
+        output_table=output_table,
+    )
+    assert task.operator.inlets == []
+    assert task.operator.outlets == []

--- a/python-sdk/tests/sql/operators/test_merge.py
+++ b/python-sdk/tests/sql/operators/test_merge.py
@@ -8,6 +8,7 @@ import pytest
 from airflow.decorators import task_group
 
 from astro import sql as aql
+from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
 from astro.databases import create_database
 from astro.files import File
@@ -349,3 +350,47 @@ def test_invalid_columns_param():
         exec_info.value.args[0]
         == "columns is not a valid type. Valid types: [tuple, list, dict], Passed: <class 'set'>"
     )
+
+
+@pytest.mark.skipif(
+    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
+)
+def test_inlets_outlets_supported_ds():
+    """Test Datasets are set as inlets and outlets"""
+    source_table = Table(
+        name="source_table", conn_id="test1", metadata=Metadata(schema="test")
+    )
+    target_table = Table(
+        name="target_table", conn_id="test2", metadata=Metadata(schema="test")
+    )
+    task = aql.merge(
+        source_table=source_table,
+        target_table=target_table,
+        target_conflict_columns=["list"],
+        columns=["set_item_1", "set_item_2", "set_item_3"],
+        if_conflicts="ignore",
+    )
+    assert task.operator.inlets == [source_table]
+    assert task.operator.outlets == [target_table]
+
+
+@pytest.mark.skipif(
+    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
+)
+def test_inlets_outlets_non_supported_ds():
+    """Test inlets and outlets are not set if Datasets are not supported"""
+    source_table = Table(
+        name="source_table", conn_id="test1", metadata=Metadata(schema="test")
+    )
+    target_table = Table(
+        name="target_table", conn_id="test2", metadata=Metadata(schema="test")
+    )
+    task = aql.merge(
+        source_table=source_table,
+        target_table=target_table,
+        target_conflict_columns=["list"],
+        columns=["set_item_1", "set_item_2", "set_item_3"],
+        if_conflicts="ignore",
+    )
+    assert task.operator.inlets == []
+    assert task.operator.outlets == []

--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -5,6 +5,7 @@ import pytest
 from airflow.decorators import task
 
 from astro import sql as aql
+from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
 from astro.files import File
 from astro.sql.table import Table
@@ -189,7 +190,7 @@ def test_transform_with_file(database_table_fixture, sample_dag):
     """Test table creation via select statement in a SQL file"""
     import pathlib  # skipcq: PYL-W0404
 
-    CWD = pathlib.Path(__file__).parent
+    cwd = pathlib.Path(__file__).parent
     database, imdb_table = database_table_fixture
 
     @aql.dataframe
@@ -199,7 +200,7 @@ def test_transform_with_file(database_table_fixture, sample_dag):
     with sample_dag:
         target_table = Table(name="test_is_{{ ds_nodash }}", conn_id="sqlite_default")
         table_from_query = aql.transform_file(
-            file_path=str(pathlib.Path(CWD).parents[0]) + "/transform/test.sql",
+            file_path=str(pathlib.Path(cwd).parents[0]) + "/transform/test.sql",
             parameters={"input_table": imdb_table, "output_table": target_table},
         )
         validate(table_from_query)
@@ -209,3 +210,35 @@ def test_transform_with_file(database_table_fixture, sample_dag):
     expected_target_table.name = "test_is_True"
     database.drop_table(expected_target_table)
     assert not database.table_exists(expected_target_table)
+
+
+@pytest.mark.skipif(
+    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
+)
+def test_inlets_outlets_supported_ds():
+    """Test Datasets are set as inlets and outlets"""
+    imdb_table = (Table(name="imdb", conn_id="sqlite_default"),)
+    output_table = Table(name="test_name")
+
+    @aql.transform
+    def top_five_animations(input_table: Table) -> str:
+        return "SELECT title, rating FROM {{ input_table }} LIMIT 5;"
+
+    task = top_five_animations(input_table=imdb_table, output_table=output_table)
+    assert task.operator.outlets == [output_table]
+
+
+@pytest.mark.skipif(
+    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
+)
+def test_inlets_outlets_non_supported_ds():
+    """Test inlets and outlets are not set if Datasets are not supported"""
+    imdb_table = (Table(name="imdb", conn_id="sqlite_default"),)
+    output_table = Table(name="test_name")
+
+    @aql.transform
+    def top_five_animations(input_table: Table) -> str:
+        return "SELECT title, rating FROM {{ input_table }} LIMIT 5;"
+
+    task = top_five_animations(input_table=imdb_table, output_table=output_table)
+    assert task.operator.outlets == []


### PR DESCRIPTION
This PR adds inlets and outlets to the operators where it is trivial and clear on what the input and output datasets are.

If users pass their inlets and outlets to the operator, SDK will use those

part of: https://github.com/astronomer/astro-sdk/issues/611

<img width="1717" alt="image" src="https://user-images.githubusercontent.com/8811558/189255276-4411eb9f-b8fc-46d3-82dd-3ce3e602e4fd.png">


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
