### PR TITLE
Add a global config for col capitalization

### DIFF
--- a/python-sdk/src/astro/constants.py
+++ b/python-sdk/src/astro/constants.py
@@ -65,4 +65,3 @@ ExportExistsStrategy = Literal["replace", "exception"]
 MergeConflictStrategy = Literal["ignore", "update", "exception"]
 
 ColumnCapitalization = Literal["upper", "lower", "original"]
-DEFAULT_COLUMN_CAPITALIZATION = "original"

--- a/python-sdk/src/astro/constants.py
+++ b/python-sdk/src/astro/constants.py
@@ -65,3 +65,4 @@ ExportExistsStrategy = Literal["replace", "exception"]
 MergeConflictStrategy = Literal["ignore", "update", "exception"]
 
 ColumnCapitalization = Literal["upper", "lower", "original"]
+DEFAULT_COLUMN_CAPITALIZATION = "original"

--- a/python-sdk/src/astro/files/types/csv.py
+++ b/python-sdk/src/astro/files/types/csv.py
@@ -7,12 +7,17 @@ from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
 
+from astro import settings
+
 
 class CSVFileType(FileType):
     """Concrete implementation to handle CSV file type"""
 
     def export_to_dataframe(
-        self, stream, columns_names_capitalization="original", **kwargs
+        self,
+        stream,
+        columns_names_capitalization=settings.COLUMN_CAPITALIZATION,
+        **kwargs,
     ) -> pd.DataFrame:
         """read csv file from one of the supported locations and return dataframe
 

--- a/python-sdk/src/astro/files/types/csv.py
+++ b/python-sdk/src/astro/files/types/csv.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import io
 
 import pandas as pd
+from astro import settings
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
-
-from astro import settings
 
 
 class CSVFileType(FileType):

--- a/python-sdk/src/astro/files/types/json.py
+++ b/python-sdk/src/astro/files/types/json.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import io
 
 import pandas as pd
+from astro import settings
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
-
-from astro import settings
 
 
 class JSONFileType(FileType):

--- a/python-sdk/src/astro/files/types/json.py
+++ b/python-sdk/src/astro/files/types/json.py
@@ -7,6 +7,8 @@ from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
 
+from astro import settings
+
 
 class JSONFileType(FileType):
     """Concrete implementation to handle JSON file type"""
@@ -14,7 +16,7 @@ class JSONFileType(FileType):
     def export_to_dataframe(
         self,
         stream: io.TextIOWrapper,
-        columns_names_capitalization="original",
+        columns_names_capitalization=settings.COLUMN_CAPITALIZATION,
         **kwargs,
     ) -> pd.DataFrame:
         """read json file from one of the supported locations and return dataframe

--- a/python-sdk/src/astro/files/types/ndjson.py
+++ b/python-sdk/src/astro/files/types/ndjson.py
@@ -9,12 +9,17 @@ from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
 
+from astro import settings
+
 
 class NDJSONFileType(FileType):
     """Concrete implementation to handle NDJSON file type"""
 
     def export_to_dataframe(
-        self, stream, columns_names_capitalization="original", **kwargs
+        self,
+        stream,
+        columns_names_capitalization=settings.COLUMN_CAPITALIZATION,
+        **kwargs,
     ):
         """read ndjson file from one of the supported locations and return dataframe
 

--- a/python-sdk/src/astro/files/types/ndjson.py
+++ b/python-sdk/src/astro/files/types/ndjson.py
@@ -4,12 +4,11 @@ import io
 import json
 
 import pandas as pd
+from astro import settings
 from astro.constants import DEFAULT_CHUNK_SIZE
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
-
-from astro import settings
 
 
 class NDJSONFileType(FileType):

--- a/python-sdk/src/astro/files/types/parquet.py
+++ b/python-sdk/src/astro/files/types/parquet.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import io
 
 import pandas as pd
+from astro import settings
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
-
-from astro import settings
 
 
 class ParquetFileType(FileType):

--- a/python-sdk/src/astro/files/types/parquet.py
+++ b/python-sdk/src/astro/files/types/parquet.py
@@ -7,12 +7,17 @@ from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
 
+from astro import settings
+
 
 class ParquetFileType(FileType):
     """Concrete implementation to handle Parquet file type"""
 
     def export_to_dataframe(
-        self, stream, columns_names_capitalization="original", **kwargs
+        self,
+        stream,
+        columns_names_capitalization=settings.COLUMN_CAPITALIZATION,
+        **kwargs,
     ):
         """read parquet file from one of the supported locations and return dataframe
 

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -1,5 +1,5 @@
 from airflow.configuration import conf
-from astro.constants import DEFAULT_SCHEMA
+from astro.constants import DEFAULT_COLUMN_CAPITALIZATION, DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
 POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback=SCHEMA)
@@ -40,4 +40,9 @@ RAW_SQL_MAX_RESPONSE_SIZE = conf.getint(
 # Should Astro SDK automatically add inlets/outlets to take advantage of Airflow 2.4 Data-aware scheduling
 AUTO_ADD_INLETS_OUTLETS = conf.getboolean(
     "astro_sdk", "auto_add_inlets_outlets", fallback=True
+)
+
+
+COLUMN_CAPITALIZATION = conf.get(
+    "astro_sdk", "column_capitalization", fallback=DEFAULT_COLUMN_CAPITALIZATION
 )

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -43,4 +43,6 @@ AUTO_ADD_INLETS_OUTLETS = conf.getboolean(
 )
 
 
-COLUMN_CAPITALIZATION = conf.get("astro_sdk", "column_capitalization", fallback="original")
+COLUMN_CAPITALIZATION = conf.get(
+    "astro_sdk", "column_capitalization", fallback="original"
+)

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -43,6 +43,4 @@ AUTO_ADD_INLETS_OUTLETS = conf.getboolean(
 )
 
 
-COLUMN_CAPITALIZATION = conf.get(
-    "astro_sdk", "column_capitalization", fallback=DEFAULT_COLUMN_CAPITALIZATION
-)
+COLUMN_CAPITALIZATION = conf.get("astro_sdk", "column_capitalization", fallback="original")

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -1,5 +1,5 @@
 from airflow.configuration import conf
-from astro.constants import DEFAULT_COLUMN_CAPITALIZATION, DEFAULT_SCHEMA
+from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
 POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback=SCHEMA)

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -13,9 +13,7 @@ except ImportError:
     from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
