### PR TITLE
Update quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
 
     ```shell
     # The sqlite_default connection has different host for MAC vs. Linux
-    export SQL_TABLE_NAME=`airflow connections get sqlite_default -o     yaml | grep host | awk '{print $2}'`
+    export SQL_TABLE_NAME=`airflow connections get sqlite_default -o yaml | grep host | awk '{print $2}'`
     sqlite3 "$SQL_TABLE_NAME" "VACUUM;"
     ```
 

--- a/python-sdk/example_dags/calculate_popular_movies.py
+++ b/python-sdk/example_dags/calculate_popular_movies.py
@@ -10,9 +10,9 @@ from astro.sql.table import Table
 @aql.transform()
 def top_five_animations(input_table: Table):
     return """
-        SELECT Title, Rating
+        SELECT title, rating
         FROM {{input_table}}
-        WHERE Genre1=='Animation'
+        WHERE genre1='Animation'
         ORDER BY Rating desc
         LIMIT 5;
     """
@@ -26,7 +26,7 @@ with DAG(
 ) as dag:
     imdb_movies = aql.load_file(
         File(
-            "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb.csv"
+            "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
         ),
         output_table=Table(conn_id="sqlite_default"),
     )
@@ -34,4 +34,3 @@ with DAG(
         input_table=imdb_movies,
         output_table=Table(name="top_animation"),
     )
-    aql.cleanup()


### PR DESCRIPTION
- This PR makes similar change as https://github.com/astronomer/astro-sdk/pull/728 to make the SQL compatible with Postgres as well as Sqlite
- Removes `aql.cleanup` task as the quick start on most machines will use sqlite with local or sequential executor



## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
