### PR TITLE
CI: Fix typo in branches

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -7,7 +7,7 @@ on:
       - '.github/workflows/ci-python-sdk.yaml'
       - '*'
   pull_request:
-    branches: [ 'main', 'release-**', 'labeled' ]
+    branches: [ 'main', 'release-**' ]
     paths:
       - 'python-sdk/**'
       - '.github/workflows/ci-python-sdk.yaml'


### PR DESCRIPTION
I meant run the job when PR is labeled, not when we create a branch called "labeled" :)

