### PR TITLE
Fix test for load_file_to_table_natively_for_fallback method

### DIFF
--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -320,12 +320,12 @@ def test_load_file_to_table_natively_for_fallback_wrong_file_location(
     database, target_table = database_table_fixture
     filepath = "https://www.data.com/data/sample.json"
 
-    response = database.load_file_to_table_natively_with_fallback(
-        source_file=File(filepath),
-        target_table=target_table,
-        enable_native_fallback=False,
-    )
-    assert response is None
+    with pytest.raises(DatabaseCustomError):
+        database.load_file_to_table_natively_with_fallback(
+            source_file=File(filepath),
+            target_table=target_table,
+            enable_native_fallback=False,
+        )
 
 
 @pytest.mark.integration

--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -330,7 +330,7 @@ def test_load_file_to_table_natively_for_fallback_raise_exception(
     database, target_table = database_table_fixture
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
     with pytest.raises(DatabaseCustomError):
-        database.git(
+        database.load_file_to_table_natively_with_fallback(
             source_file=File(filepath),
             target_table=target_table,
             enable_native_fallback=False,

--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -317,10 +317,10 @@ def test_load_file_from_cloud_to_table(database_table_fixture):
 )
 @mock.patch("astro.databases.snowflake.SnowflakeDatabase.hook")
 @mock.patch("astro.databases.snowflake.SnowflakeDatabase.create_stage")
-def test_load_file_to_table_natively_for_fallback(
+def test_load_file_to_table_natively_for_fallback_raise_exception(
     mock_stage, mock_hook, database_table_fixture
 ):
-    """Test loading on files to bigquery natively for fallback."""
+    """Test loading on files to snowflake natively for fallback raise exception."""
     mock_hook.run.side_effect = ValueError
     mock_stage.return_value = SnowflakeStage(
         name="mock_stage",
@@ -329,12 +329,12 @@ def test_load_file_to_table_natively_for_fallback(
     )
     database, target_table = database_table_fixture
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
-    response = database.load_file_to_table_natively_with_fallback(
-        source_file=File(filepath),
-        target_table=target_table,
-        enable_native_fallback=False,
-    )
-    assert response is None
+    with pytest.raises(DatabaseCustomError):
+        database.git(
+            source_file=File(filepath),
+            target_table=target_table,
+            enable_native_fallback=False,
+        )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently when native load is disabled, the loadFile raises the exception. The unit test for that doesn't reflect as per the changes on load_file_to_table_natively_with_fallback method

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #840 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Raise the exception as part of the test


## Does this introduce a breaking change?


### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
