### PR TITLE
Add filetype when resolving path in case of loading into dataframe

### DIFF
--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -4,11 +4,10 @@ from datetime import datetime, timedelta
 
 import sqlalchemy
 from airflow.models import DAG
-from astro.constants import FileType
-from astro.sql.table import Metadata, Table
-
 from astro import sql as aql
+from astro.constants import FileType
 from astro.files import File
+from astro.sql.table import Metadata, Table
 
 # To create IAM role with needed permissions,
 # refer: https://www.dataliftoff.com/iam-roles-for-loading-data-from-s3-into-redshift/

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -4,10 +4,11 @@ from datetime import datetime, timedelta
 
 import sqlalchemy
 from airflow.models import DAG
-from astro import sql as aql
 from astro.constants import FileType
-from astro.files import File
 from astro.sql.table import Metadata, Table
+
+from astro import sql as aql
+from astro.files import File
 
 # To create IAM role with needed permissions,
 # refer: https://www.dataliftoff.com/iam-roles-for-loading-data-from-s3-into-redshift/
@@ -19,6 +20,7 @@ default_args = {
     "retries": 1,
     "retry_delay": 0,
 }
+data_url = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"  # URL for Iris data API
 
 dag = DAG(
     dag_id="example_load_file",
@@ -220,5 +222,9 @@ with dag:
         enable_native_fallback=True,
     )
     # [END load_file_example_17]
+
+    # [START load_file_example_18]
+    dataframe = aql.load_file(input_file=File(path=data_url, filetype=FileType.CSV))
+    # [END load_file_example_18]
 
     aql.cleanup()

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -5,16 +5,15 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+from astro import settings
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
+from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
+from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
-
-from astro import settings
-from astro.databases import BaseDatabase, create_database
-from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 
 
 class LoadFileOperator(AstroSQLBaseOperator):

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -5,15 +5,16 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
-from astro import settings
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
-from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
-from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
+
+from astro import settings
+from astro.databases import BaseDatabase, create_database
+from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 
 
 class LoadFileOperator(AstroSQLBaseOperator):
@@ -128,6 +129,8 @@ class LoadFileOperator(AstroSQLBaseOperator):
         for file in resolve_file_path_pattern(
             input_file.path,
             input_file.conn_id,
+            normalize_config=self.normalize_config,
+            filetype=input_file.type.name,
         ):
             if isinstance(df, pd.DataFrame):
                 df = pd.concat(


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
When a `.data` file is loaded into a pandas dataframe from a URL by specifying file type, it fails. The file is basically a CSV format but has the .data extension.

Example code
```
data_url = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"  # URL for Iris data API

dataframe = aql.load_file(
            input_file=File(path=data_url, filetype=FileType.CSV)
        )
```

error log
```
ValueError: Unsupported filetype 'data' from file 'https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data'.
```
<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #881


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Pass the filetype while resolving files for loading into data frame
- Add the corresponding test for this
-

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
