### PR TITLE
Render sql code with parameters in BaseSQLDecoratedOperator

### DIFF
--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -137,10 +137,9 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         :param context: Dict with values to apply on content
         :param jinja_env: Jinja environment
         """
-        output = super().render_template_fields(context, jinja_env)
         context = self._enrich_context(context)
 
-        return output
+        return super().render_template_fields(context, jinja_env)
 
     def execute(self, context: Context) -> None:
         self._enrich_context(context)

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -179,7 +179,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         return super().render_template_fields(context, jinja_env)
 
     def execute(self, context: Context) -> None:
-        self._enrich_context(context)
+        context = self._enrich_context(context)
 
         # TODO: remove pushing to XCom once we update the airflow version.
         context["ti"].xcom_push(key="base_sql_query", value=str(self.sql))

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -137,9 +137,10 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         :param context: Dict with values to apply on content
         :param jinja_env: Jinja environment
         """
+        output = super().render_template_fields(context, jinja_env)
         context = self._enrich_context(context)
 
-        return super().render_template_fields(context, jinja_env)
+        return output
 
     def execute(self, context: Context) -> None:
         self._enrich_context(context)

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -257,8 +257,6 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
                 ) = self.database_impl.get_sqlalchemy_template_table_identifier_and_parameter(v, k)
                 context[k] = jinja_table_identifier
                 self.parameters[k] = jinja_table_parameter_value
-            # elif isinstance(v, pd.DataFrame):
-            #    raise Exception("I should not be here")
             else:
                 context[k] = self.database_impl.parameterize_variable(k)
 

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable, Sequence, cast
 
+import jinja2
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
 from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
 from sqlalchemy.sql.functions import Function
 
 from astro.airflow.datasets import kwargs_with_datasets
@@ -20,7 +22,8 @@ from astro.utils.table import find_first_table
 class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
     """Handles all decorator classes that can return a SQL function"""
 
-    template_fields: Sequence[str] = ("parameters", "op_args", "op_kwargs")
+    template_fields: Sequence[str] = ("sql", "parameters", "op_args", "op_kwargs")
+    template_ext: Sequence[str] = (".sql",)
 
     database_impl: BaseDatabase
 
@@ -59,7 +62,19 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
             **kwargs_with_datasets(kwargs=kwargs, output_datasets=self.output_table),
         )
 
-    def execute(self, context: Context) -> None:
+    def _enrich_context(self, context: Context) -> Context:
+        """
+        Prepare the sql and context for execution.
+
+        Specifically, it will do the following:
+        1. Preset database settings
+        2. Load dataframes into tables
+        3. Render sql as sqlalchemy executable string
+
+        :param context: The Airflow Context which will be extended.
+
+        :return: the enriched context with astro specific information.
+        """
         first_table = find_first_table(
             op_args=self.op_args,  # type: ignore
             op_kwargs=self.op_kwargs,
@@ -108,6 +123,26 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         # if there is no SQL to run we raise an error
         if self.sql == "" or not self.sql:
             raise AirflowException("There's no SQL to run")
+        return context
+
+    def render_template_fields(
+        self,
+        context: Context,
+        jinja_env: jinja2.Environment | None = None,
+    ) -> BaseOperator | None:
+        """Template all attributes listed in template_fields.
+
+        This mutates the attributes in-place and is irreversible.
+
+        :param context: Dict with values to apply on content
+        :param jinja_env: Jinja environment
+        """
+        context = self._enrich_context(context)
+
+        return super().render_template_fields(context, jinja_env)
+
+    def execute(self, context: Context) -> None:
+        self._enrich_context(context)
 
         # TODO: remove pushing to XCom once we update the airflow version.
         context["ti"].xcom_push(key="base_sql_query", value=str(self.sql))

--- a/python-sdk/tests/sql/operators/test_base_decorator.py
+++ b/python-sdk/tests/sql/operators/test_base_decorator.py
@@ -29,7 +29,6 @@ def test_get_source_code_handle_exception(mock_getsource, exception):
         py_callable=None
     )
 
-
 def test_load_op_arg_dataframes_into_sql():
     df_1 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     df_2 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
@@ -45,7 +44,6 @@ def test_load_op_arg_dataframes_into_sql():
     assert isinstance(results[2], BaseTable)
     assert isinstance(results[3], str)
 
-
 def test_load_op_kwarg_dataframes_into_sql():
     df_1 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     df_2 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
@@ -60,3 +58,11 @@ def test_load_op_kwarg_dataframes_into_sql():
 
     assert isinstance(results["table"], BaseTable)
     assert isinstance(results["some_str"], str)
+
+def test_base_sql_decorated_operator_template_fields_and_template_ext_with_sql():
+    """
+    Test that sql is in BaseSQLDecoratedOperator template_fields and template_ext
+     as this required for rending the sql in the task instance rendered section.
+    """
+    assert "sql" in BaseSQLDecoratedOperator.template_fields
+    assert ".sql" in BaseSQLDecoratedOperator.template_ext

--- a/python-sdk/tests/sql/operators/test_base_decorator.py
+++ b/python-sdk/tests/sql/operators/test_base_decorator.py
@@ -29,6 +29,7 @@ def test_get_source_code_handle_exception(mock_getsource, exception):
         py_callable=None
     )
 
+
 def test_load_op_arg_dataframes_into_sql():
     df_1 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     df_2 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
@@ -44,6 +45,7 @@ def test_load_op_arg_dataframes_into_sql():
     assert isinstance(results[2], BaseTable)
     assert isinstance(results[3], str)
 
+
 def test_load_op_kwarg_dataframes_into_sql():
     df_1 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     df_2 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
@@ -58,6 +60,7 @@ def test_load_op_kwarg_dataframes_into_sql():
 
     assert isinstance(results["table"], BaseTable)
     assert isinstance(results["some_str"], str)
+
 
 def test_base_sql_decorated_operator_template_fields_and_template_ext_with_sql():
     """


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, when using operators inheriting from `BaseSQLDecoratedOperator` we are unable to view the rendered SQL in the UI.

closes: #1003 
depends on: #1004 

## What is the new behavior?

- add sql and parameters to BaseSQLDecoratedOperator template_fields
- add .sql to BaseSQLDecoratedOperator template_ext
- add check for template_fields and template_ext

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
