### PR TITLE
Stop generating Datasets for temp tables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,11 +73,11 @@ repos:
     hooks:
       - id: isort
         name: Run isort for python-sdk
-        args: ["--profile=black"]
+        args: [ "--profile", "black" ]
         files: ^python-sdk/
       - id: isort
         name: Run isort for sql-cli
-        args: ["--profile=black"]
+        args: [ "--profile", "black" ]
         files: ^sql-cli/
 
   - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,11 +73,11 @@ repos:
     hooks:
       - id: isort
         name: Run isort for python-sdk
-        args: [ "--profile", "black" ]
+        args: ["--profile=black"]
         files: ^python-sdk/
       - id: isort
         name: Run isort for sql-cli
-        args: [ "--profile", "black" ]
+        args: ["--profile=black"]
         files: ^sql-cli/
 
   - repo: https://github.com/codespell-project/codespell

--- a/python-sdk/src/astro/airflow/datasets.py
+++ b/python-sdk/src/astro/airflow/datasets.py
@@ -29,8 +29,15 @@ def kwargs_with_datasets(
         and settings.AUTO_ADD_INLETS_OUTLETS
         and input_datasets
     ):
+        # Remove non-dataset objects like Temp tables (unless passed by user)
+        input_datasets = (
+            input_datasets if isinstance(input_datasets, list) else [input_datasets]
+        )
+        input_datasets = [
+            input_ds for input_ds in input_datasets if isinstance(input_ds, Dataset)
+        ]
+
         inlets = kwargs.get("inlets", input_datasets)
