### PR TITLE
Add python-sdk workflow file and global project files to ci path triggers

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -4,6 +4,7 @@ on:
     branches: [ 'main', 'release-**' ]
     paths:
       - 'python-sdk/**'
+      - '.github/workflows/ci-python-sdk.yaml'
       - '*'
   pull_request:
     branches: [ 'main', 'release-**' ]

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -9,7 +9,7 @@ on:
     branches: [ 'main', 'release-**' ]
     paths:
       - 'python-sdk/**'
-      - '.pre-commit-config.yaml'
+      - '*'
   # Run on PRs from forks
   pull_request_target:
     branches: [ 'main' ]

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -10,6 +10,7 @@ on:
     branches: [ 'main', 'release-**' ]
     paths:
       - 'python-sdk/**'
+      - '.github/workflows/ci-python-sdk.yaml'
       - '*'
   # Run on PRs from forks
   pull_request_target:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -4,10 +4,12 @@ on:
     branches: [ 'main', 'release-**' ]
     paths:
       - 'python-sdk/**'
+      - '.pre-commit-config.yaml'
   pull_request:
     branches: [ 'main', 'release-**' ]
     paths:
       - 'python-sdk/**'
+      - '.pre-commit-config.yaml'
   # Run on PRs from forks
   pull_request_target:
     branches: [ 'main' ]

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -4,7 +4,7 @@ on:
     branches: [ 'main', 'release-**' ]
     paths:
       - 'python-sdk/**'
-      - '.pre-commit-config.yaml'
+      - '*'
   pull_request:
     branches: [ 'main', 'release-**' ]
     paths:


### PR DESCRIPTION
# Description

## What is the current behavior?

The CI does not trigger the required build-docs pipeline.

related: #813

## What is the new behavior?

This PR adds the following paths to the ci triggers:

- `'.github/workflows/ci-python-sdk.yaml'`
- `'*'`

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
