### PR TITLE
Fix benchmark script build on mac m1

### DIFF
--- a/python-sdk/tests/benchmark/Dockerfile
+++ b/python-sdk/tests/benchmark/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye AS build
+FROM --platform=linux/amd64 debian:bullseye AS build
 MAINTAINER Astronomer DAG Authoring Team <airflow_dag_authors@astronomer.io>
 
 ARG GIT_HASH=""

--- a/python-sdk/tests/benchmark/Dockerfile
+++ b/python-sdk/tests/benchmark/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 debian:bullseye AS build
+FROM debian:bullseye AS build
 MAINTAINER Astronomer DAG Authoring Team <airflow_dag_authors@astronomer.io>
 
 ARG GIT_HASH=""

--- a/python-sdk/tests/benchmark/Makefile
+++ b/python-sdk/tests/benchmark/Makefile
@@ -5,7 +5,7 @@ GCP_PROJECT ?= astronomer-dag-authoring
 GIT_HASH = $(shell git log -1 --format=%h)
 APP ?= benchmark
 CONTAINER_REGISTRY=gcr.io/$(GCP_PROJECT)/$(APP)
-
+PLATFORM="linux/amd64"
 
 check_google_credentials:
 ifndef GOOGLE_APPLICATION_CREDENTIALS
@@ -36,13 +36,13 @@ run: clean
 container: clean
 	@echo "Building and pushing container $(CONTAINER_REGISTRY)"
 	@gcloud auth configure-docker gcr.io
-	@docker build --build-arg=GIT_HASH=$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):latest -f ./Dockerfile  ../../
+	@docker build --platform=$(PLATFORM) --build-arg=GIT_HASH=$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):latest -f ./Dockerfile  ../../
 	@docker push $(CONTAINER_REGISTRY)
 
 local: clean check_google_credentials
 	@echo "Building and pushing container $(CONTAINER_REGISTRY)"
 	@gcloud auth configure-docker gcr.io
-	@docker build -t benchmark -f ./Dockerfile ../../ --build-arg=GIT_HASH=$(GIT_HASH)
+	@docker build -t benchmark -f ./Dockerfile ../../ --platform=$(PLATFORM) --build-arg=GIT_HASH=$(GIT_HASH)
 	@mkdir -p /tmp/docker
 	@sudo chmod a+rwx /tmp/docker/
 	@docker run -it \


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/834

Let's build the image with `--platform` option since if build on M1 Mac then it is not working in other architecture. For now, I have added the platform value `linux/amd64` if needed we can add multiple values in future like `linux/amd64,linux/arm64 `  

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