-        inlets = inlets if isinstance(inlets, list) else [inlets]
         kwargs.update({"inlets": inlets})
 
     if (
@@ -39,8 +46,15 @@ def kwargs_with_datasets(
         and settings.AUTO_ADD_INLETS_OUTLETS
         and output_datasets
     ):
+        # Remove non-dataset objects like Temp tables (unless passed by user)
+        output_datasets = (
+            output_datasets if isinstance(output_datasets, list) else [output_datasets]
+        )
+        output_datasets = [
+            output_ds for output_ds in output_datasets if isinstance(output_ds, Dataset)
+        ]
+
         outlets = kwargs.get("outlets", output_datasets)
-        outlets = outlets if isinstance(outlets, list) else [outlets]
         kwargs.update({"outlets": outlets})
 
     return kwargs

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -13,6 +13,7 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase
 from astro.exceptions import DatabaseCustomError
+from astro.files import File
 from astro.settings import REDSHIFT_SCHEMA
 from astro.sql.table import BaseTable, Metadata, Table
 from redshift_connector.error import (
@@ -29,8 +30,6 @@ from redshift_connector.error import (
 )
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
-
-from astro.files import File
 
 DEFAULT_CONN_ID = RedshiftSQLHook.default_conn_name
 NATIVE_PATHS_SUPPORTED_FILE_TYPES = {

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -13,9 +13,8 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase
 from astro.exceptions import DatabaseCustomError
-from astro.files import File
 from astro.settings import REDSHIFT_SCHEMA
-from astro.sql.table import Metadata, Table
+from astro.sql.table import BaseTable, Metadata, Table
 from redshift_connector.error import (
     ArrayContentNotHomogenousError,
     ArrayContentNotSupportedError,
@@ -30,6 +29,8 @@ from redshift_connector.error import (
 )
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
+
+from astro.files import File
 
 DEFAULT_CONN_ID = RedshiftSQLHook.default_conn_name
 NATIVE_PATHS_SUPPORTED_FILE_TYPES = {
@@ -110,7 +111,7 @@ class RedshiftDatabase(BaseDatabase):
         )
         return len(schema_result) > 0
 
-    def table_exists(self, table: Table) -> bool:
+    def table_exists(self, table: BaseTable) -> bool:
         """
         Check if a table exists in the database.
 
@@ -126,7 +127,7 @@ class RedshiftDatabase(BaseDatabase):
     def load_pandas_dataframe_to_table(
         self,
         source_dataframe: pd.DataFrame,
-        target_table: Table,
+        target_table: BaseTable,
         if_exists: LoadExistStrategy = "replace",
         chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
@@ -210,8 +211,8 @@ class RedshiftDatabase(BaseDatabase):
 
     def merge_table(
         self,
-        source_table: Table,
-        target_table: Table,
+        source_table: BaseTable,
+        target_table: BaseTable,
         source_to_target_columns_map: Dict[str, str],
         target_conflict_columns: List[str],
         if_conflicts: MergeConflictStrategy = "exception",
@@ -300,7 +301,7 @@ class RedshiftDatabase(BaseDatabase):
                 cursor.execute(statement)
 
     def is_native_load_file_available(
-        self, source_file: File, target_table: Table
+        self, source_file: File, target_table: BaseTable
     ) -> bool:
         """
         Check if there is an optimised path for source to destination.
@@ -315,7 +316,7 @@ class RedshiftDatabase(BaseDatabase):
     def load_file_to_table_natively(
         self,
         source_file: File,
-        target_table: Table,
+        target_table: BaseTable,
         if_exists: LoadExistStrategy = "replace",
         native_support_kwargs: Optional[Dict] = None,
         **kwargs,
@@ -348,7 +349,7 @@ class RedshiftDatabase(BaseDatabase):
     def load_s3_file_to_table(
         self,
         source_file: File,
-        target_table: Table,
+        target_table: BaseTable,
         native_support_kwargs: Optional[Dict] = None,
         **kwargs,
     ):

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -15,6 +15,7 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
+from astro.files import File, resolve_file_path_pattern
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
 from pandas.io.sql import SQLDatabase
@@ -22,8 +23,6 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
-
-from astro.files import File, resolve_file_path_pattern
 
 
 class BaseDatabase(ABC):

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -15,14 +15,15 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
-from astro.files import File, resolve_file_path_pattern
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
-from astro.sql.table import Metadata, Table
+from astro.sql.table import BaseTable, Metadata
 from pandas.io.sql import SQLDatabase
 from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
+
+from astro.files import File, resolve_file_path_pattern
 
 
 class BaseDatabase(ABC):
@@ -100,7 +101,7 @@ class BaseDatabase(ABC):
             result = self.connection.execute(sql_statement, parameters)
         return result
 
-    def columns_exist(self, table: Table, columns: list[str]) -> bool:
+    def columns_exist(self, table: BaseTable, columns: list[str]) -> bool:
         """
         Check that a list of columns exist in the given table.
 
@@ -115,7 +116,7 @@ class BaseDatabase(ABC):
             for column in columns
         )
 
-    def table_exists(self, table: Table) -> bool:
+    def table_exists(self, table: BaseTable) -> bool:
         """
         Check if a table exists in the database.
 
@@ -139,7 +140,7 @@ class BaseDatabase(ABC):
         return sql
 
     @staticmethod
-    def get_table_qualified_name(table: Table) -> str:  # skipcq: PYL-R0201
+    def get_table_qualified_name(table: BaseTable) -> str:  # skipcq: PYL-R0201
         """
         Return table qualified name. This is Database-specific.
         For instance, in Sqlite this is the table name. In Snowflake, however, it is the database, schema and table
@@ -165,7 +166,7 @@ class BaseDatabase(ABC):
         """
         raise NotImplementedError
 
-    def populate_table_metadata(self, table: Table) -> Table:
+    def populate_table_metadata(self, table: BaseTable) -> BaseTable:
         """
         Given a table, check if the table has metadata.
         If the metadata is missing, and the database has metadata, assign it to the table.
@@ -184,7 +185,7 @@ class BaseDatabase(ABC):
     # ---------------------------------------------------------
     # Table creation & deletion methods
     # ---------------------------------------------------------
-    def create_table_using_columns(self, table: Table) -> None:
+    def create_table_using_columns(self, table: BaseTable) -> None:
         """
         Create a SQL table using the table columns.
 
@@ -199,7 +200,7 @@ class BaseDatabase(ABC):
 
     def create_table_using_native_schema_autodetection(
         self,
-        table: Table,
+        table: BaseTable,
         file: File,
     ) -> None:
         """
@@ -214,7 +215,7 @@ class BaseDatabase(ABC):
 
     def create_table_using_schema_autodetection(
         self,
-        table: Table,
+        table: BaseTable,
         file: File | None = None,
         dataframe: pd.DataFrame | None = None,
         columns_names_capitalization: ColumnCapitalization = "lower",  # skipcq
@@ -261,7 +262,7 @@ class BaseDatabase(ABC):
 
     def create_table(
         self,
-        table: Table,
+        table: BaseTable,
         file: File | None = None,
         dataframe: pd.DataFrame | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
@@ -288,7 +289,7 @@ class BaseDatabase(ABC):
     def create_table_from_select_statement(
         self,
         statement: str,
-        target_table: Table,
+        target_table: BaseTable,
         parameters: dict | None = None,
     ) -> None:
         """
@@ -303,7 +304,7 @@ class BaseDatabase(ABC):
         )
         self.run_sql(statement, parameters)
 
-    def drop_table(self, table: Table) -> None:
+    def drop_table(self, table: BaseTable) -> None:
         """
         Delete a SQL table, if it exists.
 
@@ -321,7 +322,7 @@ class BaseDatabase(ABC):
     def load_file_to_table(
         self,
         input_file: File,
-        output_table: Table,
+        output_table: BaseTable,
         normalize_config: dict | None = None,
         if_exists: LoadExistStrategy = "replace",
         chunk_size: int = DEFAULT_CHUNK_SIZE,
@@ -389,7 +390,7 @@ class BaseDatabase(ABC):
     def load_file_to_table_natively_with_fallback(
         self,
         source_file: File,
-        target_table: Table,
+        target_table: BaseTable,
         if_exists: LoadExistStrategy = "replace",
         native_support_kwargs: dict | None = None,
         enable_native_fallback: bool | None = True,
@@ -433,7 +434,7 @@ class BaseDatabase(ABC):
     def load_pandas_dataframe_to_table(
         self,
         source_dataframe: pd.DataFrame,
-        target_table: Table,
+        target_table: BaseTable,
         if_exists: LoadExistStrategy = "replace",
         chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
@@ -457,8 +458,8 @@ class BaseDatabase(ABC):
 
     def append_table(
         self,
-        source_table: Table,
-        target_table: Table,
+        source_table: BaseTable,
+        target_table: BaseTable,
         source_to_target_columns_map: dict[str, str],
     ) -> None:
         """
@@ -494,8 +495,8 @@ class BaseDatabase(ABC):
 
     def merge_table(
         self,
-        source_table: Table,
-        target_table: Table,
+        source_table: BaseTable,
+        target_table: BaseTable,
         source_to_target_columns_map: dict[str, str],
         target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
@@ -512,7 +513,7 @@ class BaseDatabase(ABC):
         """
         raise NotImplementedError
 
-    def get_sqla_table(self, table: Table) -> SqlaTable:
+    def get_sqla_table(self, table: BaseTable) -> SqlaTable:
         """
         Return SQLAlchemy table instance
 
@@ -528,7 +529,7 @@ class BaseDatabase(ABC):
     # ---------------------------------------------------------
     # Extract methods
     # ---------------------------------------------------------
-    def export_table_to_pandas_dataframe(self, source_table: Table) -> pd.DataFrame:
+    def export_table_to_pandas_dataframe(self, source_table: BaseTable) -> pd.DataFrame:
         """
         Copy the content of a table to an in-memory Pandas dataframe.
 
@@ -545,7 +546,7 @@ class BaseDatabase(ABC):
 
     def export_table_to_file(
         self,
-        source_table: Table,
+        source_table: BaseTable,
         target_file: File,
         if_exists: ExportExistsStrategy = "exception",
     ) -> None:
@@ -592,7 +593,7 @@ class BaseDatabase(ABC):
     # ---------------------------------------------------------
 
     def get_sqlalchemy_template_table_identifier_and_parameter(
-        self, table: Table, jinja_table_identifier: str
+        self, table: BaseTable, jinja_table_identifier: str
     ) -> tuple[str, str]:
         """
         During the conversion from a Jinja-templated SQL query to a SQLAlchemy query, there is the need to
@@ -621,7 +622,7 @@ class BaseDatabase(ABC):
         )
 
     def is_native_load_file_available(  # skipcq: PYL-R0201
-        self, source_file: File, target_table: Table  # skipcq: PYL-W0613
+        self, source_file: File, target_table: BaseTable  # skipcq: PYL-W0613
     ) -> bool:
         """
         Check if there is an optimised path for source to destination.
@@ -634,7 +635,7 @@ class BaseDatabase(ABC):
     def load_file_to_table_natively(
         self,
         source_file: File,
-        target_table: Table,
+        target_table: BaseTable,
         if_exists: LoadExistStrategy = "replace",
         native_support_kwargs: dict | None = None,
         **kwargs,

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -18,6 +18,7 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase
 from astro.exceptions import DatabaseCustomError
+from astro.files import File
 from astro.settings import BIGQUERY_SCHEMA
 from astro.sql.table import BaseTable, Metadata
 from google.api_core.exceptions import (
@@ -49,8 +50,6 @@ from google.resumable_media import InvalidResponse
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
 from tenacity import retry, stop_after_attempt
-
-from astro.files import File
 
 DEFAULT_CONN_ID = BigQueryHook.default_conn_name
 NATIVE_PATHS_SUPPORTED_FILE_TYPES = {

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -10,7 +10,7 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy, MergeConflictStrategy
 from astro.databases.base import BaseDatabase
 from astro.settings import POSTGRES_SCHEMA
-from astro.sql.table import Metadata, Table
+from astro.sql.table import BaseTable, Metadata
 from psycopg2 import sql as postgres_sql
 
 DEFAULT_CONN_ID = PostgresHook.default_conn_name
@@ -71,7 +71,7 @@ class PostgresDatabase(BaseDatabase):
     def load_pandas_dataframe_to_table(
         self,
         source_dataframe: pd.DataFrame,
-        target_table: Table,
+        target_table: BaseTable,
         if_exists: LoadExistStrategy = "replace",
         chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
@@ -102,7 +102,7 @@ class PostgresDatabase(BaseDatabase):
             conn.commit()
 
     @staticmethod
-    def get_table_qualified_name(table: Table) -> str:  # skipcq: PYL-R0201
+    def get_table_qualified_name(table: BaseTable) -> str:  # skipcq: PYL-R0201
         """
         Return table qualified name. This is Database-specific.
         For instance, in Sqlite this is the table name. In Snowflake, however, it is the database, schema and table
@@ -118,7 +118,7 @@ class PostgresDatabase(BaseDatabase):
             qualified_name = table.name
         return qualified_name
 
-    def table_exists(self, table: Table) -> bool:
+    def table_exists(self, table: BaseTable) -> bool:
         """
         Check if a table exists in the database
 
@@ -135,8 +135,8 @@ class PostgresDatabase(BaseDatabase):
 
     def merge_table(
         self,
-        source_table: Table,
-        target_table: Table,
+        source_table: BaseTable,
+        target_table: BaseTable,
         source_to_target_columns_map: dict[str, str],
         target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
@@ -152,7 +152,7 @@ class PostgresDatabase(BaseDatabase):
         :param if_conflicts: The strategy to be applied if there are conflicts.
         """
 
-        def identifier_args(table: Table):
+        def identifier_args(table: BaseTable):
             schema = table.metadata.schema
             return (schema, table.name) if schema else (table.name,)
 

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from astro import settings
 from astro.constants import (
     DEFAULT_CHUNK_SIZE,
     ColumnCapitalization,
@@ -20,6 +21,7 @@ from astro.constants import (
 )
 from astro.databases.base import BaseDatabase
 from astro.exceptions import DatabaseCustomError
+from astro.files import File
 from astro.settings import SNOWFLAKE_SCHEMA
 from astro.sql.table import BaseTable, Metadata
 from snowflake.connector import pandas_tools
@@ -35,9 +37,6 @@ from snowflake.connector.errors import (
     RequestTimeoutError,
     ServiceUnavailableError,
 )
-
-from astro import settings
-from astro.files import File
 
 DEFAULT_CONN_ID = SnowflakeHook.default_conn_name
 

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from astro.constants import MergeConflictStrategy
 from astro.databases.base import BaseDatabase
-from astro.sql.table import Metadata, Table
+from astro.sql.table import BaseTable, Metadata
 from sqlalchemy import MetaData as SqlaMetaData
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
@@ -47,7 +47,7 @@ class SqliteDatabase(BaseDatabase):
     # Table metadata
     # ---------------------------------------------------------
     @staticmethod
-    def get_table_qualified_name(table: Table) -> str:
+    def get_table_qualified_name(table: BaseTable) -> str:
         """
         Return the table qualified name.
 
@@ -55,7 +55,7 @@ class SqliteDatabase(BaseDatabase):
         """
         return str(table.name)
 
-    def populate_table_metadata(self, table: Table) -> Table:
+    def populate_table_metadata(self, table: BaseTable) -> BaseTable:
         """
         Since SQLite does not have a concept of databases or schemas, we just return the table as is,
         without any modifications.
@@ -83,8 +83,8 @@ class SqliteDatabase(BaseDatabase):
 
     def merge_table(
         self,
-        source_table: Table,
-        target_table: Table,
+        source_table: BaseTable,
+        target_table: BaseTable,
         source_to_target_columns_map: dict[str, str],
         target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
@@ -122,7 +122,7 @@ class SqliteDatabase(BaseDatabase):
 
         self.run_sql(sql_statement=query)
 
-    def get_sqla_table(self, table: Table) -> SqlaTable:
+    def get_sqla_table(self, table: BaseTable) -> SqlaTable:
         """
         Return SQLAlchemy table instance
 

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -5,10 +5,11 @@ from typing import Any
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 from astro.airflow.datasets import kwargs_with_datasets
-from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.sql.table import Table
+from astro.sql.table import BaseTable
 from astro.utils.typing_compat import Context
+
+from astro.databases import create_database
 
 
 class AppendOperator(AstroSQLBaseOperator):
@@ -27,8 +28,8 @@ class AppendOperator(AstroSQLBaseOperator):
 
     def __init__(
         self,
-        source_table: Table,
-        target_table: Table,
+        source_table: BaseTable,
+        target_table: BaseTable,
         columns: list[str] | tuple[str] | dict[str, str] | None = None,
         task_id: str = "",
         **kwargs: Any,
@@ -51,7 +52,7 @@ class AppendOperator(AstroSQLBaseOperator):
             ),
         )
 
-    def execute(self, context: Context) -> Table:  # skipcq: PYL-W0613
+    def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613
         db = create_database(self.target_table.conn_id)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
@@ -65,8 +66,8 @@ class AppendOperator(AstroSQLBaseOperator):
 
 def append(
     *,
-    source_table: Table,
-    target_table: Table,
+    source_table: BaseTable,
+    target_table: BaseTable,
     columns: list[str] | tuple[str] | dict[str, str] | None = None,
     **kwargs: Any,
 ) -> XComArg:

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -5,11 +5,10 @@ from typing import Any
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 from astro.airflow.datasets import kwargs_with_datasets
+from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable
 from astro.utils.typing_compat import Context
-
-from astro.databases import create_database
 
 
 class AppendOperator(AstroSQLBaseOperator):

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -7,14 +7,13 @@ import pandas as pd
 from airflow.decorators.base import DecoratedOperator
 from airflow.exceptions import AirflowException
 from astro.airflow.datasets import kwargs_with_datasets
+from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.sql.operators.upstream_task_mixin import UpstreamTaskMixin
 from astro.sql.table import BaseTable, Table
 from astro.utils.table import find_first_table
 from astro.utils.typing_compat import Context
 from sqlalchemy.sql.functions import Function
-
-from astro.databases import create_database
 
 
 class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -10,7 +10,7 @@ from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.sql.operators.upstream_task_mixin import UpstreamTaskMixin
-from astro.sql.table import Table
+from astro.sql.table import BaseTable, Table
 from astro.utils.table import find_first_table
 from astro.utils.typing_compat import Context
 from sqlalchemy.sql.functions import Function
@@ -165,7 +165,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         """
         # convert Jinja templating to SQLAlchemy SQL templating, safely converting table identifiers
         for k, v in self.parameters.items():
-            if isinstance(v, Table):
+            if isinstance(v, BaseTable):
                 (
                     jinja_table_identifier,
                     jinja_table_parameter_value,
@@ -201,7 +201,7 @@ def load_op_arg_dataframes_into_sql(
                 source_dataframe=arg, target_table=target_table
             )
             final_args.append(target_table)
-        elif isinstance(arg, Table):
+        elif isinstance(arg, BaseTable):
             arg = database.populate_table_metadata(arg)
             final_args.append(arg)
         else:
@@ -229,7 +229,7 @@ def load_op_kwarg_dataframes_into_sql(
                 source_dataframe=value, target_table=df_table
             )
             final_kwargs[key] = df_table
-        elif isinstance(value, Table):
+        elif isinstance(value, BaseTable):
             value = database.populate_table_metadata(value)
             final_kwargs[key] = value
         else:

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -15,12 +15,12 @@ from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.operators.dataframe import DataframeOperator
 from astro.sql.operators.load_file import LoadFileOperator
-from astro.sql.table import Table
+from astro.sql.table import BaseTable, Table, TempTable
 from astro.utils.typing_compat import Context
 
 
 def filter_for_temp_tables(task_outputs: list[Any]) -> list[Table]:
-    return [t for t in task_outputs if isinstance(t, Table) and t.temp]
+    return [t for t in task_outputs if isinstance(t, TempTable) and t.temp]
 
 
 class CleanupOperator(AstroSQLBaseOperator):
@@ -206,7 +206,7 @@ class CleanupOperator(AstroSQLBaseOperator):
             ):
                 try:
                     t = task.output.resolve(context)
-                    if isinstance(t, Table):
+                    if isinstance(t, BaseTable):
                         res.append(t)
                 except AirflowException:
                     self.log.info(

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -10,14 +10,13 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.state import State
+from astro.databases import create_database
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.operators.dataframe import DataframeOperator
 from astro.sql.operators.load_file import LoadFileOperator
 from astro.sql.table import BaseTable, TempTable
 from astro.utils.typing_compat import Context
-
-from astro.databases import create_database
 
 
 def filter_for_temp_tables(task_outputs: list[Any]) -> list[TempTable]:

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -10,16 +10,17 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.state import State
-from astro.databases import create_database
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.operators.dataframe import DataframeOperator
 from astro.sql.operators.load_file import LoadFileOperator
-from astro.sql.table import BaseTable, Table, TempTable
+from astro.sql.table import BaseTable, TempTable
 from astro.utils.typing_compat import Context
 
+from astro.databases import create_database
 
-def filter_for_temp_tables(task_outputs: list[Any]) -> list[Table]:
+
+def filter_for_temp_tables(task_outputs: list[Any]) -> list[TempTable]:
     return [t for t in task_outputs if isinstance(t, TempTable) and t.temp]
 
 
@@ -52,7 +53,7 @@ class CleanupOperator(AstroSQLBaseOperator):
     def __init__(
         self,
         *,
-        tables_to_cleanup: list[Table] | None = None,
+        tables_to_cleanup: list[BaseTable] | None = None,
         task_id: str = "",
         retries: int = 3,
         retry_delay: timedelta = timedelta(seconds=10),
@@ -82,7 +83,7 @@ class CleanupOperator(AstroSQLBaseOperator):
         for table in temp_tables:
             self.drop_table(table)
 
-    def drop_table(self, table: Table) -> None:
+    def drop_table(self, table: BaseTable) -> None:
         db = create_database(table.conn_id)
         self.log.info("Dropping table %s", table.name)
         db.drop_table(table)
@@ -172,7 +173,7 @@ class CleanupOperator(AstroSQLBaseOperator):
             job = session.get(BaseJob, job_id)
         return job.executor_class if job else None
 
-    def get_all_task_outputs(self, context: Context) -> list[Table]:
+    def get_all_task_outputs(self, context: Context) -> list[BaseTable]:
         """
         In the scenario where we are not given a list of tasks to follow, we will want to gather all temporary tables
         To prevent scenarios where we grab objects that are not tables, we try to only follow up on SQL operators or
@@ -187,7 +188,7 @@ class CleanupOperator(AstroSQLBaseOperator):
 
     def resolve_tables_from_tasks(
         self, tasks: list[BaseOperator], context: Context
-    ) -> list[Table]:
+    ) -> list[BaseTable]:
         """
         For the moment, these are the only two classes that create temporary tables.
         This function allows us to only resolve xcom for those objects
@@ -217,7 +218,9 @@ class CleanupOperator(AstroSQLBaseOperator):
         return res
 
 
-def cleanup(tables_to_cleanup: list[Table] | None = None, **kwargs) -> CleanupOperator:
+def cleanup(
+    tables_to_cleanup: list[BaseTable] | None = None, **kwargs
+) -> CleanupOperator:
     """
     Clean up temporary tables once either the DAG or upstream tasks are done
 

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -13,9 +13,7 @@ except ImportError:
     from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
-from astro import settings
 from astro.constants import ColumnCapitalization
-from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
@@ -23,9 +21,12 @@ from astro.utils.dataframe import convert_columns_names_capitalization
 from astro.utils.table import find_first_table
 from astro.utils.typing_compat import Context
 
+from astro import settings
+from astro.databases import create_database
+
 
 def _get_dataframe(
-    table: Table, columns_names_capitalization: ColumnCapitalization = "lower"
+    table: BaseTable, columns_names_capitalization: ColumnCapitalization = "lower"
 ) -> pd.DataFrame:
     """
     Exports records from a SQL table and converts it into a pandas dataframe
@@ -116,7 +117,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
         self.kwargs = kwargs or {}
         self.op_kwargs: dict = self.kwargs.get("op_kwargs") or {}
         if self.op_kwargs.get("output_table"):
-            self.output_table: Table | None = self.op_kwargs.pop("output_table")
+            self.output_table: BaseTable | None = self.op_kwargs.pop("output_table")
         else:
             self.output_table = None
         self.op_args = self.kwargs.get("op_args", ())  # type: ignore

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -13,16 +13,15 @@ except ImportError:
     from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
+from astro import settings
 from astro.constants import ColumnCapitalization
+from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.dataframe import convert_columns_names_capitalization
 from astro.utils.table import find_first_table
 from astro.utils.typing_compat import Context
-
-from astro import settings
-from astro.databases import create_database
 
 
 def _get_dataframe(

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -18,7 +18,7 @@ from astro.constants import ColumnCapitalization
 from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.sql.table import Table
+from astro.sql.table import BaseTable, Table
 from astro.utils.dataframe import convert_columns_names_capitalization
 from astro.utils.table import find_first_table
 from astro.utils.typing_compat import Context
@@ -54,7 +54,7 @@ def load_op_arg_table_into_dataframe(
     for arg in op_args_list:
         current_arg = full_spec.args.pop(0)
         if full_spec.annotations[current_arg] == pd.DataFrame and isinstance(
-            arg, Table
+            arg, BaseTable
         ):
             ret_args.append(
                 _get_dataframe(
@@ -78,7 +78,7 @@ def load_op_kwarg_table_into_dataframe(
     # this table to be converted into a dataframe, rather that passed in as a table
     return {
         k: _get_dataframe(v, columns_names_capitalization=columns_names_capitalization)
-        if param_types.get(k).annotation is pd.DataFrame and isinstance(v, Table)  # type: ignore
+        if param_types.get(k).annotation is pd.DataFrame and isinstance(v, BaseTable)  # type: ignore
         else v
         for k, v in op_kwargs.items()
     }

--- a/python-sdk/src/astro/sql/operators/drop.py
+++ b/python-sdk/src/astro/sql/operators/drop.py
@@ -4,11 +4,10 @@ from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable
 from astro.utils.typing_compat import Context
-
-from astro.databases import create_database
 
 
 class DropTableOperator(AstroSQLBaseOperator):

--- a/python-sdk/src/astro/sql/operators/drop.py
+++ b/python-sdk/src/astro/sql/operators/drop.py
@@ -4,10 +4,11 @@ from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
-from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.sql.table import Table
+from astro.sql.table import BaseTable
 from astro.utils.typing_compat import Context
+
+from astro.databases import create_database
 
 
 class DropTableOperator(AstroSQLBaseOperator):
@@ -17,7 +18,7 @@ class DropTableOperator(AstroSQLBaseOperator):
 
     def __init__(
         self,
-        table: Table,
+        table: BaseTable,
         task_id: str = "",
         **kwargs,
     ):
@@ -28,7 +29,7 @@ class DropTableOperator(AstroSQLBaseOperator):
             **kwargs,
         )
 
-    def execute(self, context: Context) -> Table:  # skipcq: PYL-W0613
+    def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613
         """Method run when the Airflow runner calls the operator."""
         database = create_database(self.table.conn_id)
         self.table = database.populate_table_metadata(self.table)
@@ -37,7 +38,7 @@ class DropTableOperator(AstroSQLBaseOperator):
 
 
 def drop_table(
-    table: Table,
+    table: BaseTable,
     **kwargs: Any,
 ) -> XComArg:
     """

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -7,11 +7,12 @@ from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import ExportExistsStrategy
-from astro.databases import create_database
-from astro.files import File
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
+
+from astro.databases import create_database
+from astro.files import File
 
 
 class ExportFileOperator(AstroSQLBaseOperator):
@@ -26,7 +27,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
 
     def __init__(
         self,
-        input_data: Table | pd.DataFrame,
+        input_data: BaseTable | pd.DataFrame,
         output_file: File,
         if_exists: ExportExistsStrategy = "exception",
         **kwargs,
@@ -65,7 +66,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
 
 
 def export_file(
-    input_data: Table | pd.DataFrame,
+    input_data: BaseTable | pd.DataFrame,
     output_file: File,
     if_exists: ExportExistsStrategy = "exception",
     task_id: str | None = None,

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -7,12 +7,11 @@ from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import ExportExistsStrategy
+from astro.databases import create_database
+from astro.files import File
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
-
-from astro.databases import create_database
-from astro.files import File
 
 
 class ExportFileOperator(AstroSQLBaseOperator):

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -10,7 +10,7 @@ from astro.constants import ExportExistsStrategy
 from astro.databases import create_database
 from astro.files import File
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.sql.table import Table
+from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
 
 
@@ -46,7 +46,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
         Infers SQL database type based on connection.
         """
         # Infer db type from `input_conn_id`.
-        if isinstance(self.input_data, Table):
+        if isinstance(self.input_data, BaseTable):
             database = create_database(self.input_data.conn_id)
             self.input_data = database.populate_table_metadata(self.input_data)
             df = database.export_table_to_pandas_dataframe(self.input_data)

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -5,15 +5,16 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
-from astro import settings
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
-from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
-from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
+
+from astro import settings
+from astro.databases import BaseDatabase, create_database
+from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 
 
 class LoadFileOperator(AstroSQLBaseOperator):
@@ -39,7 +40,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
     def __init__(
         self,
         input_file: File,
-        output_table: Table | None = None,
+        output_table: BaseTable | None = None,
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         if_exists: LoadExistStrategy = "replace",
         ndjson_normalize_sep: str = "_",
@@ -90,7 +91,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
                 raise IllegalLoadToDatabaseException()
             return self.load_data_to_dataframe(input_file)
 
-    def load_data_to_table(self, input_file: File) -> Table:
+    def load_data_to_table(self, input_file: File) -> BaseTable:
         """
         Loads csv/parquet table from local/S3/GCS with Pandas.
         Infers SQL database type based on connection then loads table to db.
@@ -191,7 +192,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
 
 def load_file(
     input_file: File,
-    output_table: Table | None = None,
+    output_table: BaseTable | None = None,
     task_id: str | None = None,
     if_exists: LoadExistStrategy = "replace",
     ndjson_normalize_sep: str = "_",

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -12,7 +12,7 @@ from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.sql.table import Table
+from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
 
 
@@ -95,7 +95,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         Loads csv/parquet table from local/S3/GCS with Pandas.
         Infers SQL database type based on connection then loads table to db.
         """
-        if not isinstance(self.output_table, Table):
+        if not isinstance(self.output_table, BaseTable):
             raise ValueError(
                 "Please pass a valid Table instance in 'output_table' parameter"
             )

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -5,16 +5,15 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+from astro import settings
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
+from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
+from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
-
-from astro import settings
-from astro.databases import BaseDatabase, create_database
-from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 
 
 class LoadFileOperator(AstroSQLBaseOperator):

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -6,11 +6,10 @@ from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import MergeConflictStrategy
+from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable
 from astro.utils.typing_compat import Context
-
-from astro.databases import create_database
 
 
 class MergeOperator(AstroSQLBaseOperator):

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -6,10 +6,11 @@ from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import MergeConflictStrategy
-from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.sql.table import Table
+from astro.sql.table import BaseTable
 from astro.utils.typing_compat import Context
+
+from astro.databases import create_database
 
 
 class MergeOperator(AstroSQLBaseOperator):
@@ -31,8 +32,8 @@ class MergeOperator(AstroSQLBaseOperator):
     def __init__(
         self,
         *,
-        target_table: Table,
-        source_table: Table,
+        target_table: BaseTable,
+        source_table: BaseTable,
         columns: list[str] | tuple[str] | dict[str, str],
         if_conflicts: MergeConflictStrategy,
         target_conflict_columns: list[str],
@@ -60,7 +61,7 @@ class MergeOperator(AstroSQLBaseOperator):
             ),
         )
 
-    def execute(self, context: Context) -> Table:
+    def execute(self, context: Context) -> BaseTable:
         db = create_database(self.target_table.conn_id)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
@@ -77,8 +78,8 @@ class MergeOperator(AstroSQLBaseOperator):
 
 def merge(
     *,
-    target_table: Table,
-    source_table: Table,
+    target_table: BaseTable,
+    source_table: BaseTable,
     columns: list[str] | tuple[str] | dict[str, str],
     target_conflict_columns: list[str],
     if_conflicts: MergeConflictStrategy,

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -152,7 +152,7 @@ class Table(BaseTable, Dataset):
     extra: dict | None = field(init=False, factory=dict)
 
     def __new__(cls, *args, **kwargs):
-        name = kwargs.get("name", "") or (args[0] if len(args) > 0 else "")
+        name = kwargs.get("name") or args and args[0] or ""
         temp = kwargs.get("temp", False)
         if temp or (not name or name.startswith("_tmp")):
             return TempTable(*args, **kwargs)

--- a/python-sdk/src/astro/utils/table.py
+++ b/python-sdk/src/astro/utils/table.py
@@ -1,20 +1,20 @@
 import inspect
 from typing import Callable, Optional
 
-from astro.sql.table import Table
+from astro.sql.table import BaseTable
 
 
-def _pull_first_table_from_parameters(parameters: dict) -> Optional[Table]:
+def _pull_first_table_from_parameters(parameters: dict) -> Optional[BaseTable]:
     """
     When trying to "magically" determine the context of a decorator, we will try to find the first table.
     This function attempts this by checking parameters
 
     :param parameters: a user-defined dictionary of parameters
-    :return: the first parameter of type Table, if any. Return None otherwise.
+    :return: the first parameter of type BaseTable, if any. Return None otherwise.
     """
     first_table = None
     params_of_table_type = [
-        param for param in parameters.values() if isinstance(param, Table)
+        param for param in parameters.values() if isinstance(param, BaseTable)
     ]
     if (
         len(params_of_table_type) == 1
@@ -26,19 +26,20 @@ def _pull_first_table_from_parameters(parameters: dict) -> Optional[Table]:
 
 def _pull_first_table_from_op_kwargs(
     op_kwargs: dict, python_callable: Callable
-) -> Optional[Table]:
+) -> Optional[BaseTable]:
     """
     When trying to "magically" determine the context of a decorator, we will try to find the first table.
     This function attempts this by checking op_kwargs
 
     :param op_kwargs: user-defined operator's kwargs
-    :return: the first kwarg declared in the decorated method which is an instance of Table. Return None if non-existent
+    :return: the first kwarg declared in the decorated method which is an
+        instance of BaseTable. Return None if non-existent
     """
     first_table = None
     kwargs_of_table_type = [
         op_kwargs[kwarg.name]
         for kwarg in inspect.signature(python_callable).parameters.values()
-        if isinstance(op_kwargs[kwarg.name], Table)
+        if isinstance(op_kwargs[kwarg.name], BaseTable)
     ]
     if (
         len(kwargs_of_table_type) == 1
@@ -48,16 +49,16 @@ def _pull_first_table_from_op_kwargs(
     return first_table
 
 
-def _find_first_table_from_op_args(op_args: tuple) -> Optional[Table]:
+def _find_first_table_from_op_args(op_args: tuple) -> Optional[BaseTable]:
     """
     When trying to "magically" determine the context of a decorator, we will try to find the first table.
     This function attempts this by checking op_args
 
     :param op_args: user-defined operator's args
-    :return: the first arg which is an instance of Table. If there are no instances, return None.
+    :return: the first arg which is an instance of BaseTable. If there are no instances, return None.
     """
     first_table = None
-    args_of_table_type = [arg for arg in op_args if isinstance(arg, Table)]
+    args_of_table_type = [arg for arg in op_args if isinstance(arg, BaseTable)]
     # Check to see if all tables belong to same conn_id. Otherwise, we this can go wrong for cases
     # 1. When we have tables from different DBs.
     # 2. When we have tables from different conn_id, since they can be configured with different
@@ -72,7 +73,7 @@ def _find_first_table_from_op_args(op_args: tuple) -> Optional[Table]:
 
 def find_first_table(
     op_args: tuple, op_kwargs: dict, python_callable: Callable, parameters: dict
-) -> Optional[Table]:
+) -> Optional[BaseTable]:
     """
     When we create our SQL operation, we run with the assumption that the first table given is the "main table".
     This means that a user doesn't need to define default conn_id, database, etc. in the function unless they want
@@ -81,7 +82,7 @@ def find_first_table(
     :param parameters: user-defined parameters to be injected into SQL statement
     :return: the first table declared as decorator arg or kwarg
     """
-    first_table: Optional[Table] = None
+    first_table: Optional[BaseTable] = None
     if op_args:
         first_table = _find_first_table_from_op_args(op_args=op_args)
 

--- a/python-sdk/tests/airflow/test_datasets.py
+++ b/python-sdk/tests/airflow/test_datasets.py
@@ -88,7 +88,9 @@ def test_kwargs_with_datasets(
         )
 
 
-@mock.patch("astro.airflow.datasets.DATASET_SUPPORT", new=True)
+@pytest.mark.skipif(
+    airflow.__version__ < "2.4.0", reason="Require Airflow version >= 2.4.0"
+)
 def test_kwargs_with_temp_table():
     """Test that temp tables are not passed to inlets and outlets"""
     assert kwargs_with_datasets(

--- a/python-sdk/tests/airflow/test_datasets.py
+++ b/python-sdk/tests/airflow/test_datasets.py
@@ -42,8 +42,8 @@ from astro.sql.table import Table
             True,
             {
                 "task_id": "ex1",
-                "inlets": [Table("inlet", conn_id="con1")],
-                "outlets": [Table("outlet")],
+                "inlets": Table("inlet", conn_id="con1"),
+                "outlets": Table("outlet"),
             },
         ),
         (None, None, None, False, {}),
@@ -66,8 +66,8 @@ from astro.sql.table import Table
             False,
             {
                 "task_id": "ex1",
-                "inlets": [Table("inlet", conn_id="con1")],
-                "outlets": [Table("outlet", conn_id="con2")],
+                "inlets": Table("inlet", conn_id="con1"),
+                "outlets": Table("outlet", conn_id="con2"),
             },
         ),
     ],
@@ -88,14 +88,32 @@ def test_kwargs_with_datasets(
         )
 
 
+@mock.patch("astro.airflow.datasets.DATASET_SUPPORT", new=True)
+def test_kwargs_with_temp_table():
+    """Test that temp tables are not passed to inlets and outlets"""
+    assert kwargs_with_datasets(
+        kwargs={"task_id": "ex1"},
+        input_datasets=Table(conn_id="con1"),  # temp table
+        output_datasets=[
+            Table("outlet", conn_id="con2"),
+            Table("_tmp_1", conn_id="con1"),  # temp table
+        ],
+    ) == {
+        "task_id": "ex1",
+        "inlets": [],
+        "outlets": [Table("outlet", conn_id="con2")],
+    }
+
+
 @pytest.mark.skipif(
     airflow.__version__ < "2.4.0", reason="Require Airflow version >= 2.4.0"
 )
 def test_example_dataset_dag():
+    from airflow.datasets import Dataset
+    from airflow.models.dataset import DatasetModel
+
     dir_path = os.path.dirname(os.path.realpath(__file__))
     db = DagBag(dir_path + "/../../example_dags")
-
-    from airflow.datasets import Dataset
 
     producer_dag = db.get_dag("example_dataset_producer")
     consumer_dag = db.get_dag("example_dataset_consumer")
@@ -105,6 +123,9 @@ def test_example_dataset_dag():
     # Test that dataset_triggers is only set if all the instances passed to the DAG object are Datasets
     assert consumer_dag.dataset_triggers == outlets
     assert outlets[0].uri == "astro://sqlite_default@?table=imdb_movies"
+    assert DatasetModel.from_public(outlets[0]) == Dataset(
+        "astro://sqlite_default@?table=imdb_movies"
+    )
 
 
 def test_disable_auto_inlets_outlets():

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from airflow import DAG
 from astro.sql import get_value_list
-from astro.sql.table import Metadata, Table
+from astro.sql.table import Metadata, Table, TempTable
 
 
 def test_table_with_explicit_name():
@@ -101,10 +101,6 @@ def test_get_value_list():
             "astro://test_conn@?table=test_table",
         ),
         (
-            Table(name="test_table", conn_id="test_conn", temp=True),
-            "astro://test_conn@?table=test_table",
-        ),
-        (
             Table(
                 name="test_table",
                 conn_id="test_conn",
@@ -133,3 +129,19 @@ def test_table_to_datasets_extra():
         name="test_table", conn_id="test_conn", metadata=Metadata(schema="schema")
     )
     assert table.extra == {}
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        Table(),
+        Table("_tmp"),
+        Table(name="_tmp", conn_id="test_conn"),
+        Table(name="name", conn_id="test_conn", temp=True),
+    ],
+)
+def test_temp_table(table):
+    """Verify that temp table is generated if no name is passed or temp is set to True"""
+    assert table.temp
+    assert isinstance(table, TempTable)
+    assert not isinstance(table, Table)


### PR DESCRIPTION
closes https://github.com/astronomer/astro-sdk/issues/856

We don't want to generate datasets for temp tables so I have created a separate internal class called `TempTable` which will be used when users don't pass a name to the Table class.

```python
In [1]: from astro.sql.table import Table, TempTable

In [2]: Table()
Out[2]: TempTable(_name='', conn_id='', metadata=Metadata(schema=None, database=None), columns=[], temp=True)

In [3]: Table("name", conn_id="con1")
Out[3]: Table(_name='name', conn_id='con1', metadata=Metadata(schema=None, database=None), columns=[], temp=False, uri='astro://con1@?table=name', extra={})

```

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary - **No user-facing change is required -- maybe we just add a single line in ** https://github.com/astronomer/astro-sdk/pull/852 to say "Temp tables won't generate Datasets"
