### PR TITLE
Make docker image tag dynamic

### DIFF
--- a/python-sdk/tests/benchmark/Makefile
+++ b/python-sdk/tests/benchmark/Makefile
@@ -36,7 +36,7 @@ run: clean
 container: clean check_google_credentials
 	@echo "Building and pushing container $(CONTAINER_REGISTRY)"
 	@gcloud auth configure-docker gcr.io
-	@docker build --platform=$(PLATFORM) --build-arg=GIT_HASH=$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):latest -f ./Dockerfile  ../../
+	@docker build --platform=$(PLATFORM) --build-arg=GIT_HASH=$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) -f ./Dockerfile  ../../
 	@gcloud auth activate-service-account --key-file $(GOOGLE_APPLICATION_CREDENTIALS)
 	@docker push $(CONTAINER_REGISTRY)
 
@@ -59,7 +59,8 @@ run_job:
 	@kubectl apply -f infrastructure/kubernetes/namespace.yaml
 	@kubectl apply -f infrastructure/kubernetes/postgres.yaml
 	@kubectl apply -f infrastructure/kubernetes/postgres_svc.yaml
-	@kubectl create -f infrastructure/kubernetes/job.yaml
+	@sed s/%VERSION%/${GIT_HASH}/g infrastructure/kubernetes/job.yaml > infrastructure/kubernetes/job_final.yaml
+	@kubectl create -f infrastructure/kubernetes/job_final.yaml
 
 # Takes approximately 2min
 teardown_gke:

--- a/python-sdk/tests/benchmark/infrastructure/kubernetes/job.yaml
+++ b/python-sdk/tests/benchmark/infrastructure/kubernetes/job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: benchmark
-        image: gcr.io/astronomer-dag-authoring/benchmark
+        image: gcr.io/astronomer-dag-authoring/benchmark:%VERSION%
         command: ["./run.sh"]
         resources:
           requests:


### PR DESCRIPTION
# Description
## What is the current behavior?
Every new docker image is labeled as latest and if we have two parallel branches that run benchmark one might conflict with another branch. We should have new labels per commit basis.


closes: #887

## What is the new behavior?
Modified Makefile to use git sha instead of the latest tag.

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
