### PR TITLE
Updated the log level to logging.WARNING

### DIFF
--- a/python-sdk/src/astro/__init__.py
+++ b/python-sdk/src/astro/__init__.py
@@ -15,9 +15,8 @@ __version__ = "1.2.0.dev1"
 
 import logging
 
-from airflow.configuration import conf
-
 import astro.sql  # noqa: F401
+from airflow.configuration import conf
 
 # Override the default log level from logging.ERROR to logging.WARNING
 logging.getLogger().setLevel(level=logging.WARNING)

--- a/python-sdk/src/astro/__init__.py
+++ b/python-sdk/src/astro/__init__.py
@@ -13,8 +13,14 @@ __version__ = "1.2.0.dev1"
 # imported beforehand, it will also load astro.sql. In astro.sql we import lots of operators which depend on
 # astro.database, and this is what leads to the circular dependency.
 
-import astro.sql  # noqa: F401
+import logging
+
 from airflow.configuration import conf
+
+import astro.sql  # noqa: F401
+
+# Override the default log level from logging.ERROR to logging.WARNING
+logging.getLogger().setLevel(level=logging.WARNING)
 
 
 # This is needed to allow Airflow to pick up specific metadata fields it needs


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, we are not showing the warning message when the native path fails and we default to pandas path to load the file in DB. 

closes: #827


## What is the new behavior?
Found the default log level to ERROR and changed it to WARNING.

## Does this introduce a breaking change?
Nope