### PR TITLE
Fix postgres performance regression

### DIFF
--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -457,7 +457,9 @@ class BaseDatabase(ABC):
 
     @staticmethod
     def get_dataframe_from_file(file: File):
-        """Get pandas dataframe file
+        """
+        Get pandas dataframe file
+
         :param file: File path and conn_id for object stores
         """
         # We need export_to_dataframe() for Biqqery, Snowflake and Redshift except for Postgres. For postgres

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -18,8 +18,6 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
-from astro.files import File, resolve_file_path_pattern
-from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
@@ -28,6 +26,9 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
+
+from astro.files import File, resolve_file_path_pattern
+from astro.files.types import create_file_type
 
 
 class BaseDatabase(ABC):
@@ -454,6 +455,13 @@ class BaseDatabase(ABC):
                 if_exists="append",
                 chunk_size=chunk_size,
             )
+
+    @staticmethod
+    def get_dataframe_from_file(file: File):
+        """Get pandas dataframe file
+        :param file: File path and conn_id for object stores
+        """
+        return file.export_to_dataframe()
 
     def load_file_to_table_using_pandas(
         self,

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -18,6 +18,8 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
+from astro.files import File, resolve_file_path_pattern
+from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
@@ -26,9 +28,6 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
-
-from astro.files import File, resolve_file_path_pattern
-from astro.files.types import create_file_type
 
 
 class BaseDatabase(ABC):

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -18,8 +18,6 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
-from astro.files import File, resolve_file_path_pattern
-from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
@@ -28,6 +26,9 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
+
+from astro.files import File, resolve_file_path_pattern
+from astro.files.types import create_file_type
 
 
 class BaseDatabase(ABC):
@@ -460,6 +461,10 @@ class BaseDatabase(ABC):
         """Get pandas dataframe file
         :param file: File path and conn_id for object stores
         """
+        # We need export_to_dataframe() for Biqqery, Snowflake and Redshift except for Postgres. For postgres
+        # we are overriding this method and using export_to_dataframe_via_byte_stream(). export_to_dataframe_via_
+        # byte_stream copies files in a buffer and then use that buffer to ingest data. With this approach
+        # we have significant performance boost for postgres.
         return file.export_to_dataframe()
 
     def load_file_to_table_using_pandas(

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -18,8 +18,6 @@ from astro.constants import (
     MergeConflictStrategy,
 )
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
-from astro.files import File, resolve_file_path_pattern
-from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.sql.table import BaseTable, Metadata
@@ -28,6 +26,9 @@ from sqlalchemy import column, insert, select
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
+
+from astro.files import File, resolve_file_path_pattern
+from astro.files.types import create_file_type
 
 
 class BaseDatabase(ABC):
@@ -458,14 +459,14 @@ class BaseDatabase(ABC):
     @staticmethod
     def get_dataframe_from_file(file: File):
         """
-        Get pandas dataframe file
+        Get pandas dataframe file. We need export_to_dataframe() for Biqqery,Snowflake and Redshift except for Postgres.
+        For postgres we are overriding this method and using export_to_dataframe_via_byte_stream().
+        export_to_dataframe_via_byte_stream copies files in a buffer and then use that buffer to ingest data.
+        With this approach we have significant performance boost for postgres.
 
         :param file: File path and conn_id for object stores
         """
-        # We need export_to_dataframe() for Biqqery, Snowflake and Redshift except for Postgres. For postgres
-        # we are overriding this method and using export_to_dataframe_via_byte_stream(). export_to_dataframe_via_
-        # byte_stream copies files in a buffer and then use that buffer to ingest data. With this approach
-        # we have significant performance boost for postgres.
+
         return file.export_to_dataframe()
 
     def load_file_to_table_using_pandas(

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -480,7 +480,7 @@ class BaseDatabase(ABC):
 
         for file in input_files:
             self.load_pandas_dataframe_to_table(
-                file.export_to_dataframe(),
+                self.get_dataframe_from_file(file),
                 output_table,
                 chunk_size=chunk_size,
                 if_exists=if_exists,

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -13,6 +13,8 @@ from astro.settings import POSTGRES_SCHEMA
 from astro.sql.table import BaseTable, Metadata
 from psycopg2 import sql as postgres_sql
 
+from astro.files import File
+
 DEFAULT_CONN_ID = PostgresHook.default_conn_name
 
 
@@ -186,3 +188,10 @@ class PostgresDatabase(BaseDatabase):
 
         sql = query.as_string(self.hook.get_conn())
         self.run_sql(sql=sql)
+
+    @staticmethod
+    def get_dataframe_from_file(file: File):
+        """Get pandas dataframe file
+        :param file: File path and conn_id for object stores
+        """
+        return file.export_to_dataframe_via_byte_stream()

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -9,11 +9,10 @@ import sqlalchemy
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy, MergeConflictStrategy
 from astro.databases.base import BaseDatabase
+from astro.files import File
 from astro.settings import POSTGRES_SCHEMA
 from astro.sql.table import BaseTable, Metadata
 from psycopg2 import sql as postgres_sql
-
-from astro.files import File
 
 DEFAULT_CONN_ID = PostgresHook.default_conn_name
 

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -190,7 +190,9 @@ class PostgresDatabase(BaseDatabase):
 
     @staticmethod
     def get_dataframe_from_file(file: File):
-        """Get pandas dataframe file
+        """
+        Get pandas dataframe file
+
         :param file: File path and conn_id for object stores
         """
         return file.export_to_dataframe_via_byte_stream()

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -5,13 +5,12 @@ import pathlib
 
 import pandas as pd
 import smart_open
