### PR TITLE
Fix issues with pickling & unpickling the `Table` object

### DIFF
--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -63,6 +63,7 @@ class BaseTable:
     columns: list[Column] = field(factory=list)
     temp: bool = field(default=False)
 
+    # We need this method to pickle Table object, without this we cannot push/pull this object from xcom.
     def __getstate__(self):
         return self.__dict__
 

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -63,6 +63,9 @@ class BaseTable:
     columns: list[Column] = field(factory=list)
     temp: bool = field(default=False)
 
+    def __getstate__(self):
+        return self.__dict__
+
     def __attrs_post_init__(self) -> None:
         if not self._name or self._name.startswith("_tmp"):
             self.temp = True

--- a/python-sdk/tests/files/test_file.py
+++ b/python-sdk/tests/files/test_file.py
@@ -389,4 +389,5 @@ def test_smart_open_file_stream_only_conveted_to_BytesIO_buffer_for_parquet(file
 
 def test_if_file_object_can_be_pickled():
     """Verify if we can pickle File object"""
-    pickle.loads(pickle.dumps(File(path="test")))
+    file = File(path="./test.csv")
+    assert pickle.loads(pickle.dumps(file)) == file

--- a/python-sdk/tests/files/test_file.py
+++ b/python-sdk/tests/files/test_file.py
@@ -6,12 +6,11 @@ from unittest.mock import mock_open, patch
 import pandas as pd
 import pytest
 from airflow import DAG
+from astro import constants
 from astro.constants import SUPPORTED_FILE_TYPES, FileType
+from astro.files import File, get_file_list, resolve_file_path_pattern
 from botocore.client import BaseClient
 from google.cloud.storage import Client
-
-from astro import constants
-from astro.files import File, get_file_list, resolve_file_path_pattern
 
 sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent, "data/sample.csv")
 sample_filepaths_per_filetype = [

--- a/python-sdk/tests/files/test_file.py
+++ b/python-sdk/tests/files/test_file.py
@@ -1,15 +1,17 @@
 import pathlib
+import pickle
 from datetime import datetime
 from unittest.mock import mock_open, patch
 
 import pandas as pd
 import pytest
 from airflow import DAG
-from astro import constants
 from astro.constants import SUPPORTED_FILE_TYPES, FileType
-from astro.files import File, get_file_list, resolve_file_path_pattern
 from botocore.client import BaseClient
 from google.cloud.storage import Client
+
+from astro import constants
+from astro.files import File, get_file_list, resolve_file_path_pattern
 
 sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent, "data/sample.csv")
 sample_filepaths_per_filetype = [
@@ -384,3 +386,8 @@ def test_smart_open_file_stream_only_conveted_to_BytesIO_buffer_for_parquet(file
             _convert_remote_file_to_byte_stream.assert_called()
         else:
             _convert_remote_file_to_byte_stream.assert_not_called()
+
+
+def test_if_file_object_can_be_pickled():
+    """Verify if we can pickle File object"""
+    pickle.loads(pickle.dumps(File(path="test")))

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -3,9 +3,8 @@ from datetime import datetime
 
 import pytest
 from airflow import DAG
-from astro.sql.table import Metadata, Table, TempTable
-
 from astro.sql import get_value_list
+from astro.sql.table import Metadata, Table, TempTable
 
 
 def test_table_with_explicit_name():

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -3,8 +3,9 @@ from datetime import datetime
 
 import pytest
 from airflow import DAG
-from astro.sql import get_value_list
 from astro.sql.table import Metadata, Table, TempTable
+
+from astro.sql import get_value_list
 
 
 def test_table_with_explicit_name():
@@ -150,4 +151,5 @@ def test_temp_table(table):
 
 def test_if_table_object_can_be_pickled():
     """Verify if we can pickle Table object"""
-    pickle.loads(pickle.dumps(Table(name="test")))
+    table = Table()
+    assert pickle.loads(pickle.dumps(table)) == table

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -1,9 +1,11 @@
+import pickle
 from datetime import datetime
 
 import pytest
 from airflow import DAG
-from astro.sql import get_value_list
 from astro.sql.table import Metadata, Table, TempTable
+
+from astro.sql import get_value_list
 
 
 def test_table_with_explicit_name():
@@ -145,3 +147,8 @@ def test_temp_table(table):
     assert table.temp
     assert isinstance(table, TempTable)
     assert not isinstance(table, Table)
+
+
+def test_if_table_object_can_be_pickled():
+    """Verify if we can pickle Table object"""
+    pickle.loads(pickle.dumps(Table(name="test")))


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, Python-sdk is falling with pickling error.

```
airflow.exceptions.AirflowException: When using a synchronous executor (e.g. SequentialExecutor and DebugExecutor), the first run of this task will fail on purpose, so the single worker thread is unblocked to execute other tasks. The task is set up for retry and eventually works.
[2022-09-16 22:52:28,847] {backfill_job.py:190} ERROR - Task instance <TaskInstance: example_google_bigquery_gcs_load_and_save.cleanup backfill__2016-01-01T00:00:00+00:00 [failed]> failed
[2022-09-16 22:52:28,851] {backfill_job.py:370} INFO - [backfill progress] | finished run 0 of 1 | tasks waiting: 3 | succeeded: 1 | running: 0 | failed: 1 | skipped: 0 | deadlocked: 0 | not ready: 3
[2022-09-16 22:52:28,865] {base_executor.py:95} INFO - Adding to queue: ['<TaskInstance: example_google_bigquery_gcs_load_and_save.extract_top_5_movies backfill__2016-01-01T00:00:00+00:00 [queued]>']
[2022-09-16 22:52:28,872] {base_executor.py:95} INFO - Adding to queue: ['<TaskInstance: example_google_bigquery_gcs_load_and_save.save_file_to_gcs backfill__2016-01-01T00:00:00+00:00 [queued]>']
[2022-09-16 22:52:28,901] {debug_executor.py:85} ERROR - Failed to execute task: 'utf-8' codec can't decode byte 0x80 in position 0: invalid start byte.
Traceback (most recent call last):
  File "/Users/utkarsharma/sandbox/astronomer/astro/.nox/dev/lib/python3.8/site-packages/airflow/models/xcom.py", line 618, in deserialize_value
    return pickle.loads(result.value)
_pickle.UnpicklingError: state is not a dictionary

```
## What is the new behavior?
To fix the above issue we need to add __getstate__() to the table class

## Does this introduce a breaking change?
Nope

### Checklist
- [X] Created tests that fail without the change (if possible)
- [X] Extended the README/documentation, if necessary