-from astro import settings
 from astro.constants import ColumnCapitalization
-from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
@@ -23,9 +21,13 @@ from astro.utils.dataframe import convert_columns_names_capitalization
 from astro.utils.table import find_first_table
 from astro.utils.typing_compat import Context
 
+from astro import settings
+from astro.databases import create_database
+
 
 def _get_dataframe(
-    table: BaseTable, columns_names_capitalization: ColumnCapitalization = "lower"
+    table: BaseTable,
+    columns_names_capitalization: ColumnCapitalization = settings.COLUMN_CAPITALIZATION,
 ) -> pd.DataFrame:
     """
     Exports records from a SQL table and converts it into a pandas dataframe
@@ -106,7 +108,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
         conn_id: str | None = None,
         database: str | None = None,
         schema: str | None = None,
-        columns_names_capitalization: ColumnCapitalization = "lower",
+        columns_names_capitalization: ColumnCapitalization = settings.COLUMN_CAPITALIZATION,
         **kwargs,
     ):
         self.conn_id: str = conn_id or ""
@@ -178,7 +180,7 @@ def dataframe(
     conn_id: str = "",
     database: str | None = None,
     schema: str | None = None,
-    columns_names_capitalization: ColumnCapitalization = "lower",
+    columns_names_capitalization: ColumnCapitalization = settings.COLUMN_CAPITALIZATION,
     **kwargs: Any,
 ) -> TaskDecorator:
     """

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -13,16 +13,15 @@ except ImportError:
     from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
+from astro import settings
 from astro.constants import ColumnCapitalization
+from astro.databases import create_database
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.dataframe import convert_columns_names_capitalization
 from astro.utils.table import find_first_table
 from astro.utils.typing_compat import Context
-
-from astro import settings
-from astro.databases import create_database
 
 
 def _get_dataframe(

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -5,15 +5,16 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
-from astro import settings
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
-from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
-from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
+
+from astro import settings
+from astro.databases import BaseDatabase, create_database
+from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 
 
 class LoadFileOperator(AstroSQLBaseOperator):
@@ -45,7 +46,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         ndjson_normalize_sep: str = "_",
         use_native_support: bool = True,
         native_support_kwargs: dict | None = None,
-        columns_names_capitalization: ColumnCapitalization = "original",
+        columns_names_capitalization: ColumnCapitalization = settings.COLUMN_CAPITALIZATION,
         enable_native_fallback: bool | None = True,
         **kwargs,
     ) -> None:
@@ -199,7 +200,7 @@ def load_file(
     ndjson_normalize_sep: str = "_",
     use_native_support: bool = True,
     native_support_kwargs: dict | None = None,
-    columns_names_capitalization: ColumnCapitalization = "original",
+    columns_names_capitalization: ColumnCapitalization = settings.COLUMN_CAPITALIZATION,
     enable_native_fallback: bool | None = True,
     **kwargs: Any,
 ) -> XComArg:

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -5,16 +5,15 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+from astro import settings
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
+from astro.databases import BaseDatabase, create_database
 from astro.exceptions import IllegalLoadToDatabaseException
+from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.typing_compat import Context
-
-from astro import settings
-from astro.databases import BaseDatabase, create_database
-from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 
 
 class LoadFileOperator(AstroSQLBaseOperator):

--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -1,16 +1,15 @@
 import pathlib
 
+import astro.sql as aql
 import pandas
 import pytest
 from airflow.models.xcom import XCom
 from airflow.utils import timezone
+from astro import settings
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
-from astro.sql.table import Table
-
-import astro.sql as aql
-from astro import settings
 from astro.files import File
+from astro.sql.table import Table
 from tests.sql.operators import utils as test_utils
 
 # Import Operator

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -77,7 +77,7 @@ def test_load_file_with_http_path_file(sample_dag, database_table_fixture):
     os.environ, {"AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE": "False"}
 )
 def test_unsafe_loading_of_dataframe(sample_dag):
-    from astro import settings
+    from astro import settings  # skipcq: PYL-W0404
 
     importlib.reload(settings)
 

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -19,17 +19,16 @@ import pytest
 from airflow.exceptions import BackfillUnfinished
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from astro import settings
+from astro import sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database, FileType
 from astro.exceptions import IllegalLoadToDatabaseException
+from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.operators.load_file import load_file
 from astro.sql.table import Metadata, Table
 from pandas.testing import assert_frame_equal
-
-from astro import settings
-from astro import sql as aql
-from astro.files import File
 from tests.sql.operators import utils as test_utils
 
 OUTPUT_TABLE_NAME = test_utils.get_table_name("load_file_test_table")


### PR DESCRIPTION
# Description
## What is the current behavior?
Users expressed confusion on why the column names for output tables are lowercased. It's due to this [default setting](https://github.com/astronomer/astro-sdk/blob/main/python-sdk/src/astro/sql/operators/dataframe.py#L110).


closes: #917


## What is the new behavior?
The default behavior should be to not change casing and it should be configureable with a global variable.

That way we can avoid hardcoding this setting into the Astro Build dagfile generator script.


## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
