### PR TITLE
Generate synthetic dataset

### DIFF
--- a/python-sdk/tests/benchmark/datasets.md
+++ b/python-sdk/tests/benchmark/datasets.md
@@ -43,9 +43,11 @@ Within `s3://astro-sdk-test/benchmark/fake_data/`, following are the files with 
 
 ## Origin of the synthetic datasets
 
-To make the benchmarking results uniform, we have generated synthetic dataset for various size for all the file types:
+To make the benchmarking results uniform, we have generated synthetic dataset for various size for all the file types.
 
 1. CSV files
+
+The [script](synthetic_csv_generator.py) is used to generate the Parquet file.
 
 - GCS path
 
@@ -59,6 +61,8 @@ To make the benchmarking results uniform, we have generated synthetic dataset fo
 | two_gb     | 2 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/two_gb.csv     |
 | five_gb    | 5 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/five_gb.csv    |
 | ten_gb     | 10 GB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/ten_gb.csv     |
+| five_gb    | 5 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/five_gb/       |
+| ten_gb     | 10 GB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/ten_gb/        |
 
 - AWS S3 path
 
@@ -72,8 +76,12 @@ To make the benchmarking results uniform, we have generated synthetic dataset fo
 | two_gb     | 2 GB   | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/two_gb.csv     |
 | five_gb    | 5 GB   | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/five_gb.csv    |
 | ten_gb     | 10 GB  | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/ten_gb.csv     |
+| five_gb    | 5 GB   | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/five_gb/       |
+| ten_gb     | 10 GB  | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/ten_gb/        |
 
 2. Parquet files
+
+The [script](synthetic_parquet_generator.py) is used to generate the Parquet file.
 
 - GCS path
 
@@ -104,6 +112,8 @@ To make the benchmarking results uniform, we have generated synthetic dataset fo
 | ten_gb     | 10 GB  | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/ten_gb/            |
 
 3. NDJSON files
+
+The [script](synthetic_ndjson_generator.py) is used to generate the NDJSON file.
 
 - GCS path
 

--- a/python-sdk/tests/benchmark/datasets.md
+++ b/python-sdk/tests/benchmark/datasets.md
@@ -41,6 +41,55 @@ Within `s3://astro-sdk-test/benchmark/fake_data/`, following are the files with 
 | ten_gb     | 10 GB  | csv     | 385,007,364 | 7       | 10_gb.csv                 |
 
 
+## Origin of the synthetic datasets
+
+To make the benchmarking results uniform, we have generated synthetic dataset for various size for all the file types:
+
+1. CSV files
+
+- GCS path
+
+|            | size   | format | GCS path to csv file(s)                                       |
+|------------|--------|--------|---------------------------------------------------------------|
+| ten_kb     | 10 KB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/ten_kb.csv     |
+| hundred_kb | 100 KB | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/hundred_kb.csv |
+| ten_mb     | 10 MB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/ten_mb.csv     |
+| hundred_mb | 100 MB | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/hundred_mb.csv |
+| one_gb     | 1 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/one_gb.csv     |
+| two_gb     | 2 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/two_gb.csv     |
+| five_gb    | 5 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/five_gb.csv    |
+| ten_gb     | 10 GB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/ten_gb.csv     |
+
+2. Parquet files
+
+- GCS path
+
+|            | size   | format     | GCS path to parquet file(s)                                           |
+|------------|--------|------------|-----------------------------------------------------------------------|
+| ten_kb     | 10 KB  | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/ten_kb.parquet     |
+| hundred_kb | 100 KB | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_kb.parquet |
+| ten_mb     | 10 MB  | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/ten_mb.parquet     |
+| hundred_mb | 100 MB | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_mb.parquet |
+| one_gb     | 1 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/one_gb.parquet     |
+| two_gb     | 2 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/two_gb.parquet     |
+| five_gb    | 5 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb.parquet    |
+| ten_gb     | 10 GB  | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/ten_gb.parquet     |
+
+3. NDJSON files
+
+- GCS path
+
+|            | size   | format | GCS path to ndjson file(s)                                          |
+|------------|--------|--------|---------------------------------------------------------------------|
+| ten_kb     | 10 KB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_kb.ndjson     |
+| hundred_kb | 100 KB | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/hundred_kb.csv    |
+| ten_mb     | 10 MB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_mb.ndjson     |
+| hundred_mb | 100 MB | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/hundred_mb.ndjson |
+| one_gb     | 1 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/one_gb.ndjson     |
+| two_gb     | 2 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/two_gb.ndjson     |
+| five_gb    | 5 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/five_gb.ndjson    |
+| ten_gb     | 10 GB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_gb.ndjson     |
+
 ## Origin of the real datasets
 
 ### UK COVID overview

