### PR TITLE
Rename param sql_statement to sql in get_value_list

### DIFF
--- a/python-sdk/example_dags/example_dynamic_task_template.py
+++ b/python-sdk/example_dags/example_dynamic_task_template.py
@@ -62,9 +62,7 @@ with DAG(
         return sum(rating_list) / len(rating_list)
 
     rating = custom_task.expand(
-        rating_val=get_value_list(
-            sql=QUERY_STATEMENT, conn_id=ASTRO_GCP_CONN_ID
-        )
+        rating_val=get_value_list(sql=QUERY_STATEMENT, conn_id=ASTRO_GCP_CONN_ID)
     )
 
     print(avg_rating(rating))

--- a/python-sdk/example_dags/example_dynamic_task_template.py
+++ b/python-sdk/example_dags/example_dynamic_task_template.py
@@ -63,7 +63,7 @@ with DAG(
 
     rating = custom_task.expand(
         rating_val=get_value_list(
-            sql_statement=QUERY_STATEMENT, conn_id=ASTRO_GCP_CONN_ID
+            sql=QUERY_STATEMENT, conn_id=ASTRO_GCP_CONN_ID
         )
     )
 

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -112,7 +112,8 @@ class BaseDatabase(ABC):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        sql = sql or kwargs.get("sql_statement")  # type: ignore
+        if kwargs.get("sql_statement"):
+            sql = kwargs.get("sql_statement")  # type: ignor
 
         if isinstance(sql, str):
             result = self.connection.execute(sqlalchemy.text(sql), parameters)

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -321,7 +321,7 @@ class BaseDatabase(ABC):
         statement = self._create_table_statement.format(
             self.get_table_qualified_name(target_table), statement
         )
-        self.run_sql_query(statement, parameters)
+        self.run_sql(statement, parameters)
 
     def drop_table(self, table: BaseTable) -> None:
         """
@@ -332,7 +332,7 @@ class BaseDatabase(ABC):
         statement = self._drop_table_statement.format(
             self.get_table_qualified_name(table)
         )
-        self.run_sql_query(statement)
+        self.run_sql(statement)
 
     # ---------------------------------------------------------
     # Table load methods
@@ -586,7 +586,7 @@ class BaseDatabase(ABC):
         # TODO: We should fix the following Type Error
         # incompatible type List[ColumnClause[<nothing>]]; expected List[Column[Any]]
         sql = insert(target_table_sqla).from_select(target_columns, sel)  # type: ignore[arg-type]
-        self.run_sql_query(sql=sql)
+        self.run_sql(sql=sql)
 
     def merge_table(
         self,
@@ -673,7 +673,7 @@ class BaseDatabase(ABC):
         # doesn't actually create a schema.
         if schema and not self.schema_exists(schema):
             statement = self._create_schema_statement.format(schema)
-            self.run_sql_query(statement)
+            self.run_sql(statement)
 
     def schema_exists(self, schema: str) -> bool:
         """

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from abc import ABC
-from typing import Any, Callable, Mapping, Union
+from typing import Any, Callable, Mapping
 
 import pandas as pd
 import sqlalchemy
@@ -112,7 +112,7 @@ class BaseDatabase(ABC):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        sql: Union[str, ClauseElement] = sql or kwargs.get("sql_statement")
+        sql = sql or kwargs.get("sql_statement")  # type: ignore
 
         if isinstance(sql, str):
             result = self.connection.execute(sqlalchemy.text(sql), parameters)

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -105,14 +105,13 @@ class BaseDatabase(ABC):
         if parameters is None:
             parameters = {}
 
-        if "sql_statement" in kwargs:
+        if "sql_statement" in kwargs:  # pragma: no cover
             warnings.warn(
                 "`sql_statement` is deprecated and will be removed in future release"
                 "Please use  `sql` param instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-        if kwargs.get("sql_statement"):
             sql = kwargs.get("sql_statement")  # type: ignore
 
         if isinstance(sql, str):

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -88,22 +88,10 @@ class BaseDatabase(ABC):
         return self.hook.get_sqlalchemy_engine()  # type: ignore[no-any-return]
 
     def run_sql(
-            self,
-            sql_statement: str | ClauseElement,
-            parameters: dict | None = None,
-    ):
-        warnings.warn(
-            "`run_sql` is deprecated and will be removed "
-            "Please use  `run_sql_query` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.run_sql_query(sql=sql_statement, parameters=parameters)
-
-    def run_sql_query(
         self,
-        sql: str | ClauseElement,
+        sql: str | ClauseElement = '',
         parameters: dict | None = None,
+        **kwargs,
     ):
         """
         Return the results to running a SQL statement.
@@ -116,6 +104,15 @@ class BaseDatabase(ABC):
         """
         if parameters is None:
             parameters = {}
+
+        if "sql_statement" in kwargs:
+            warnings.warn(
+                "`sql_statement` is deprecated and will be removed in future release"
+                "Please use  `sql` param instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        sql = sql or kwargs.get("sql_statement")
 
         if isinstance(sql, str):
             result = self.connection.execute(sqlalchemy.text(sql), parameters)

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -113,7 +113,7 @@ class BaseDatabase(ABC):
                 stacklevel=2,
             )
         if kwargs.get("sql_statement"):
-            sql = kwargs.get("sql_statement")  # type: ignor
+            sql = kwargs.get("sql_statement")  # type: ignore
 
         if isinstance(sql, str):
             result = self.connection.execute(sqlalchemy.text(sql), parameters)

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -89,7 +89,7 @@ class BaseDatabase(ABC):
 
     def run_sql(
         self,
-        sql: str | ClauseElement = '',
+        sql: str | ClauseElement = "",
         parameters: dict | None = None,
         **kwargs,
     ):

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from abc import ABC
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Union
 
 import pandas as pd
 import sqlalchemy
@@ -112,7 +112,7 @@ class BaseDatabase(ABC):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        sql = sql or kwargs.get("sql_statement")
+        sql: Union[str, ClauseElement] = sql or kwargs.get("sql_statement")
 
         if isinstance(sql, str):
             result = self.connection.execute(sqlalchemy.text(sql), parameters)

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -234,7 +234,7 @@ class BigqueryDatabase(BaseDatabase):
             # Note: Ignoring below sql injection warning, as we validate that the table columns exist beforehand.
             update_statement = f"UPDATE SET {update_statement_map}"  # skipcq BAN-B608
             merge_statement += f" WHEN MATCHED THEN {update_statement}"
-        self.run_sql_query(sql=merge_statement)
+        self.run_sql(sql=merge_statement)
 
     def is_native_autodetect_schema_available(  # skipcq: PYL-R0201
         self, file: File  # skipcq: PYL-W0613

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -234,7 +234,7 @@ class BigqueryDatabase(BaseDatabase):
             # Note: Ignoring below sql injection warning, as we validate that the table columns exist beforehand.
             update_statement = f"UPDATE SET {update_statement_map}"  # skipcq BAN-B608
             merge_statement += f" WHEN MATCHED THEN {update_statement}"
-        self.run_sql(sql_statement=merge_statement)
+        self.run_sql_query(sql=merge_statement)
 
     def is_native_autodetect_schema_available(  # skipcq: PYL-R0201
         self, file: File  # skipcq: PYL-W0613

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -185,4 +185,4 @@ class PostgresDatabase(BaseDatabase):
         )
 
         sql = query.as_string(self.hook.get_conn())
-        self.run_sql(sql=sql)  # pragma: no cover
+        self.run_sql(sql=sql)

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -185,4 +185,4 @@ class PostgresDatabase(BaseDatabase):
         )
 
         sql = query.as_string(self.hook.get_conn())
-        self.run_sql_query(sql=sql)
+        self.run_sql(sql=sql)

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -185,4 +185,4 @@ class PostgresDatabase(BaseDatabase):
         )
 
         sql = query.as_string(self.hook.get_conn())
-        self.run_sql(sql=sql)
+        self.run_sql(sql=sql)  # pragma: no cover

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -185,4 +185,4 @@ class PostgresDatabase(BaseDatabase):
         )
 
         sql = query.as_string(self.hook.get_conn())
-        self.run_sql(sql_statement=sql)
+        self.run_sql_query(sql=sql)

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -704,7 +704,7 @@ class SnowflakeDatabase(BaseDatabase):
             target_conflict_columns=target_conflict_columns,
             if_conflicts=if_conflicts,
         )
-        self.run_sql(sql=statement, parameters=params)  # pragma: no cover
+        self.run_sql(sql=statement, parameters=params)
 
     def _build_merge_sql(
         self,

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -704,7 +704,7 @@ class SnowflakeDatabase(BaseDatabase):
             target_conflict_columns=target_conflict_columns,
             if_conflicts=if_conflicts,
         )
-        self.run_sql(sql=statement, parameters=params)
+        self.run_sql(sql=statement, parameters=params)  # pragma: no cover
 
     def _build_merge_sql(
         self,

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -313,7 +313,7 @@ class SnowflakeDatabase(BaseDatabase):
             ]
         )
 
