### PR TITLE
Make the benchmark script more verbose during failure

### DIFF
--- a/python-sdk/tests/benchmark/run.sh
+++ b/python-sdk/tests/benchmark/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-set -x
-set -v
-set -e
+set -x  # print the shell command before being executed
+set -v  # run bash in verbose mode (echos each command before running it)
+set -e  # stop the execution instantly if a command returns a non-zero status
 
 
 repeat=${1:-3}  # how many times we want to repeat each DAG run (default: 3)
@@ -73,9 +73,10 @@ echo - Output: $(get_abs_filename $results_file)
       jq -r '.datasets[] | [.name] | @tsv' $config_path | while IFS=$'\t' read -r dataset; do
         for chunk_size in "${chunk_sizes_array[@]}"; do
           echo "$i $dataset $database $chunk_size"
+          set +e  # allow us to see the content of $results_file regardless of the run being successful or not
           ASTRO_CHUNKSIZE=$chunk_size python3 -W ignore $runner_path --dataset="$dataset" --database="$database" --revision $git_revision --chunk-size=$chunk_size 1>> $results_file
           cat $results_file
-
+          set -e  # do not allow errors from here onwards
           if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
         echo "$GOOGLE_APPLICATION_CREDENTIALS is not defined"
       else


### PR DESCRIPTION
Before, the users would receive the following message - which is not very informative  - and the problem would be logged into the results file but would never be printed. Now we are printing the results file regardless if the command succeeds or not.
```
+ ASTRO_CHUNKSIZE=1000000
+ python3 -W ignore /opt/app/tests/benchmark/run.py --dataset=ten_kb --database=snowflake --revision a85915a --chunk-size=1000000
Traceback (most recent call last):
  File "/opt/app/tests/benchmark/run.py", line 146, in <module>
    run_dag(
  File "/opt/app/tests/benchmark/run.py", line 66, in wrapper
    dag = func(*args, **kwargs)
  File "/opt/app/tests/benchmark/run.py", line 103, in run_dag
    dag.run(
  File "/usr/local/lib/python3.9/dist-packages/airflow/models/dag.py", line 2426, in run
    job.run()
  File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/base_job.py", line 247, in run
    self._execute()
  File "/usr/local/lib/python3.9/dist-packages/airflow/utils/session.py", line 75, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/airflow/jobs/backfill_job.py", line 856, in _execute
    raise BackfillUnfinished(err, ti_status)
airflow.exceptions.BackfillUnfinished: Some task instances failed:
DAG ID                           Task ID    Run ID                                        Try number
-------------------------------  ---------  ------------------------------------------  ------------
load_file_ten_kb_into_snowflake  cleanup    backfill__2022-09-21T11:06:42.777500+00:00             1
load_file_ten_kb_into_snowflake  load       backfill__2022-09-21T11:06:42.777500+00:00             1
```