--- a/python-sdk/tests/benchmark/datasets.md
+++ b/python-sdk/tests/benchmark/datasets.md
@@ -49,7 +49,7 @@ To make the benchmarking results uniform, we have generated synthetic dataset fo
 
 - GCS path
 
-|            | size   | format | GCS path to csv file(s)                                       |
+|            | size   | format | path to csv file(s)                                           |
 |------------|--------|--------|---------------------------------------------------------------|
 | ten_kb     | 10 KB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/ten_kb.csv     |
 | hundred_kb | 100 KB | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/hundred_kb.csv |
@@ -60,11 +60,24 @@ To make the benchmarking results uniform, we have generated synthetic dataset fo
 | five_gb    | 5 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/five_gb.csv    |
 | ten_gb     | 10 GB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/csv/ten_gb.csv     |
 
+- AWS S3 path
+
+|            | size   | format | path to csv file(s)                                           |
+|------------|--------|--------|---------------------------------------------------------------|
+| ten_kb     | 10 KB  | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/ten_kb.csv     |
+| hundred_kb | 100 KB | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/hundred_kb.csv |
+| ten_mb     | 10 MB  | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/ten_mb.csv     |
+| hundred_mb | 100 MB | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/hundred_mb.csv |
+| one_gb     | 1 GB   | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/one_gb.csv     |
+| two_gb     | 2 GB   | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/two_gb.csv     |
+| five_gb    | 5 GB   | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/five_gb.csv    |
+| ten_gb     | 10 GB  | csv    | s3://astro-sdk/benchmark/synthetic-dataset/csv/ten_gb.csv     |
+
 2. Parquet files
 
 - GCS path
 
-|            | size   | format     | GCS path to parquet file(s)                                           |
+|            | size   | format     | path to parquet file(s)                                               |
 |------------|--------|------------|-----------------------------------------------------------------------|
 | ten_kb     | 10 KB  | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/ten_kb.parquet     |
 | hundred_kb | 100 KB | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_kb.parquet |
@@ -72,23 +85,53 @@ To make the benchmarking results uniform, we have generated synthetic dataset fo
 | hundred_mb | 100 MB | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_mb.parquet |
 | one_gb     | 1 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/one_gb.parquet     |
 | two_gb     | 2 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/two_gb.parquet     |
-| five_gb    | 5 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb.parquet    |
-| ten_gb     | 10 GB  | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/ten_gb.parquet     |
+| five_gb    | 2.8 GB | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb.parquet    |
+| five_gb    | 5 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb/           |
+| ten_gb     | 10 GB  | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/ten_gb/            |
+
+- AWS S3 path
+
+|            | size   | format     | path to parquet file(s)                                               |
+|------------|--------|------------|-----------------------------------------------------------------------|
+| ten_kb     | 10 KB  | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/ten_kb.parquet     |
+| hundred_kb | 100 KB | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_kb.parquet |
+| ten_mb     | 10 MB  | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/ten_mb.parquet     |
+| hundred_mb | 100 MB | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_mb.parquet |
+| one_gb     | 1 GB   | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/one_gb.parquet     |
+| two_gb     | 2 GB   | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/two_gb.parquet     |
+| five_gb    | 2.8 GB | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb.parquet    |
+| five_gb    | 5 GB   | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb/           |
+| ten_gb     | 10 GB  | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/ten_gb/            |
 
 3. NDJSON files
 
 - GCS path
 