-        self.run_sql_query(sql_statement)
+        self.run_sql(sql_statement)
 
         return file_format
 
@@ -400,7 +400,7 @@ class SnowflakeDatabase(BaseDatabase):
             ]
         )
 
-        self.run_sql_query(sql_statement)
+        self.run_sql(sql_statement)
 
         return stage
 
@@ -704,7 +704,7 @@ class SnowflakeDatabase(BaseDatabase):
             target_conflict_columns=target_conflict_columns,
             if_conflicts=if_conflicts,
         )
-        self.run_sql_query(sql=statement, parameters=params)
+        self.run_sql(sql=statement, parameters=params)
 
     def _build_merge_sql(
         self,

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -313,7 +313,7 @@ class SnowflakeDatabase(BaseDatabase):
             ]
         )
 
-        self.run_sql(sql_statement)
+        self.run_sql_query(sql_statement)
 
         return file_format
 
@@ -400,7 +400,7 @@ class SnowflakeDatabase(BaseDatabase):
             ]
         )
 
-        self.run_sql(sql_statement)
+        self.run_sql_query(sql_statement)
 
         return stage
 
@@ -704,7 +704,7 @@ class SnowflakeDatabase(BaseDatabase):
             target_conflict_columns=target_conflict_columns,
             if_conflicts=if_conflicts,
         )
