### PR TITLE
Add kwargs space in config for database/dataset combo

### DIFF
--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -4,96 +4,30 @@
       "kwargs": {
         "enable_native_fallback": false
       },
-      "name": "snowflake",
+      "name": "bigquery",
       "output_table": {
-        "conn_id": "snowflake_conn"
-      }
-    },
-    {
-      "kwargs": {
-        "enable_native_fallback": false
-      },
-      "name": "postgres",
-      "output_table": {
-        "conn_id": "postgres_benchmark_conn",
+        "conn_id": "bigquery",
         "metadata": {
-          "database": "postgres"
+          "database": "bigquery"
         }
       }
     }
   ],
   "datasets": [
     {
-      "conn_id": "bigquery",
+      "conn_id": "aws_conn",
       "database_kwargs": {
-        "postgres": {},
-        "snowflake": {}
+        "bigquery": {
+          "native_support_kwargs": {
+            "skip_leading_rows": "1"
+          }
+        }
       },
-      "file_type": "parquet",
+      "file_type": "csv",
       "name": "ten_kb",
-      "path": "gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.parquet",
+      "path": "s3://astro-sdk/benchmark/synthetic-dataset/csv/ten_kb.csv",
       "rows": 160,
       "size": "10 KB"
-    },
-    {
-      "conn_id": "bigquery",
-      "database_kwargs": {
-        "postgres": {},
-        "snowflake": {}
-      },
-      "file_type": "csv",
-      "name": "hundred_kb",
-      "path": "gs://astro-sdk/benchmark/trimmed/tate_britain/artist_data_100kb.csv",
-      "rows": 748,
-      "size": "100 KB"
-    },
-    {
-      "conn_id": "bigquery",
-      "database_kwargs": {
-        "postgres": {},
-        "snowflake": {}
-      },
-      "file_type": "csv",
-      "name": "ten_mb",
-      "path": "gs://astro-sdk/benchmark/trimmed/imdb/title_ratings_10mb.csv",
-      "rows": 600000,
-      "size": "10M"
-    },
-    {
-      "conn_id": "bigquery",
-      "database_kwargs": {
-        "postgres": {},
-        "snowflake": {}
-      },
-      "file_type": "ndjson",
-      "name": "one_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/stackoverflow/stackoverflow_posts_1g.ndjson",
-      "rows": 940000,
-      "size": "1G"
-    },
-    {
-      "conn_id": "bigquery",
-      "database_kwargs": {
-        "postgres": {},
-        "snowflake": {}
-      },
-      "file_type": "ndjson",
-      "name": "five_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/pypi/",
-      "rows": 7530243,
-      "size": "5G"
-    },
-    {
-      "conn_id": "bigquery",
-      "database_kwargs": {
-        "postgres": {},
-        "snowflake": {}
-      },
-      "file_type": "ndjson",
-      "name": "ten_gb",
-      "path": "gs://astro-sdk/benchmark/trimmed/github/github-archive/",
-      "rows": 1263685,
-      "size": "10G"
     }
   ]
 }

--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -4,30 +4,72 @@
       "kwargs": {
         "enable_native_fallback": false
       },
-      "name": "bigquery",
+      "name": "snowflake",
       "output_table": {
-        "conn_id": "bigquery",
+        "conn_id": "snowflake_conn"
+      }
+    },
+    {
+      "kwargs": {
+        "enable_native_fallback": false
+      },
+      "name": "postgres",
+      "output_table": {
+        "conn_id": "postgres_benchmark_conn",
         "metadata": {
-          "database": "bigquery"
+          "database": "postgres"
         }
       }
     }
   ],
   "datasets": [
     {
-      "conn_id": "aws_conn",
-      "database_kwargs": {
-        "bigquery": {
-          "native_support_kwargs": {
-            "skip_leading_rows": "1"
-          }
-        }
-      },
-      "file_type": "csv",
+      "conn_id": "bigquery",
+      "file_type": "parquet",
       "name": "ten_kb",
-      "path": "s3://astro-sdk/benchmark/synthetic-dataset/csv/ten_kb.csv",
+      "path": "gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.parquet",
       "rows": 160,
       "size": "10 KB"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "csv",
+      "name": "hundred_kb",
+      "path": "gs://astro-sdk/benchmark/trimmed/tate_britain/artist_data_100kb.csv",
+      "rows": 748,
+      "size": "100 KB"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "csv",
+      "name": "ten_mb",
+      "path": "gs://astro-sdk/benchmark/trimmed/imdb/title_ratings_10mb.csv",
+      "rows": 600000,
+      "size": "10M"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "ndjson",
+      "name": "one_gb",
+      "path": "gs://astro-sdk/benchmark/trimmed/stackoverflow/stackoverflow_posts_1g.ndjson",
+      "rows": 940000,
+      "size": "1G"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "ndjson",
+      "name": "five_gb",
+      "path": "gs://astro-sdk/benchmark/trimmed/pypi/",
+      "rows": 7530243,
+      "size": "5G"
+    },
+    {
+      "conn_id": "bigquery",
+      "file_type": "ndjson",
+      "name": "ten_gb",
+      "path": "gs://astro-sdk/benchmark/trimmed/github/github-archive/",
+      "rows": 1263685,
+      "size": "10G"
     }
   ]
 }

