### PR TITLE
Fix flaky snowflake test

### DIFF
--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -157,22 +157,6 @@ def test_snowflake_create_table_using_native_schema_autodetection(
     response = database.run_sql(statement)
     rows = response.fetchall()
     assert len(rows) == 2
-    assert rows == [
-        (
-            "name",
-            "VARCHAR(16777216)",
-            "COLUMN",
-            "Y",
-            None,
-            "N",
-            "N",
-            None,
-            None,
-            None,
-            None,
-        ),
-        ("id", "NUMBER(38,0)", "COLUMN", "Y", None, "N", "N", None, None, None, None),
-    ]
     statement = f"SELECT COUNT(*) FROM {database.get_table_qualified_name(table)}"
     count = database.run_sql(statement).scalar()
     assert count == 0


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, the snowflake test for creating a table from a parquet file is failing every now and then due to inconsistent order of columns when reading the parquet file. Moreover we rely on the DESC TABLE output which we should not as we cannot control its output.

See recent failed test [here](https://github.com/astronomer/astro-sdk/actions/runs/3153878080/jobs/5130852629#step:11:370). Note that not only the order is different - also the _name_ type changes between `VARCHAR` and `VARCHAR(16777216)`.

## What is the new behavior?

We remove the assertion which is testing for specific DESC TABLE output.

Why?
1. According to the parquet-format spec, column order is not guaranteed to be consistent on read which means snowflake uses a random order.
2. We should not use the exact DESC TABLE snowflake output to compare as we cannot guarantee that it won't change.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