-        self.run_sql(sql_statement=statement, parameters=params)
+        self.run_sql_query(sql=statement, parameters=params)
 
     def _build_merge_sql(
         self,

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -120,7 +120,7 @@ class SqliteDatabase(BaseDatabase):
             merge_keys=",".join(list(target_conflict_columns)),
         )
 
-        self.run_sql(sql=query)  # pragma: no cover
+        self.run_sql(sql=query)
 
     def get_sqla_table(self, table: BaseTable) -> SqlaTable:
         """

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -120,7 +120,7 @@ class SqliteDatabase(BaseDatabase):
             merge_keys=",".join(list(target_conflict_columns)),
         )
 
-        self.run_sql_query(sql=query)
+        self.run_sql(sql=query)
 
     def get_sqla_table(self, table: BaseTable) -> SqlaTable:
         """

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -120,7 +120,7 @@ class SqliteDatabase(BaseDatabase):
             merge_keys=",".join(list(target_conflict_columns)),
         )
 
-        self.run_sql(sql_statement=query)
+        self.run_sql_query(sql=query)
 
     def get_sqla_table(self, table: BaseTable) -> SqlaTable:
         """

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -120,7 +120,7 @@ class SqliteDatabase(BaseDatabase):
             merge_keys=",".join(list(target_conflict_columns)),
         )
 
-        self.run_sql(sql=query)
+        self.run_sql(sql=query)  # pragma: no cover
 
     def get_sqla_table(self, table: BaseTable) -> SqlaTable:
         """

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -13,14 +13,14 @@ from astro.sql.operators.transform import TransformOperator, transform, transfor
 from astro.sql.table import Metadata, Table
 
 