-from astro.airflow.datasets import Dataset
-from astro.files.locations.base import BaseFileLocation
-from attr import define, field
-
 from astro import constants
+from astro.airflow.datasets import Dataset
 from astro.files.locations import create_file_location
+from astro.files.locations.base import BaseFileLocation
 from astro.files.types import FileType, create_file_type
+from attr import define, field
 
 
 @define

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+import io
 import pathlib
 
 import pandas as pd
 import smart_open
-from astro import constants
 from astro.airflow.datasets import Dataset
-from astro.files.locations import create_file_location
 from astro.files.locations.base import BaseFileLocation
-from astro.files.types import FileType, create_file_type
 from attr import define, field
+
+from astro import constants
+from astro.files.locations import create_file_location
+from astro.files.types import FileType, create_file_type
 
 
 @define
@@ -93,6 +95,36 @@ class File(Dataset):
             self.path, mode=mode, transport_params=self.location.transport_params
         ) as stream:
             return self.type.export_to_dataframe(stream, **kwargs)
+
+    def _convert_remote_file_to_byte_stream(self) -> io.IOBase:
+        """
+        Read file from all supported location and convert them into a buffer that can be streamed into other data
+        structures.
+        Due to noted issues with using smart_open with pandas (like
+        https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
+        before exporting to a dataframe. We've found a sizable speed improvement with this optimizat
+        Returns: an io object that can be streamed into a dataframe (or other object)
+        """
+
+        mode = "rb" if self.is_binary() else "r"
+        remote_obj_buffer = io.BytesIO() if self.is_binary() else io.StringIO()
+        with smart_open.open(
+            self.path, mode=mode, transport_params=self.location.transport_params
+        ) as stream:
+            remote_obj_buffer.write(stream.read())
+        remote_obj_buffer.seek(0)
+        return remote_obj_buffer
+
+    def export_to_dataframe_via_byte_stream(self, **kwargs) -> pd.DataFrame:
+        """Read file from all supported location and convert them into dataframes.
+        Due to noted issues with using smart_open with pandas (like
+        https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
+        before exporting to a dataframe. We've found a sizable speed improvement with this optimization.
+        """
+
+        return self.type.export_to_dataframe(
+            self._convert_remote_file_to_byte_stream(), **kwargs
+        )
 
     def exists(self) -> bool:
         """Check if the file exists or not"""

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -116,7 +116,7 @@ class File(Dataset):
         return remote_obj_buffer
 
     def export_to_dataframe_via_byte_stream(self, **kwargs) -> pd.DataFrame:
