### PR TITLE
Check for filetype only for pattern and fix coverage

### DIFF
--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -17,6 +17,8 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
+from astro.files import File, resolve_file_path_pattern
+from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
@@ -25,9 +27,6 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
-
-from astro.files import File, resolve_file_path_pattern
-from astro.files.types import create_file_type
 
 
 class BaseDatabase(ABC):

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -17,8 +17,6 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
-from astro.files import File, resolve_file_path_pattern
-from astro.files.types import create_file_type
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
 from pandas.io.sql import SQLDatabase
@@ -26,6 +24,9 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
+
+from astro.files import File, resolve_file_path_pattern
+from astro.files.types import create_file_type
 
 
 class BaseDatabase(ABC):
@@ -747,11 +748,18 @@ class BaseDatabase(ABC):
         source_filetype = create_file_type(
             path=source_file.path, filetype=source_file.type.name
         )
-        is_source_filetype_supported = (
-            (source_filetype in filetype_supported.get("filetype"))  # type: ignore
-            if filetype_supported
-            else None
-        )
+        if source_file.is_pattern():
+            is_source_filetype_supported = (
+                (source_filetype in filetype_supported.get("filetype"))  # type: ignore
+                if filetype_supported
+                else None
+            )
+        else:
+            is_source_filetype_supported = (
+                (source_filetype.type.name in filetype_supported.get("filetype"))  # type: ignore
+                if filetype_supported
+                else None
+            )
 
         location_type = self.NATIVE_PATHS.get(source_file.location.location_type)
         return bool(location_type and is_source_filetype_supported)

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -17,8 +17,7 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
-from astro.files import File, resolve_file_path_pattern
-from astro.files.types import create_file_type
+from astro.files.types.base import FileType as FileTypeConstants
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
 from pandas.io.sql import SQLDatabase
@@ -26,6 +25,9 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
+
+from astro.files import File, resolve_file_path_pattern
+from astro.files.types import create_file_type
 
 
 class BaseDatabase(ABC):
@@ -744,21 +746,17 @@ class BaseDatabase(ABC):
             source_file.location.location_type
         )
 
-        source_filetype = create_file_type(
-            path=source_file.path, filetype=source_file.type.name
+        source_filetype = (
+            source_file
+            if isinstance(source_file.type, FileTypeConstants)
+            else create_file_type(path=source_file.path, filetype=source_file.type)  # type: ignore
         )
-        if source_file.is_pattern():
-            is_source_filetype_supported = (
-                (source_filetype in filetype_supported.get("filetype"))  # type: ignore
-                if filetype_supported
-                else None
-            )
-        else:
-            is_source_filetype_supported = (
-                (source_filetype.type.name in filetype_supported.get("filetype"))  # type: ignore
-                if filetype_supported
-                else None
-            )
+
+        is_source_filetype_supported = (
+            (source_filetype.type.name in filetype_supported.get("filetype"))  # type: ignore
+            if filetype_supported
+            else None
+        )
 
         location_type = self.NATIVE_PATHS.get(source_file.location.location_type)
         return bool(location_type and is_source_filetype_supported)

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -17,6 +17,8 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
+from astro.files import File, resolve_file_path_pattern
+from astro.files.types import create_file_type
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
 from pandas.io.sql import SQLDatabase
@@ -24,9 +26,6 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
-
-from astro.files import File, resolve_file_path_pattern
-from astro.files.types import create_file_type
 
 
 class BaseDatabase(ABC):

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -74,7 +74,6 @@ def test_check_schema_autodetection_is_supported():
         db.check_schema_autodetection_is_supported(
             source_file=File(path="gs://bucket/prefix/key.csv")
         )
-        is True
     )
 
     assert (

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -68,7 +68,6 @@ def test_check_schema_autodetection_is_supported():
         db.check_schema_autodetection_is_supported(
             source_file=File(path="gs://bucket/prefix", filetype=FileType.CSV)
         )
-        is True
     )
 
     assert (

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -3,13 +3,12 @@ from unittest import mock
 
 import pytest
 from astro.constants import Database, FileType
+from astro.databases import create_database
 from astro.databases.base import BaseDatabase
+from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table
 from pandas import DataFrame
-
-from astro.databases import create_database
-from astro.files import File
 
 CWD = pathlib.Path(__file__).parent
 

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -74,11 +74,10 @@ def test_check_schema_autodetection_is_supported():
         )
     )
 
-    assert (
+    assert not (
         db.check_schema_autodetection_is_supported(
             source_file=File(path="s3://bucket/prefix/key.csv")
         )
-        is False
     )
 
 

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -64,10 +64,8 @@ def test_check_schema_autodetection_is_supported():
     Test the condition native schema autodetection for files and prefixes
     """
     db = create_database("gcp_conn")
-    assert (
-        db.check_schema_autodetection_is_supported(
-            source_file=File(path="gs://bucket/prefix", filetype=FileType.CSV)
-        )
+    assert db.check_schema_autodetection_is_supported(
+        source_file=File(path="gs://bucket/prefix", filetype=FileType.CSV)
     )
 
     assert (

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -68,10 +68,8 @@ def test_check_schema_autodetection_is_supported():
         source_file=File(path="gs://bucket/prefix", filetype=FileType.CSV)
     )
 
-    assert (
-        db.check_schema_autodetection_is_supported(
-            source_file=File(path="gs://bucket/prefix/key.csv")
-        )
+    assert db.check_schema_autodetection_is_supported(
+        source_file=File(path="gs://bucket/prefix/key.csv")
     )
 
     assert not (

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -3,12 +3,13 @@ from unittest import mock
 
 import pytest
 from astro.constants import Database, FileType
-from astro.databases import create_database
 from astro.databases.base import BaseDatabase
-from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table
 from pandas import DataFrame
+
+from astro.databases import create_database
+from astro.files import File
 
 CWD = pathlib.Path(__file__).parent
 
@@ -57,6 +58,33 @@ def test_create_table_using_columns_raises_exception():
     with pytest.raises(ValueError) as exc_info:
         db.create_table_using_columns(table)
     assert exc_info.match("To use this method, table.columns must be defined")
+
+
+def test_check_schema_autodetection_is_supported():
+    """
+    Test the condition native schema autodetection for files and prefixes
+    """
+    db = create_database("gcp_conn")
+    assert (
+        db.check_schema_autodetection_is_supported(
+            source_file=File(path="gs://bucket/prefix", filetype=FileType.CSV)
+        )
+        is True
+    )
+
+    assert (
+        db.check_schema_autodetection_is_supported(
+            source_file=File(path="gs://bucket/prefix/key.csv")
+        )
+        is True
+    )
+
+    assert (
+        db.check_schema_autodetection_is_supported(
+            source_file=File(path="s3://bucket/prefix/key.csv")
+        )
+        is False
+    )
 
 
 def test_subclass_missing_append_table_raises_exception():


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently is filetype is passed then pattern doesn't need to be resolved to check native autodetect

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #873


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Create file type in case not provided before checking for native autodetect schema


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