-|            | size   | format | GCS path to ndjson file(s)                                          |
-|------------|--------|--------|---------------------------------------------------------------------|
-| ten_kb     | 10 KB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_kb.ndjson     |
-| hundred_kb | 100 KB | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/hundred_kb.csv    |
-| ten_mb     | 10 MB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_mb.ndjson     |
-| hundred_mb | 100 MB | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/hundred_mb.ndjson |
-| one_gb     | 1 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/one_gb.ndjson     |
-| two_gb     | 2 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/two_gb.ndjson     |
-| five_gb    | 5 GB   | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/five_gb.ndjson    |
-| ten_gb     | 10 GB  | csv    | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_gb.ndjson     |
+|            | size   | format   | path to ndjson file(s)                                              |
+|------------|--------|----------|---------------------------------------------------------------------|
+| ten_kb     | 10 KB  | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_kb.ndjson     |
+| hundred_kb | 100 KB | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/hundred_kb.ndjson |
+| ten_mb     | 10 MB  | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_mb.ndjson     |
+| hundred_mb | 100 MB | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/hundred_mb.ndjson |
+| one_gb     | 1 GB   | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/one_gb.ndjson     |
+| two_gb     | 2 GB   | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/two_gb.ndjson     |
+| five_gb    | 4.5 GB | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/five_gb.ndjson    |
+| five_gb    | 5 GB   | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/five_gb/          |
+| ten_gb     | 10 GB  | NDJSON   | gs://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_gb/           |
+
+- AWS S3 path
+
+|            | size   | format   | path to ndjson file(s)                                              |
+|------------|--------|----------|---------------------------------------------------------------------|
+| ten_kb     | 10 KB  | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_kb.ndjson     |
+| hundred_kb | 100 KB | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/hundred_kb.ndjson |
+| ten_mb     | 10 MB  | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_mb.ndjson     |
+| hundred_mb | 100 MB | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/hundred_mb.ndjson |
+| one_gb     | 1 GB   | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/one_gb.ndjson     |
+| two_gb     | 2 GB   | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/two_gb.ndjson     |
+| five_gb    | 4.5 GB | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/five_gb.ndjson    |
+| five_gb    | 5 GB   | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/five_gb/          |
+| ten_gb     | 10 GB  | NDJSON   | s3://astro-sdk/benchmark/synthetic-dataset/ndjson/ten_gb/           |
 
 ## Origin of the real datasets
 

--- a/python-sdk/tests/benchmark/synthetic_csv_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_csv_generator.py
@@ -1,0 +1,37 @@
+"""
+Function to generate csv files of various sizes
+"""
+import csv
+import random
+
+from faker import Faker
+
+
+def generate_data(row_size, file_name):
+    row_size = 11000000
+
+    faked_obj: object = Faker("en_GB")
+
+    file_obj = open(file_name, "w")
+    write_obj = csv.writer(file_obj)
+    write_obj.writerow(("id", "name", "address", "college", "company", "dob", "age"))
+    for i in range(row_size):
+        write_obj.writerow(
+            (
+                i + 1,
+                faked_obj.name(),
+                faked_obj.address(),
+                random.choice(["psg", "sona", "amirta", "anna university"]),
+                random.choice(["CTS", "INFY", "HTC"]),
+                (
+                    random.randrange(1950, 1995, 1),
+                    random.randrange(1, 13, 1),
+                    random.randrange(1, 32, 1),
+                ),
+                random.choice(range(0, 100)),
+            )
+        )
+    file_obj.close()
+
+
+generate_data(11000000, "one_gb.csv")

--- a/python-sdk/tests/benchmark/synthetic_ndjson_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_ndjson_generator.py
@@ -13,12 +13,13 @@ def generate_data(file_name, records):
     customer = []
     # Iterate the loop based on the input value and generate fake data
     for n in range(0, records):
-        cus = {}
-        cus["id"] = n
-        cus["name"] = fake.name()
-        cus["address"] = fake.address()
-        cus["email"] = str(fake.email())
-        cus["phone"] = str(fake.phone_number())
+        cus = {
+            "id": n,
+            "name": fake.name(),
+            "address": fake.address(),
+            "email": str(fake.email()),
+            "phone": str(fake.phone_number()),
+        }
         customer.append(cus)
     # Write the data into the NDJSON file
     with open(file_name, "w") as fp:

--- a/python-sdk/tests/benchmark/synthetic_ndjson_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_ndjson_generator.py
@@ -9,18 +9,16 @@ fake = Faker()
 
 # Define function to generate fake data and store into a NDJSON file
 def generate_data(file_name, records):