-        """Read file from all supported location and convert them into dataframes.
+        """Read files from all supported locations and convert them into dataframes.
         Due to noted issues with using smart_open with pandas (like
         https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
         before exporting to a dataframe. We've found a sizable speed improvement with this optimization.

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -101,7 +101,7 @@ class File(Dataset):
         structures.
         Due to noted issues with using smart_open with pandas (like
         https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
-        before exporting to a dataframe. We've found a sizable speed improvement with this optimizat
+        before exporting to a dataframe. We've found a sizable speed improvement with this optimization
 
         :returns: an io object that can be streamed into a dataframe (or other object)
         """

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -102,7 +102,8 @@ class File(Dataset):
         Due to noted issues with using smart_open with pandas (like
         https://github.com/RaRe-Technologies/smart_open/issues/524), we create a BytesIO or StringIO buffer
         before exporting to a dataframe. We've found a sizable speed improvement with this optimizat
-        Returns: an io object that can be streamed into a dataframe (or other object)
+
+        :returns: an io object that can be streamed into a dataframe (or other object)
         """
 
         mode = "rb" if self.is_binary() else "r"

--- a/python-sdk/src/astro/files/types/ndjson.py
+++ b/python-sdk/src/astro/files/types/ndjson.py
@@ -59,7 +59,7 @@ class NDJSONFileType(FileType):
         nrows = kwargs.get("nrows", float("inf"))
         chunksize = kwargs.get("chunksize", DEFAULT_CHUNK_SIZE)
 
-        result_df = None
+        result_df = []
         row_count = 0
         extra_rows = []
 
@@ -76,14 +76,18 @@ class NDJSONFileType(FileType):
             else:
                 extra_rows = []
 
-            df = pd.DataFrame(
-                pd.json_normalize([json.loads(row) for row in rows], **normalize_config)
+            # ToDo: Check if there is an alternative to pandas json_normalize(). A custom implementation is much faster.
+            # But that would entail breaking changes.
+            # ref : https://stackoverflow.com/questions/69945941/
+            #   why-does-pandas-json-normalize-run-slower-than-my-hand-crafted-loop
+            df = pd.json_normalize(
+                [json.loads(row) for row in rows], **normalize_config
             )
-            if result_df is None:
-                result_df = df
-            else:
-                result_df = pd.concat([result_df, df])
+            result_df.append(df)
 
-            row_count = result_df.shape[0]
+            row_count = row_count + df.shape[0]
 
-        return result_df
+        # Running concat multiple times is much slower instead we are appending all the generated dataframes
+        # in a list and then concatenating in single call. This brought down the cost from 351.79550790786743
+        # to 2.3778765201568604.
+        return pd.concat(result_df)

--- a/python-sdk/src/astro/files/types/ndjson.py
+++ b/python-sdk/src/astro/files/types/ndjson.py
@@ -76,10 +76,6 @@ class NDJSONFileType(FileType):
             else:
                 extra_rows = []
 
-            # ToDo: Check if there is an alternative to pandas json_normalize(). A custom implementation is much faster.
-            # But that would entail breaking changes.
-            # ref : https://stackoverflow.com/questions/69945941/
-            #   why-does-pandas-json-normalize-run-slower-than-my-hand-crafted-loop
             df = pd.json_normalize(
                 [json.loads(row) for row in rows], **normalize_config
             )

--- a/python-sdk/tests/databases/test_all_databases.py
+++ b/python-sdk/tests/databases/test_all_databases.py
@@ -5,10 +5,9 @@ from unittest import mock
 import pandas as pd
 import pytest
 from astro.constants import Database
+from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table
-
-from astro.files import File
 
 CWD = pathlib.Path(__file__).parent
 

--- a/python-sdk/tests/databases/test_all_databases.py
+++ b/python-sdk/tests/databases/test_all_databases.py
@@ -5,9 +5,10 @@ from unittest import mock
 import pandas as pd
 import pytest
 from astro.constants import Database
-from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table
+
+from astro.files import File
 
 CWD = pathlib.Path(__file__).parent
 
@@ -87,7 +88,7 @@ def test_export_to_dataframe_via_byte_stream_is_called_for_postgres(
     database_table_fixture,
 ):
     """Test export_to_dataframe_via_byte_stream() is called in case the db is postgres."""
-    database, table = database_table_fixture
+    database, _ = database_table_fixture
     file = File(str(pathlib.Path(CWD.parent, "data/sample.csv")))
 
     with mock.patch(

--- a/python-sdk/tests/databases/test_all_databases.py
+++ b/python-sdk/tests/databases/test_all_databases.py
@@ -1,12 +1,14 @@
 """Tests all Database implementations."""
 import pathlib
+from unittest import mock
 
 import pandas as pd
 import pytest
 from astro.constants import Database
-from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.table import Metadata, Table
+
+from astro.files import File
 
 CWD = pathlib.Path(__file__).parent
 
@@ -60,3 +62,42 @@ def test_export_table_to_pandas_dataframe(
         ]
     )
     assert df.rename(columns=str.lower).equals(expected)
+
+
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.BIGQUERY,
+            "table": Table(metadata=Metadata(schema=SCHEMA)),
+        },
+        {
+            "database": Database.POSTGRES,
+            "table": Table(metadata=Metadata(schema=SCHEMA.lower())),
+        },
+        {
+            "database": Database.SNOWFLAKE,
+            "table": Table(metadata=Metadata(schema=SCHEMA)),
+        },
+        {"database": Database.SQLITE, "table": Table()},
+    ],
+    indirect=True,
+    ids=["bigquery", "postgres", "redshift", "snowflake", "sqlite"],
+)
+def test_export_to_dataframe_via_byte_stream_is_called_for_postgres(
+    database_table_fixture,
+):
+    """Test export_to_dataframe_via_byte_stream() is called in case the db is postgres."""
+    database, table = database_table_fixture
+    file = File(str(pathlib.Path(CWD.parent, "data/sample.csv")))
+
+    with mock.patch(
+        "astro.files.base.File.export_to_dataframe"
+    ) as export_to_dataframe, mock.patch(
+        "astro.files.base.File.export_to_dataframe_via_byte_stream"
+    ) as export_to_dataframe_via_byte_stream:
+        database.get_dataframe_from_file(file)
+        if database.sql_type == "postgresql":
+            export_to_dataframe_via_byte_stream.assert_called()
+        else:
+            export_to_dataframe.assert_called()

