### PR TITLE
Benchmarking script changes

### DIFF
--- a/.github/workflows/ci-benchmark.yaml
+++ b/.github/workflows/ci-benchmark.yaml
@@ -43,7 +43,7 @@ jobs:
       AIRFLOW_VAR_FOO: templated_file_name
       AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE: True
       FORCE_COLOR: "true"
-      ASTRO_PUBLISH_BENCHMARK_DATA: ${{ github.event_name == 'schedule' }}
+      ASTRO_PUBLISH_BENCHMARK_DATA: True
     steps:
       - uses: actions/checkout@v2
       - run: rm -f python-sdk/test-connections.yaml

--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -20,6 +20,18 @@
           "database": "postgres"
         }
       }
+    },
+    {
+      "kwargs": {
+        "enable_native_fallback": false
+      },
+      "name": "bigquery",
+      "params": {
+        "conn_id": "bigquery",
+        "metadata": {
+          "database": "bigquery"
+        }
+      }
     }
   ],
   "datasets": [
@@ -30,46 +42,6 @@
       "path": "gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.parquet",
       "rows": 160,
       "size": "10 KB"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "csv",
-      "name": "hundred_kb",
-      "path": "gs://astro-sdk/benchmark/trimmed/tate_britain/artist_data_100kb.csv",
-      "rows": 748,
-      "size": "100 KB"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "csv",
-      "name": "ten_mb",
-      "path": "gs://astro-sdk/benchmark/trimmed/imdb/title_ratings_10mb.csv",
-      "rows": 600000,
-      "size": "10M"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "ndjson",
-      "name": "one_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/stackoverflow/stackoverflow_posts_1g.ndjson",
-      "rows": 940000,
-      "size": "1G"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "ndjson",
-      "name": "five_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/pypi/",
-      "rows": 7530243,
-      "size": "5G"
-    },
-    {
-      "conn_id": "bigquery",
-      "file_type": "ndjson",
-      "name": "ten_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/github/github-archive/",
-      "rows": 1263685,
-      "size": "10G"
     }
   ]
 }

--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -20,18 +20,6 @@
           "database": "postgres"
         }
       }
-    },
-    {
-      "kwargs": {
-        "enable_native_fallback": false
-      },
-      "name": "bigquery",
-      "output_table": {
-        "conn_id": "bigquery",
-        "metadata": {
-          "database": "bigquery"
-        }
-      }
     }
   ],
   "datasets": [
@@ -42,6 +30,46 @@
       "path": "gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.parquet",
       "rows": 160,
       "size": "10 KB"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "csv",
+      "name": "hundred_kb",
+      "path": "gs://astro-sdk/benchmark/trimmed/tate_britain/artist_data_100kb.csv",
+      "rows": 748,
+      "size": "100 KB"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "csv",
+      "name": "ten_mb",
+      "path": "gs://astro-sdk/benchmark/trimmed/imdb/title_ratings_10mb.csv",
+      "rows": 600000,
+      "size": "10M"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "ndjson",
+      "name": "one_gb",
+      "path": "gs://astro-sdk/benchmark/trimmed/stackoverflow/stackoverflow_posts_1g.ndjson",
+      "rows": 940000,
+      "size": "1G"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "ndjson",
+      "name": "five_gb",
+      "path": "gs://astro-sdk/benchmark/trimmed/pypi/",
+      "rows": 7530243,
+      "size": "5G"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "ndjson",
+      "name": "ten_gb",
+      "path": "gs://astro-sdk/benchmark/trimmed/github/github-archive/",
+      "rows": 1263685,
+      "size": "10G"
     }
   ]
 }

--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -26,7 +26,7 @@
         "enable_native_fallback": false
       },
       "name": "bigquery",