-    # Declare an empty list
-    customer = []
-    # Iterate the loop based on the input value and generate fake data
-    for n in range(0, records):
-        cus = {
+    customer = [
+        {
             "id": n,
             "name": fake.name(),
             "address": fake.address(),
             "email": str(fake.email()),
             "phone": str(fake.phone_number()),
         }
-        customer.append(cus)
+        for n in range(0, records)
+    ]
     # Write the data into the NDJSON file
     with open(file_name, "w") as fp:
         ndjson.dump(customer, fp)

--- a/python-sdk/tests/benchmark/synthetic_ndjson_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_ndjson_generator.py
@@ -1,0 +1,63 @@
+"""
+Function to generate ndjson files of various sizes
+"""
+import ndjson
+from faker import Faker
+
+fake = Faker()
+
+
+# Define function to generate fake data and store into a NDJSON file
+def generate_data(file_name, records):
+    # Declare an empty list
+    customer = []
+    # Iterate the loop based on the input value and generate fake data
+    for n in range(0, records):
+        cus = {}
+        cus["id"] = n
+        cus["name"] = fake.name()
+        cus["address"] = fake.address()
+        cus["email"] = str(fake.email())
+        cus["phone"] = str(fake.phone_number())
+        customer.append(cus)
+    # Write the data into the NDJSON file
+    with open(file_name, "w") as fp:
+        ndjson.dump(customer, fp)
+
+    print(f"File {file_name} has been created.")
+
+
+# create ten_kb ndjson file
+ten_kb = "fake_dataset/ndjson/ten_kb.ndjson"
+ten_kb_rows = 67
+generate_data(ten_kb, ten_kb_rows)
+
+# create hundred_kb ndjson file
+hundred_kb = "/fake_dataset/ndjson/hundred_kb.ndjson"
+hundred_kb_rows = 601
+generate_data(hundred_kb, hundred_kb_rows)
+
+# create hundred_mb ndjson file
+hundred_mb = "/fake_dataset/ndjson/hundred_mb.ndjson"
+hundred_mb_rows = 591336
+generate_data(hundred_mb, hundred_mb_rows)
+
+# create ten_mb ndjson file
+ten_mb = "/fake_dataset/ndjson/ten_mb.ndjson"
+ten_mb_rows = 59324
+generate_data(ten_mb, ten_mb_rows)
+
+# create one_mb ndjson file
+one_mb = "/fake_dataset/ndjson/one_mb.ndjson"
+one_mb_rows = 6483
+generate_data(one_mb, one_mb_rows)
+
+# create one_gb ndjson file
+one_gb = "/fake_dataset/ndjson/one_gb.ndjson"
+one_gb_rows = 5993353
+generate_data(one_gb, one_gb_rows)
+
+# create two_gb ndjson file
+two_gb = "/fake_dataset/ndjson/two_gb.ndjson"
+two_gb_rows = 14794706
+generate_data(two_gb, two_gb_rows)

--- a/python-sdk/tests/benchmark/synthetic_parquet_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_parquet_generator.py
@@ -1,0 +1,63 @@
+"""
+Function to generate PARQUET files of various sizes
+"""
+import pandas as pd
+from faker import Faker
+
+fake = Faker()
+
+
+def generate_data(file_name, records):
+    # Declare an empty dictionary
+    customer = {}
+    # Iterate the loop based on the input value and generate fake data
+    for n in range(0, records):
+        customer[str(n)] = {}
+        customer[str(n)]["id"] = str(n)
+        customer[str(n)]["name"] = fake.name()
+        customer[str(n)]["address"] = fake.address()
+        customer[str(n)]["email"] = str(fake.email())
+        customer[str(n)]["phone"] = str(fake.phone_number())
+
+    df = pd.DataFrame(data=customer)
+    df.to_parquet(file_name)
+
+    print(f"File {file_name} has been created.")
+
+
+# create ten_kb parquet file
+ten_kb = "/fake_dataset/parquet/ten_kb.parquet"
+ten_kb_rows = 13
+# generate_data(ten_kb,ten_kb_rows)
+
+# create hundred_kb parquet file
+hundred_kb = "/fake_dataset/parquet/hundred_kb.parquet"
+hundred_kb_rows = 140
+# generate_data(hundred_kb,hundred_kb_rows)
+
+
+# create hundred_mb json file
+hundred_mb = "/fake_dataset/parquet/hundred_mb.parquet"
+hundred_mb_rows = 15295
+generate_data(hundred_mb, hundred_mb_rows)
+
+# create ten_mb json file
+ten_mb = "/fake_dataset/parquet/ten_mb.parquet"
+ten_mb_rows = 14061
+generate_data(ten_mb, ten_mb_rows)
+
+# create one_mb json file
+one_mb = "/fake_dataset/parquet/one_mb.parquet"
+one_mb_rows = 1506
+# generate_data(one_mb,one_mb_rows)
+
+
+# create one_gb json file
+one_gb = "/fake_dataset/parquet/one_gb.parquet"
+one_gb_rows = 1616194
+generate_data(one_gb, one_gb_rows)
+
+# create two_gb json file
+two_gb = "/fake_dataset/parquet/two_gb.parquet"
+two_gb_rows = 3312389
+generate_data(two_gb, two_gb_rows)


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, we have only one option per type and size, we should have multiple options for a particular size since there are cases when a dataset is not consumable by a native or default path, which causes issues in running benchmarking.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #574 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

**Ideal datasets**
- Clean dataset - Synthetic dataset
- Available in all file formats supported - CSV, NDJSON, Parquet
- For all Sizes 10KB, 100KB, 10MB, 100MB, 1GB, 5GB, 10GB
- For Single, Multiple files
- This dataset is available on GCS and S3


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