--- a/python-sdk/tests/benchmark/config.json
+++ b/python-sdk/tests/benchmark/config.json
@@ -25,6 +25,10 @@
   "datasets": [
     {
       "conn_id": "bigquery",
+      "database_kwargs": {
+        "postgres": {},
+        "snowflake": {}
+      },
       "file_type": "parquet",
       "name": "ten_kb",
       "path": "gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.parquet",
@@ -33,6 +37,10 @@
     },
     {
       "conn_id": "bigquery",
+      "database_kwargs": {
+        "postgres": {},
+        "snowflake": {}
+      },
       "file_type": "csv",
       "name": "hundred_kb",
       "path": "gs://astro-sdk/benchmark/trimmed/tate_britain/artist_data_100kb.csv",
@@ -41,6 +49,10 @@
     },
     {
       "conn_id": "bigquery",
+      "database_kwargs": {
+        "postgres": {},
+        "snowflake": {}
+      },
       "file_type": "csv",
       "name": "ten_mb",
       "path": "gs://astro-sdk/benchmark/trimmed/imdb/title_ratings_10mb.csv",
@@ -49,6 +61,10 @@
     },
     {
       "conn_id": "bigquery",
+      "database_kwargs": {
+        "postgres": {},
+        "snowflake": {}
+      },
       "file_type": "ndjson",
       "name": "one_gb",
       "path": "gs://astro-sdk/benchmark/trimmed/stackoverflow/stackoverflow_posts_1g.ndjson",
@@ -57,6 +73,10 @@
     },
     {
       "conn_id": "bigquery",
+      "database_kwargs": {
+        "postgres": {},
+        "snowflake": {}
+      },
       "file_type": "ndjson",
       "name": "five_gb",
       "path": "gs://astro-sdk/benchmark/trimmed/pypi/",
@@ -65,6 +85,10 @@
     },
     {
       "conn_id": "bigquery",
+      "database_kwargs": {
+        "postgres": {},
+        "snowflake": {}
+      },
       "file_type": "ndjson",
       "name": "ten_gb",
       "path": "gs://astro-sdk/benchmark/trimmed/github/github-archive/",

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -4,10 +4,11 @@ from datetime import datetime
 from pathlib import Path
 
 from airflow import DAG
-from astro import sql as aql
 from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.files import File
 from astro.sql.table import Metadata, Table
+
+from astro import sql as aql
+from astro.files import File
 
 START_DATE = datetime(2000, 1, 1)
 
@@ -35,12 +36,14 @@ def count_columns(input_table: Table):
     """
 
 
-def create_dag(database_name, table_args, dataset, kwargs):
+def create_dag(database_name, table_args, dataset, global_db_kwargs):
     dataset_name = dataset["name"]
     dataset_path = dataset["path"]
     dataset_conn_id = dataset.get("conn_id")
     dataset_filetype = dataset.get("file_type")
     # dataset_rows = dataset["rows"]
+    dataset_databases_kwargs = dataset.get("database_kwargs", {})
+    local_db_kwargs = dataset_databases_kwargs.get(database_name, {})
 
     dag_name = f"load_file_{dataset_name}_into_{database_name}"
 
@@ -62,9 +65,74 @@ def create_dag(database_name, table_args, dataset, kwargs):
             "output_table": table,
             "chunk_size": chunk_size,
         }
-        # Override params from config
-        params.update(kwargs)
 
+        # Override params from config
+        # example config:
+        # {
+        #     "databases": [
+        #         {
+        #             "kwargs": {                            # global config bigquery db
+        #                 "enable_native_fallback": false
+        #             },
+        #             "name": "biquery",
+        #             "output_table": {
+        #                 "conn_id": "biquery"
+        #             }
+        #         },{
+        #              "kwargs": {                          # global config for redshift db
+        #                   "enable_native_fallback": false
+        #               },
+        #               "name": "redshift",
+        #               "output_table": {
+        #                   "conn_id": "redshift"
+        #               }
+        #         }],
+        #       "datasets": [
+        #             {
+        #                 "conn_id": "aws",
+        #                 "file_type": "parquet",
+        #                 "name": "ten_kb",
+        #                 "path": "s3://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.csv",
+        #                 "rows": 160,
+        #                 "size": "10 KB",
+        #                 "database_kwargs" : {
+        #                      "biquery": {                           # local config for bigquery db
+        #                          native_support_kwargs: {"skip_leading_rows": 1}
+        #                      },
+        #                      "redshift": {                          # local config for redshift db
+        #                            native_support_kwargs:{
+        #                               "IGNOREHEADER": 1,
+        #                               "REGION": "us-west-2",
+        #                               "IAM_ROLE": "REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN",
+        #                             }
+        #                      }
+        #                  }
+        #             }]
+        # }
+        #
+        # Final config for load_file()
+        #     1. Redshift
+        #         {
+        #             native_support_kwargs: {
+        #                 "IGNOREHEADER": 1,
+        #                 "REGION": "us-west-2",
+        #                 "IAM_ROLE": REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN".
+        #             },
+        #             "enable_native_fallback": false
+        #         }
+        #     2.  Bigquery
+        #         {
+        #             native_support_kwargs: {
+        #                 "skip_leading_rows": 1,
+        #             },
+        #             "enable_native_fallback": false
+        #         }
+        # Note - If there is a config present in both local and global config.
+        # Local config will override the global one.
+
+        params.update(global_db_kwargs)
+        params.update(local_db_kwargs)
+        print("params: ", params)
         my_table = aql.load_file(**params)
         aql.cleanup([my_table])
 
@@ -83,9 +151,9 @@ config = load_config()
 for database in config["databases"]:
     database_name = database["name"]
     table_args = database["output_table"]
-    kwargs = database["kwargs"]
+    global_db_kwargs = database["kwargs"]
     for dataset in config["datasets"]:
         table_args_copy = table_args.copy()
 
-        dag = create_dag(database_name, table_args_copy, dataset, kwargs)
+        dag = create_dag(database_name, table_args_copy, dataset, global_db_kwargs)
         globals()[dag.dag_id] = dag

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -4,11 +4,10 @@ from datetime import datetime
 from pathlib import Path
 
 from airflow import DAG
-from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.sql.table import Metadata, Table
-
 from astro import sql as aql
+from astro.constants import DEFAULT_CHUNK_SIZE, FileType
 from astro.files import File
+from astro.sql.table import Metadata, Table
 
 START_DATE = datetime(2000, 1, 1)
 

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -5,10 +5,11 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from airflow import DAG
-from astro import sql as aql
 from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.files import File
 from astro.sql.table import Metadata, Table
+
+from astro import sql as aql
+from astro.files import File
 
 START_DATE = datetime(2000, 1, 1)
 
@@ -44,6 +45,73 @@ def get_location(path):
 
 
 def create_dag(database_name, table_args, dataset, global_db_kwargs):
+    """
+    Create dag dynamically
+
+    Override params from config
+    example config:
+    {
+        "databases": [
+            {
+                "kwargs": {                            # global config bigquery db
+                    "enable_native_fallback": false
+                },
+                "name": "biquery",
+                "output_table": {
+                    "conn_id": "biquery"
+                }
+            },{
+                 "kwargs": {                          # global config for redshift db
+                      "enable_native_fallback": false
+                  },
+                  "name": "redshift",
+                  "output_table": {
+                      "conn_id": "redshift"
+                  }
+            }],
+          "datasets": [
+                {
+                    "conn_id": "aws",
+                    "file_type": "parquet",
+                    "name": "ten_kb",
+                    "path": "s3://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.csv",
+                    "rows": 160,
+                    "size": "10 KB",
+                    "database_kwargs" : {
+                         "biquery": {                           # local config for bigquery db
+                             native_support_kwargs: {"skip_leading_rows": 1}
+                         },
+                         "redshift": {                          # local config for redshift db
+                               native_support_kwargs:{
+                                  "IGNOREHEADER": 1,
+                                  "REGION": "us-west-2",
+                                  "IAM_ROLE": "REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN",
+                                }
+                         }
+                     }
+                }]
+    }
+
+    Final config for load_file()
+        1. Redshift
+            {
+                native_support_kwargs: {
+                    "IGNOREHEADER": 1,
+                    "REGION": "us-west-2",
+                    "IAM_ROLE": REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN".
+                },
+                "enable_native_fallback": false
+            }
+        2.  Bigquery
+            {
+                native_support_kwargs: {
+                    "skip_leading_rows": 1,
+                },
+                "enable_native_fallback": false
+            }
+    Note - If there is a config present in both local and global config.
+    Local config will override the global one."""
+
     dataset_name = dataset["name"]
     dataset_path = dataset["path"]
     dataset_conn_id = dataset.get("conn_id")
@@ -76,73 +144,8 @@ def create_dag(database_name, table_args, dataset, global_db_kwargs):
             "chunk_size": chunk_size,
         }
 
-        # Override params from config
-        # example config:
-        # {
-        #     "databases": [
-        #         {
-        #             "kwargs": {                            # global config bigquery db
-        #                 "enable_native_fallback": false
-        #             },
-        #             "name": "biquery",
-        #             "output_table": {
-        #                 "conn_id": "biquery"
-        #             }
-        #         },{
-        #              "kwargs": {                          # global config for redshift db
-        #                   "enable_native_fallback": false
-        #               },
-        #               "name": "redshift",
-        #               "output_table": {
-        #                   "conn_id": "redshift"
-        #               }
-        #         }],
-        #       "datasets": [
-        #             {
-        #                 "conn_id": "aws",
-        #                 "file_type": "parquet",
-        #                 "name": "ten_kb",
-        #                 "path": "s3://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.csv",
-        #                 "rows": 160,
-        #                 "size": "10 KB",
-        #                 "database_kwargs" : {
-        #                      "biquery": {                           # local config for bigquery db
-        #                          native_support_kwargs: {"skip_leading_rows": 1}
-        #                      },
-        #                      "redshift": {                          # local config for redshift db
-        #                            native_support_kwargs:{
-        #                               "IGNOREHEADER": 1,
-        #                               "REGION": "us-west-2",
-        #                               "IAM_ROLE": "REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN",
-        #                             }
-        #                      }
-        #                  }
-        #             }]
-        # }
-        #
-        # Final config for load_file()
-        #     1. Redshift
-        #         {
-        #             native_support_kwargs: {
-        #                 "IGNOREHEADER": 1,
-        #                 "REGION": "us-west-2",
-        #                 "IAM_ROLE": REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN".
-        #             },
-        #             "enable_native_fallback": false
-        #         }
-        #     2.  Bigquery
-        #         {
-        #             native_support_kwargs: {
-        #                 "skip_leading_rows": 1,
-        #             },
-        #             "enable_native_fallback": false
-        #         }
-        # Note - If there is a config present in both local and global config.
-        # Local config will override the global one.
-
         params.update(global_db_kwargs)
         params.update(local_db_kwargs)
-        print("params: ", params)
         my_table = aql.load_file(**params)
         aql.cleanup([my_table])
 

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -5,11 +5,10 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from airflow import DAG
-from astro.constants import DEFAULT_CHUNK_SIZE, FileType
-from astro.sql.table import Metadata, Table
-
 from astro import sql as aql
+from astro.constants import DEFAULT_CHUNK_SIZE, FileType
 from astro.files import File
+from astro.sql.table import Metadata, Table
 
 START_DATE = datetime(2000, 1, 1)
 


### PR DESCRIPTION
# Description
## What is the current behavior?
We need a space where we can pass the kwargs specif to a database/dataset combination:
if we have a dataset:
`s3://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.csv`

We need different kwargs passed to native method for different db
1. Redshift
```
{
         native_support_kwargs: {
            "IGNOREHEADER": 1,
             "REGION": "us-west-2",
             "IAM_ROLE": REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN".
         },
         "enable_native_fallback": false
    }
```

2. Bigquery

```
{
       native_support_kwargs: {
             "skip_leading_rows": 1,
       },
      "enable_native_fallback": false
}
```
related: #972

## What is the new behavior?
Added a field in config to have this db/dataset-specific config.

## Does this introduce a breaking change?
Nope