-      "params": {
+      "output_table": {
         "conn_id": "bigquery",
         "metadata": {
           "database": "bigquery"

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -4,11 +4,10 @@ from datetime import datetime
 from pathlib import Path
 
 from airflow import DAG
-from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.sql.table import Metadata, Table
-
 from astro import sql as aql
+from astro.constants import DEFAULT_CHUNK_SIZE, FileType
 from astro.files import File
+from astro.sql.table import Metadata, Table
 
 START_DATE = datetime(2000, 1, 1)
 

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -5,11 +5,10 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from airflow import DAG
-from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.sql.table import Metadata, Table
-
 from astro import sql as aql
+from astro.constants import DEFAULT_CHUNK_SIZE, FileType
 from astro.files import File
+from astro.sql.table import Metadata, Table
 
 START_DATE = datetime(2000, 1, 1)
 

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -2,12 +2,14 @@ import json
 import os
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 from airflow import DAG
-from astro import sql as aql
 from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.files import File
 from astro.sql.table import Metadata, Table
+
+from astro import sql as aql
+from astro.files import File
 
 START_DATE = datetime(2000, 1, 1)
 
@@ -35,14 +37,24 @@ def count_columns(input_table: Table):
     """
 
 
+def get_location(path):
+    scheme = urlparse(path).scheme
+    if scheme == "":
+        return "local"
+    return scheme
+
+
 def create_dag(database_name, table_args, dataset, kwargs):
     dataset_name = dataset["name"]
     dataset_path = dataset["path"]
     dataset_conn_id = dataset.get("conn_id")
     dataset_filetype = dataset.get("file_type")
+    location = get_location(dataset_path)
     # dataset_rows = dataset["rows"]
 
-    dag_name = f"load_file_{dataset_name}_{dataset_filetype}_into_{database_name}"
+    dag_name = (
+        f"load_file_{dataset_name}_{dataset_filetype}_{location}_into_{database_name}"
+    )
 
     with DAG(dag_name, schedule_interval=None, start_date=START_DATE) as dag:
         chunk_size = int(os.getenv("ASTRO_CHUNK_SIZE", str(DEFAULT_CHUNK_SIZE)))

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -4,10 +4,11 @@ from datetime import datetime
 from pathlib import Path
 
 from airflow import DAG
-from astro import sql as aql
 from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.files import File
 from astro.sql.table import Metadata, Table
+
+from astro import sql as aql
+from astro.files import File
 
 START_DATE = datetime(2000, 1, 1)
 
@@ -42,7 +43,7 @@ def create_dag(database_name, table_args, dataset, kwargs):
     dataset_filetype = dataset.get("file_type")
     # dataset_rows = dataset["rows"]
 
-    dag_name = f"load_file_{dataset_name}_into_{database_name}"
+    dag_name = f"load_file_{dataset_name}_{dataset_filetype}_into_{database_name}"
 
     with DAG(dag_name, schedule_interval=None, start_date=START_DATE) as dag:
         chunk_size = int(os.getenv("ASTRO_CHUNK_SIZE", str(DEFAULT_CHUNK_SIZE)))

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -12,8 +12,9 @@ from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
-from astro.databases import create_database
 from astro.sql.table import Metadata, Table
+
+from astro.databases import create_database
 
 
 def get_disk_usage():
@@ -40,7 +41,9 @@ def export_profile_data_to_bq(profile_data: dict, conn_id: str = "bigquery"):
         name=benchmark_settings.publish_benchmarks_table,
         metadata=Metadata(schema=benchmark_settings.publish_benchmarks_schema),
     )
-    db.load_pandas_dataframe_to_table(df, table, if_exists="append")
+    print("table : ", table)
+    print("df :", df)
+    db.load_pandas_dataframe_to_table(df, table, if_exists="replace")
 
 
 @provide_session

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -41,7 +41,7 @@ def export_profile_data_to_bq(profile_data: dict, conn_id: str = "bigquery"):
         name=benchmark_settings.publish_benchmarks_table,
         metadata=Metadata(schema=benchmark_settings.publish_benchmarks_schema),
     )
-    db.load_pandas_dataframe_to_table(df, table, if_exists="replace")
+    db.load_pandas_dataframe_to_table(df, table, if_exists="append")
 
 
 @provide_session

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -13,8 +13,9 @@ from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
-from astro.databases import create_database
 from astro.sql.table import Metadata, Table
+
+from astro.databases import create_database
 
 
 def get_disk_usage():
@@ -41,7 +42,7 @@ def export_profile_data_to_bq(profile_data: dict, conn_id: str = "bigquery"):
         name=benchmark_settings.publish_benchmarks_table,
         metadata=Metadata(schema=benchmark_settings.publish_benchmarks_schema),
     )
-    db.load_pandas_dataframe_to_table(df, table, if_exists="append")
+    db.load_pandas_dataframe_to_table(df, table, if_exists="replace")
 
 
 @provide_session

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -12,9 +12,8 @@ from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
-from astro.sql.table import Metadata, Table
-
 from astro.databases import create_database
+from astro.sql.table import Metadata, Table
 
 
 def get_disk_usage():

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -13,9 +13,8 @@ from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
-from astro.sql.table import Metadata, Table
-
 from astro.databases import create_database
+from astro.sql.table import Metadata, Table
 
 
 def get_disk_usage():

--- a/python-sdk/tests/benchmark/run.sh
+++ b/python-sdk/tests/benchmark/run.sh
@@ -79,7 +79,7 @@ echo - Output: $(get_abs_filename $results_file)
           set +e  # allow us to see the content of $results_file regardless of the run being successful or not
           ASTRO_CHUNKSIZE=$chunk_size python3 -W ignore $runner_path --dataset="$dataset_name" --database="$database" --filetype="$dataset_type" --path="$dataset_path" --revision $git_revision --chunk-size=$chunk_size 1>> $results_file
           cat $results_file
-#          set -e  # do not allow errors from here onwards
+          set -e  # do not allow errors from here onwards
           if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
             echo "$GOOGLE_APPLICATION_CREDENTIALS is not defined"
           else

--- a/python-sdk/tests/benchmark/run.sh
+++ b/python-sdk/tests/benchmark/run.sh
@@ -79,7 +79,7 @@ echo - Output: $(get_abs_filename $results_file)
           set +e  # allow us to see the content of $results_file regardless of the run being successful or not
           ASTRO_CHUNKSIZE=$chunk_size python3 -W ignore $runner_path --dataset="$dataset_name" --database="$database" --filetype="$dataset_type" --path="$dataset_path" --revision $git_revision --chunk-size=$chunk_size 1>> $results_file
           cat $results_file
-          set -e  # do not allow errors from here onwards
+#          set -e  # do not allow errors from here onwards
           if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
             echo "$GOOGLE_APPLICATION_CREDENTIALS is not defined"
           else

--- a/python-sdk/tests/benchmark/run.sh
+++ b/python-sdk/tests/benchmark/run.sh
@@ -70,20 +70,22 @@ echo - Output: $(get_abs_filename $results_file)
 
   for i in {1..$(($2))}; do
     jq -r '.databases[] | [.name] | @tsv' $config_path | while IFS=$'\t' read -r database; do
-      jq -r '.datasets[] | [.name] | @tsv' $config_path | while IFS=$'\t' read -r dataset; do
+      jq -r '.datasets[] | [.name, .file_type, .path] | @tsv' $config_path | while IFS=$'\t' read -r dataset; do
         for chunk_size in "${chunk_sizes_array[@]}"; do
+          dataset_name=$(echo $dataset | cut -d " " -f1)
+          dataset_type=$(echo $dataset | cut -d " " -f2)
+          dataset_path=$(echo $dataset | cut -d " " -f3)
           echo "$i $dataset $database $chunk_size"
           set +e  # allow us to see the content of $results_file regardless of the run being successful or not
-          ASTRO_CHUNKSIZE=$chunk_size python3 -W ignore $runner_path --dataset="$dataset" --database="$database" --revision $git_revision --chunk-size=$chunk_size 1>> $results_file
+          ASTRO_CHUNKSIZE=$chunk_size python3 -W ignore $runner_path --dataset="$dataset_name" --database="$database" --filetype="$dataset_type" --path="$dataset_path" --revision $git_revision --chunk-size=$chunk_size 1>> $results_file
           cat $results_file
           set -e  # do not allow errors from here onwards
           if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
-        echo "$GOOGLE_APPLICATION_CREDENTIALS is not defined"
-      else
-        echo "$GOOGLE_APPLICATION_CREDENTIALS is defined"
-            gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
-      fi
-
+            echo "$GOOGLE_APPLICATION_CREDENTIALS is not defined"
+          else
+            echo "$GOOGLE_APPLICATION_CREDENTIALS is defined"
+                gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+          fi
           gsutil cp $results_file gs://${GCP_BUCKET}/benchmark/results/
           if command -v peekprof &> /dev/null; then
              # https://github.com/exapsy/peekprof

--- a/python-sdk/tests/benchmark/settings.py
+++ b/python-sdk/tests/benchmark/settings.py
@@ -6,7 +6,7 @@ publish_benchmarks_db_conn_id = os.getenv(
 )
 publish_benchmarks_schema = os.getenv("ASTRO_PUBLISH_BENCHMARK_SCHEMA", "benchmark")
 publish_benchmarks_table = os.getenv(
-    "ASTRO_PUBLISH_BENCHMARK_TABLE", "load_files_to_database"
+    "ASTRO_PUBLISH_BENCHMARK_TABLE", "load_files_to_databaseV2"
 )
 publish_benchmarks_table_grouping_col = os.getenv(
     "ASTRO_PUBLISH_BENCHMARK_GROUPING_COL", "revision"


### PR DESCRIPTION
# Description
## What is the current behavior?
Since we added filetype dimension to benchmarking there are few changes required to reflect the profiling data better

related: #972

## What is the new behavior?
1. Added a dataset path, type, name in the profiling data.
2. Created a new table to store updated schmea
3. Modified dag_id to contain filetype

## Does this introduce a breaking change?
Nope