--- a/python-sdk/tests/databases/test_all_databases.py
+++ b/python-sdk/tests/databases/test_all_databases.py
@@ -81,7 +81,7 @@ def test_export_table_to_pandas_dataframe(
         {"database": Database.SQLITE, "table": Table()},
     ],
     indirect=True,
-    ids=["bigquery", "postgres", "redshift", "snowflake", "sqlite"],
+    ids=["bigquery", "postgres", "snowflake", "sqlite"],
 )
 def test_export_to_dataframe_via_byte_stream_is_called_for_postgres(
     database_table_fixture,


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, the performance for loading files in the Postgres database is way too much slower then what it use to be.

OLD Benchmark
GCS to Postgres
Git Sha:  56ac86a1b42fbe2110becd4c226969809fd67147
Run 1
| database   | dataset    | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   | memory_pss   | memory_shared   |
|:-----------|:-----------|:-------------|:-------------|:----------------|:------------------|:-------------|:----------------|
| postgres   | five_gb    | 56.07s       | 45.02MB      | 32.01s          | 14.81s            | 42.36MB      | 7.48MB          |
| postgres   | hundred_kb | 867.03ms     | 32.41MB      | 780.0ms         | 40.0ms            | 29.51MB      | 7.96MB          |
| postgres   | one_gb     | 25.55s       | 37.09MB      | 15.43s          | 8.37s             | 34.13MB      | 7.23MB          |
| postgres   | ten_gb     | 2.71min      | 43.75MB      | 1.38min         | 59.72s            | 40.9MB       | 7.59MB          |
| postgres   | ten_kb     | 888.75ms     | 66.29MB      | 800.0ms         | 80.0ms            | 64.94MB      | 18.96MB         |
| postgres   | ten_mb     | 3.0s         | 55.53MB      | 2.15s           | 220.0ms           | 52.78MB      | 7.77MB          |


Run 2
| database   | dataset    | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   | memory_pss   | memory_shared   |
|:-----------|:-----------|:-------------|:-------------|:----------------|:------------------|:-------------|:----------------|
| postgres   | five_gb    | 51.39s       | 43.38MB      | 32.21s          | 14.75s            | 40.9MB       | 7.32MB          |
| postgres   | hundred_kb | 760.32ms     | 32.46MB      | 780.0ms         | 70.0ms            | 29.75MB      | 7.8MB           |
| postgres   | one_gb     | 23.59s       | 36.65MB      | 15.49s          | 7.7s              | 33.89MB      | 7.22MB          |
| postgres   | ten_gb     | 2.49min      | 43.08MB      | 1.34min         | 59.42s            | 40.55MB      | 7.19MB          |
| postgres   | ten_kb     | 857.16ms     | 61.13MB      | 850.0ms         | 60.0ms            | 59.03MB      | 19.54MB         |
| postgres   | ten_mb     | 2.99s        | 54.93MB      | 2.17s           | 220.0ms           | 52.38MB      | 7.65MB          |


Current main branch:
GCS to Postgres:
Git Sha: 187ad9b
branch: main 
| database   | dataset    | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   |
|:-----------|:-----------|:-------------|:-------------|:----------------|:------------------|
| postgres   | hundred_kb | 500.05ms     | 32.47MB      | 520.0ms         | 30.0ms            |
| postgres   | one_gb     | 6.86min      | 1.24GB       | 3.08min         | 46.24s            |
| postgres   | ten_kb     | 541.13ms     | 63.17MB      | 500.0ms         | 60.0ms            |
| postgres   | ten_mb     | 3.62s        | 50.15MB      | 1.5s            | 120.0ms           |


closes: #876


## What is the new behavior?
There were two bottlenecks found:
1. Reading files in memory and populating them in Postgres - introduced in commit https://github.com/astronomer/astro-sdk/tree/postgres-imp-2
2. The way we were doing dataframe concat was suboptimal.

Branch: postgres_performance_boost

| database   | dataset    | total_time   | memory_rss   | cpu_time_user   | cpu_time_system   |
|:-----------|:-----------|:-------------|:-------------|:----------------|:------------------|
| postgres   | hundred_kb | 905.51ms     | 32.18MB      | 940.0ms         | 70.0ms            |
| postgres   | one_gb     | 1.88min      | 1.08GB       | 1.14min         | 15.41s            |
| postgres   | ten_kb     | 950.24ms     | 69.5MB       | 940.0ms         | 80.0ms            |
| postgres   | ten_mb     | 3.1s         | 54.19MB      | 2.44s           | 190.0ms           |


## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
