### PR TITLE
Pin the sphinx version to 5.0.0

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -84,7 +84,7 @@ all = [
 ]
 doc = [
     "myst-parser>=0.17",
-    "sphinx>=4.4.0",
+    "sphinx==5.0.0", # TODO: https://github.com/astronomer/astro-sdk/issues/916
     "sphinx-autoapi",
     "sphinx-rtd-theme"
 ]


### PR DESCRIPTION
# Description
build_docs is failing in main due to recent changes in sphinx. not sure what immediate I can do so pined the sphinx version to 5.0.0

sphinx: https://github.com/sphinx-doc/sphinx/pull/10852
```
Warning, treated as error:
Using the :property: flag with the py:method directiveis deprecated, use ".. py:property::" instead.
make: *** [Makefile:20: html] Error 2
nox > Command make html failed with exit code 2
nox > Session build_docs failed.
Error: Process completed with exit code 1.
0s
``` 



## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
