### PR TITLE
Fix mypy hook not finding attrs module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
       rev: 'v0.971'
       hooks:
       - id: mypy
-        additional_dependencies: [types-PyYAML, types-attrs]
+        additional_dependencies: [types-PyYAML, types-attrs, attrs]
         pass_filenames: false
         files: "^python-sdk/"
         entry: bash -c 'cd python-sdk && mypy "$@"' --


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, pre-commit mypy check is failing due to missing attrs module.

## What is the new behavior?

We are adding the attrs module to mypy hook's additional dependencies.

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