-def get_value_list(sql_statement: str, conn_id: str, **kwargs) -> XComArg:
+def get_value_list(sql: str, conn_id: str, **kwargs) -> XComArg:
     """
     Execute a sql statement and return the result.
     By default, the response size is less than equal to value of ``max_map_length`` conf.
     You can call a callable handler to alter the response by default it call ``fetchall`` on database result set.
 
 
-    :param sql_statement: sql query to execute.
+    :param sql: sql query to execute.
         If the sql query will return huge number of row then it can overload the XCOM.
         also, If you are using output of this method to expand a task using dynamic task map then
         it can create lots of parallel task. So it is advisable to limit your sql query statement.
@@ -38,7 +38,7 @@ def get_value_list(sql_statement: str, conn_id: str, **kwargs) -> XComArg:
     )
     kwargs.update({"task_id": task_id})
     return RawSQLOperator(
-        sql=sql_statement,
+        sql=sql,
         conn_id=conn_id,
         op_kwargs=op_kwargs,
         python_callable=(lambda *args: None),

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -28,8 +28,8 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
     def execute(self, context: Context) -> Any:
         super().execute(context)
 
-        result = self.database_impl.run_sql(
-            sql_statement=self.sql, parameters=self.parameters
+        result = self.database_impl.run_sql_query(
+            sql=self.sql, parameters=self.parameters
         )
         if self.response_size == -1 and not settings.IS_CUSTOM_XCOM_BACKEND:
             logging.warning(

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -28,7 +28,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
     def execute(self, context: Context) -> Any:
         super().execute(context)
 
-        result = self.database_impl.run_sql_query(
+        result = self.database_impl.run_sql(
             sql=self.sql, parameters=self.parameters
         )
         if self.response_size == -1 and not settings.IS_CUSTOM_XCOM_BACKEND:

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -28,9 +28,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
     def execute(self, context: Context) -> Any:
         super().execute(context)
 
-        result = self.database_impl.run_sql(
-            sql=self.sql, parameters=self.parameters
-        )
+        result = self.database_impl.run_sql(sql=self.sql, parameters=self.parameters)
         if self.response_size == -1 and not settings.IS_CUSTOM_XCOM_BACKEND:
             logging.warning(
                 "Using `run_raw_sql` without `response_size` can result in excessive amount of data being recorded "

--- a/python-sdk/tests/sql/operators/test_merge.py
+++ b/python-sdk/tests/sql/operators/test_merge.py
@@ -162,11 +162,9 @@ def test_merge(
         {"database": Database.SNOWFLAKE},
         {"database": Database.BIGQUERY},
         {"database": Database.REDSHIFT},
-        {"database": Database.POSTGRES},
-        {"database": Database.SQLITE},
     ],
     indirect=True,
-    ids=["snowflake", "bigquery", "redshift", "postgres", "sqlite"],
+    ids=["snowflake", "bigquery", "redshift"],
 )
 @pytest.mark.parametrize(
     "multiple_tables_fixture",

--- a/python-sdk/tests/sql/operators/test_merge.py
+++ b/python-sdk/tests/sql/operators/test_merge.py
@@ -113,9 +113,11 @@ def run_merge(target_table: Table, source_table: Table, merge_parameters, mode):
         {"database": Database.SNOWFLAKE},
         {"database": Database.BIGQUERY},
         {"database": Database.REDSHIFT},
+        {"database": Database.POSTGRES},
+        {"database": Database.SQLITE},
     ],
     indirect=True,
-    ids=["snowflake", "bigquery", "redshift"],
+    ids=["snowflake", "bigquery", "redshift", "postgres", "sqlite"],
 )
 @pytest.mark.parametrize(
     "multiple_tables_fixture",
@@ -160,9 +162,11 @@ def test_merge(
         {"database": Database.SNOWFLAKE},
         {"database": Database.BIGQUERY},
         {"database": Database.REDSHIFT},
+        {"database": Database.POSTGRES},
+        {"database": Database.SQLITE},
     ],
     indirect=True,
-    ids=["snowflake", "bigquery", "redshift"],
+    ids=["snowflake", "bigquery", "redshift", "postgres", "sqlite"],
 )
 @pytest.mark.parametrize(
     "multiple_tables_fixture",

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -83,13 +83,13 @@ def test_get_value_list():
     """Assert that get_file_list handle kwargs correctly"""
     dag = DAG(dag_id="dag1", start_date=datetime(2022, 1, 1))
 
-    resp = get_value_list(sql_statement="path", conn_id="conn", dag=dag)
+    resp = get_value_list(sql="path", conn_id="conn", dag=dag)
     assert resp.operator.task_id == "get_value_list"
 
-    resp = get_value_list(sql_statement="path", conn_id="conn", dag=dag)
+    resp = get_value_list(sql="path", conn_id="conn", dag=dag)
     assert resp.operator.task_id != "get_value_list"
 
-    resp = get_value_list(sql_statement="path", conn_id="conn", task_id="test")
+    resp = get_value_list(sql="path", conn_id="conn", task_id="test")
     assert resp.operator.task_id == "test"
 
 


### PR DESCRIPTION
# Description
Rename param `sql_statement` to `sql` in `get_value_list` dynamic task template pattern in order to make public interfaces more consistent. 
closes: #865 #866


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->




### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
