### PR TITLE
Skip loading file for bigquery schema detection

### DIFF
--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -18,7 +18,6 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase
 from astro.exceptions import DatabaseCustomError
-from astro.files import File
 from astro.settings import BIGQUERY_SCHEMA
 from astro.sql.table import Metadata, Table
 from google.api_core.exceptions import (
@@ -50,6 +49,8 @@ from google.resumable_media import InvalidResponse
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
 from tenacity import retry, stop_after_attempt
+
+from astro.files import File
 
 DEFAULT_CONN_ID = BigQueryHook.default_conn_name
 NATIVE_PATHS_SUPPORTED_FILE_TYPES = {
@@ -247,7 +248,7 @@ class BigqueryDatabase(BaseDatabase):
             return True
         return False
 
-    def create_table_using_native_schema_autodetection(
+    def create_table_using_native_schema_autodetection(  # skipcq: PYL-R0201
         self,
         table: Table,
         file: File,

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -18,6 +18,7 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase
 from astro.exceptions import DatabaseCustomError
+from astro.files import File
 from astro.settings import BIGQUERY_SCHEMA
 from astro.sql.table import Metadata, Table
 from google.api_core.exceptions import (
@@ -49,8 +50,6 @@ from google.resumable_media import InvalidResponse
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
 from tenacity import retry, stop_after_attempt
-
-from astro.files import File
 
 DEFAULT_CONN_ID = BigQueryHook.default_conn_name
 NATIVE_PATHS_SUPPORTED_FILE_TYPES = {

--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -8,8 +8,10 @@ import pandas as pd
 import pytest
 import sqlalchemy
 from astro.constants import Database
+from astro.databases import create_database
 from astro.databases.google.bigquery import BigqueryDatabase, S3ToBigqueryDataTransfer
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
+from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table
 from astro.utils.load import copy_remote_file_to_local
@@ -18,9 +20,6 @@ from google.cloud.bigquery_datatransfer_v1.types import (
     TransferConfig,
     TransferRun,
 )
-
-from astro.databases import create_database
-from astro.files import File
 from tests.sql.operators import utils as test_utils
 
 DEFAULT_CONN_ID = "google_cloud_default"

--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -8,10 +8,8 @@ import pandas as pd
 import pytest
 import sqlalchemy
 from astro.constants import Database
-from astro.databases import create_database
 from astro.databases.google.bigquery import BigqueryDatabase, S3ToBigqueryDataTransfer
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
-from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table
 from astro.utils.load import copy_remote_file_to_local
@@ -20,6 +18,9 @@ from google.cloud.bigquery_datatransfer_v1.types import (
     TransferConfig,
     TransferRun,
 )
+
+from astro.databases import create_database
+from astro.files import File
 from tests.sql.operators import utils as test_utils
 
 DEFAULT_CONN_ID = "google_cloud_default"
@@ -144,51 +145,6 @@ def test_bigquery_create_table_with_columns(database_table_fixture):
     indirect=True,
     ids=["bigquery"],
 )
-def test_bigquery_create_table_using_native_schema_autodetection(
-    database_table_fixture,
-):
-    """Test table creation using native schema autodetection"""
-    database, table = database_table_fixture
-
-    # Looking for specific columns in INFORMATION_SCHEMA.COLUMNS as Bigquery can add/remove columns in the table.
-    statement = (
-        f"SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE "
-        f"FROM {table.metadata.schema}.INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
-    )
-    response = database.run_sql(statement)
-    assert response.first() is None
-
-    file = File("gs://astro-sdk/workspace/test-sample-njson.ndjson", conn_id="gcp_conn")
-    database.create_table(table, file)
-    response = database.run_sql(statement)
-    rows = response.fetchall()
-    assert len(rows) == 2
-    assert rows == [
-        (
-            "astronomer-dag-authoring",
-            table.metadata.schema,
-            table.name,
-            "result",
-            (
-                "STRUCT<pageData STRUCT<timestamp INT64, statusCode INT64>,"
-                " sequenceNumber INT64, timestamp INT64, extractorData STRUCT<data"
-                " ARRAY<STRUCT<`group` ARRAY<STRUCT<Business ARRAY<STRUCT<text STRING,"
-                " href STRING>>>>>>, url STRING>>"
-            ),
-        ),
-        (
-            "astronomer-dag-authoring",
-            table.metadata.schema,
-            table.name,
-            "url",
-            "STRING",
-        ),
-    ]
-    statement = f"SELECT COUNT(*) FROM {database.get_table_qualified_name(table)}"
-    count = database.run_sql(statement).scalar()
-    assert count == 0
-
-
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",

--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -8,10 +8,8 @@ import pandas as pd
 import pytest
 import sqlalchemy
 from astro.constants import Database
-from astro.databases import create_database
 from astro.databases.google.bigquery import BigqueryDatabase, S3ToBigqueryDataTransfer
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
-from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table
 from astro.utils.load import copy_remote_file_to_local
@@ -20,6 +18,9 @@ from google.cloud.bigquery_datatransfer_v1.types import (
     TransferConfig,
     TransferRun,
 )
+
+from astro.databases import create_database
+from astro.files import File
 from tests.sql.operators import utils as test_utils
 
 DEFAULT_CONN_ID = "google_cloud_default"
@@ -130,20 +131,6 @@ def test_bigquery_create_table_with_columns(database_table_fixture):
     )
 
 
-@pytest.mark.integration
-@pytest.mark.parametrize(
-    "database_table_fixture",
-    [
-        {
-            "database": Database.BIGQUERY,
-            "table": Table(
-                metadata=Metadata(schema=SCHEMA),
-            ),
-        }
-    ],
-    indirect=True,
-    ids=["bigquery"],
-)
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -19,16 +19,15 @@ import pytest
 from airflow.exceptions import BackfillUnfinished
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from astro import sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database, FileType
 from astro.exceptions import IllegalLoadToDatabaseException
+from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.operators.load_file import load_file
 from astro.sql.table import Metadata, Table
 from pandas.testing import assert_frame_equal
-
-from astro import sql as aql
-from astro.files import File
 from tests.sql.operators import utils as test_utils
 
 OUTPUT_TABLE_NAME = test_utils.get_table_name("load_file_test_table")


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, the way we are autodetecting schema for bigquery is loading an entire file, and then truncating the table loaded earlier is not an optimal approach.
 
related: https://github.com/astronomer/astro-sdk/issues/709
closes: #838 

## What is the new behavior?
We can skip autodetection altogether and this would prevent us from loading files twice as well.

## Does this introduce a breaking change?
No