### PR TITLE
Fix Astro CLI doc link

### DIFF
--- a/python-sdk/docs/getting-started/GETTING_STARTED.md
+++ b/python-sdk/docs/getting-started/GETTING_STARTED.md
@@ -28,7 +28,7 @@ To complete this tutorial, you need:
 - An AWS S3 account with a [storage bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/GetStartedWithS3.html). If you don't already have an account, Amazon offers 5GB of free storage in S3 for 12 months. This should be more than enough for this tutorial.
 - A Snowflake Enterprise account. If you don't already have an account, Snowflake has a [free Snowflake trial](https://signup.snowflake.com/) for 30 days.
 - Python 3.
-- A local Airflow environment. You can use either [Apache Airflow](https://airflow.apache.org/docs/apache-airflow/stable/start/local.html) or [the Astro CLI](https://docs.astronomer.io/astro/cli/get-started) to run your environment. If you're using the Astro CLI, we recommend [creating a new Astro project](https://docs.astronomer.io/astro/create-project) for this tutorial.
+- A local Airflow environment. You can use either [Apache Airflow](https://airflow.apache.org/docs/apache-airflow/stable/start/local.html) or [the Astro CLI](https://docs.astronomer.io/astro/cli/install-cli) to run your environment. If you're using the Astro CLI, we recommend [creating a new Astro project](https://docs.astronomer.io/astro/create-project) for this tutorial.
 
 ## Step 1: Set up your data stores
 


### PR DESCRIPTION
This old link no longer works and is redirected to https://docs.astronomer.io/astro/cli/install-cli
