### PR TITLE
Improve benchmark teardown

### DIFF
--- a/python-sdk/tests/benchmark/Makefile
+++ b/python-sdk/tests/benchmark/Makefile
@@ -64,4 +64,4 @@ run_job:
 teardown_gke:
 	@cd infrastructure/terraform && \
 		terraform init && \
-		terraform apply -destroy
+		terraform destroy --target google_container_node_pool.benchmark -auto-approve


### PR DESCRIPTION
So it only deletes the K8s cluster, reducing the level of permissions required to set up the cluster

This relates to the task of enabling Github actions to trigger benchmark runs.
