### PR TITLE
Do not run identity pre-commit hook in ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ---
 ci:
-  skip: [mypy]
+  skip:
+    - mypy  # requires additional dependencies in ci
+    - identity  # output is too verbose for ci; pre-commit.ci truncates almost all output after that
 default_stages: [commit, push]
 default_language_version:
   # force all unspecified python hooks to run python3


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, the pre-commit.ci output is being truncated because of identity hook being too verbose.

Example [here](https://results.pre-commit.ci/run/github/435573069/1663162240.QyWx3JFaRKSvxyfWmP0Wvw)

## What is the new behavior?

I think it would be fine disabling it in CI. Testing which files pre-commit uses can also be checked locally. However if we need the identity in CI we should find another way of increasing the limit of the output or raising a ticket [here](https://github.com/pre-commit-ci/issues/issues).

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
