### PR TITLE
Allow users to disable auto addition of inlets/outlets via airflow.cfg

### DIFF
--- a/python-sdk/src/astro/airflow/datasets.py
+++ b/python-sdk/src/astro/airflow/datasets.py
@@ -20,13 +20,25 @@ def kwargs_with_datasets(
     Extract inlets and outlets from kwargs if users have passed it. If not, set input datasets as inlets and
     set output dataset as outlets
     """
+    from astro import settings
+
     kwargs = kwargs or {}
-    if "inlets" in kwargs or DATASET_SUPPORT and input_datasets:
+    if (
+        "inlets" in kwargs
+        or DATASET_SUPPORT
+        and settings.AUTO_ADD_INLETS_OUTLETS
+        and input_datasets
+    ):
         inlets = kwargs.get("inlets", input_datasets)
         inlets = inlets if isinstance(inlets, list) else [inlets]
         kwargs.update({"inlets": inlets})
 
-    if "outlets" in kwargs or DATASET_SUPPORT and output_datasets:
+    if (
+        "outlets" in kwargs
+        or DATASET_SUPPORT
+        and settings.AUTO_ADD_INLETS_OUTLETS
+        and output_datasets
+    ):
         outlets = kwargs.get("outlets", output_datasets)
         outlets = outlets if isinstance(outlets, list) else [outlets]
         kwargs.update({"outlets": outlets})

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -36,3 +36,8 @@ LOAD_TABLE_AUTODETECT_ROWS_COUNT = conf.getint(
 RAW_SQL_MAX_RESPONSE_SIZE = conf.getint(
     section="astro_sdk", key="run_raw_sql_response_size", fallback=-1
 )
+
+# Should Astro SDK automatically add inlets/outlets to take advantage of Airflow 2.4 Data-aware scheduling
+AUTO_ADD_INLETS_OUTLETS = conf.getboolean(
+    "astro_sdk", "auto_add_inlets_outlets", fallback=True
+)

--- a/python-sdk/tests/airflow/test_datasets.py
+++ b/python-sdk/tests/airflow/test_datasets.py
@@ -25,6 +25,13 @@ from astro.sql.table import Table
             },
         ),
         (
+            {"task_id": "ex1", "inlets": [], "outlets": []},
+            Table("inlet", conn_id="con1"),
+            Table("outlet", conn_id="con2"),
+            True,
+            {"task_id": "ex1", "inlets": [], "outlets": []},
+        ),
+        (
             {
                 "task_id": "ex1",
                 "inlets": Table("inlet", conn_id="con1"),
@@ -72,7 +79,7 @@ def test_kwargs_with_datasets(
     Test that:
       1. we can extract inlets and outlets from kwargs if users pass it
       2. passed input_datasets and output_datasets are correctly set as inlets/outlets and passed to kwargs
-      3. if dataset is not support (Airflow <2.4), we do not set inlets/outlets unless user specifies it
+      3. if dataset is not supported (Airflow <2.4), we do not set inlets/outlets unless user specifies it
     """
     with mock.patch("astro.airflow.datasets.DATASET_SUPPORT", new=dataset_support):
         assert (
@@ -98,3 +105,13 @@ def test_example_dataset_dag():
     # Test that dataset_triggers is only set if all the instances passed to the DAG object are Datasets
     assert consumer_dag.dataset_triggers == outlets
     assert outlets[0].uri == "astro://sqlite_default@?table=imdb_movies"
+
+
+def test_disable_auto_inlets_outlets():
+    """Test that if ``[astro_sdk] auto_add_inlets_outlets = False``, inlets/outlets are not set"""
+    with mock.patch("astro.settings.AUTO_ADD_INLETS_OUTLETS", new=False):
+        assert kwargs_with_datasets(
+            {"task_id": "ex1"},
+            [Table("inlet", conn_id="con1")],
+            [Table("outlet", conn_id="con2")],
+        ) == {"task_id": "ex1"}


### PR DESCRIPTION
Astro SDK automatically adds inlets and outlets for all the operators if DATASET is supported (Airflow >=2.4).

Users can over-ride it on a task level by adding inlets and outlets themselves. However, for users who want to use SDK with Airflow 2.4 and above but do not want to leverage Data-aware scheduling, auto-addition of inlets/outlets would be annoying so this new config setting will provide an escape hatch for such users.

closes https://github.com/astronomer/astro-sdk/issues/857


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary. -- @pankajkoti can you add it in https://github.com/astronomer/astro-sdk/pull/854 plz
 