### PR TITLE
Moved kwargs to config

### DIFF
--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -1,14 +1,20 @@
 {
   "databases": [
     {
+      "kwargs": {
+        "enable_native_fallback": false
+      },
       "name": "snowflake",
-      "params": {
+      "output_table": {
         "conn_id": "snowflake_conn"
       }
     },
     {
+      "kwargs": {
+        "enable_native_fallback": false
+      },
       "name": "postgres",
-      "params": {
+      "output_table": {
         "conn_id": "postgres_benchmark_conn",
         "metadata": {
           "database": "postgres"

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -4,11 +4,10 @@ from datetime import datetime
 from pathlib import Path
 
 from airflow import DAG
-from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.sql.table import Metadata, Table
-
 from astro import sql as aql
+from astro.constants import DEFAULT_CHUNK_SIZE, FileType
 from astro.files import File
+from astro.sql.table import Metadata, Table
 
 START_DATE = datetime(2000, 1, 1)
 


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, we need to modify the dag if we want to modify the behavior of load_file operator. This is not scalable since we need to run the same dag or all paths - native and non-natives.

closes: #884

## What is the new behavior?
We can keep the kwargs that will be passed to load_file() operator in config.json in a new key "load_file_kwargs" as follows:
```
"databases": [{
    "name": "postgres",
    "params": {
      "conn_id": "postgres_conn_benchmark",
      "metadata": {
        "database": "postgres"
      }
    },
    "kwargs": {
      "use_native_support": True,
      "enable_native_fallback": False
    }
  }]
```
and pass this new value to `load_file()` operator.

## Does this introduce a breaking change?


### Checklist
- [ ] We should be able to run benchmarking scripts for both native and non-native paths without modifying the dag.
