### PR TITLE
Fix the dataset generation scripts to run for all databases

### DIFF
--- a/python-sdk/tests/benchmark/synthetic_csv_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_csv_generator.py
@@ -8,7 +8,6 @@ from faker import Faker
 
 
 def generate_data(row_size, file_name):
-    row_size = 11000000
 
     faked_obj: object = Faker("en_GB")
 
@@ -20,7 +19,7 @@ def generate_data(row_size, file_name):
             (
                 i + 1,
                 faked_obj.name(),
-                faked_obj.address(),
+                str(faked_obj.address()).replace("\n", " "),
                 random.choice(["psg", "sona", "amirta", "anna university"]),
                 random.choice(["CTS", "INFY", "HTC"]),
                 (
@@ -34,4 +33,16 @@ def generate_data(row_size, file_name):
     file_obj.close()
 
 
-generate_data(11000000, "one_gb.csv")
+generate_data(125, "/fake_dataset/csv/ten_kb.csv")
+generate_data(1100, "/fake_dataset/csv/hundred_kb.csv")
+generate_data(107430, "/fake_dataset/csv/ten_mb.csv")
+generate_data(1074300, "/fake_dataset/csv/hundred_mb.csv")
+generate_data(11000000, "/fake_dataset/csv/one_gb.csv")
+generate_data(11000000 * 2, "/fake_dataset/csv/two_gb.csv")
+generate_data(11000000 * 5, "/fake_dataset/csv/five_gb.csv")
+generate_data(11000000 * 2, "/fake_dataset/csv/five_gb/second.csv")
+generate_data(11000000 * 2, "/fake_dataset/csv/five_gb/first.csv")
+generate_data(11000000, "/fake_dataset/csv/five_gb/third.csv")
+generate_data(11000000 * 2, "/fake_dataset/csv/ten_gb/second.csv")
+generate_data(11000000 * 2, "/fake_dataset/csv/ten_gb/first.csv")
+generate_data(11000000, "/fake_dataset/csv/ten_gb/third.csv")

--- a/python-sdk/tests/benchmark/synthetic_parquet_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_parquet_generator.py
@@ -7,57 +7,50 @@ from faker import Faker
 fake = Faker()
 
 
-def generate_data(file_name, records):
+def generate_data(file_name, start, end):
     # Declare an empty dictionary
-    customer = {}
+    customer = []
     # Iterate the loop based on the input value and generate fake data
-    for n in range(0, records):
-        customer[str(n)] = {}
-        customer[str(n)]["id"] = str(n)
-        customer[str(n)]["name"] = fake.name()
-        customer[str(n)]["address"] = fake.address()
-        customer[str(n)]["email"] = str(fake.email())
-        customer[str(n)]["phone"] = str(fake.phone_number())
+    for n in range(start, end):
+        cust = {}
+        cust["id"] = str(n)
+        cust["name"] = fake.name()
+        cust["address"] = fake.address()
+        cust["email"] = str(fake.email())
+        cust["phone"] = str(fake.phone_number())
+        customer.append(cust)
 
     df = pd.DataFrame(data=customer)
-    df.to_parquet(file_name)
+    print(df)
+
+    df.to_parquet(file_name, index=None)
 
     print(f"File {file_name} has been created.")
 
 
-# create ten_kb parquet file
-ten_kb = "/fake_dataset/parquet/ten_kb.parquet"
-ten_kb_rows = 13
-# generate_data(ten_kb,ten_kb_rows)
+five_gb = "/home/ankit_chaurasia/fake_dataset/parquet/five_gb.parquet"
+five_gb_rows = 8849701
+generate_data(five_gb, 0, five_gb_rows)
+#
 
-# create hundred_kb parquet file
-hundred_kb = "/fake_dataset/parquet/hundred_kb.parquet"
-hundred_kb_rows = 140
-# generate_data(hundred_kb,hundred_kb_rows)
+# create one_gb parquet file
+one_gb = "/home/ankit_chaurasia/fake_dataset/parquet/ten_gb/sixth.parquet"
+one_gb_rows = 9697180
+generate_data(one_gb, 8080983, one_gb_rows)
 
+# create ten gb parquet files
+one_gb = "/home/ankit_chaurasia/fake_dataset/parquet/ten_gb/seventh.parquet"
+one_gb_rows = 11313377
+generate_data(one_gb, 9697182, one_gb_rows)
 
-# create hundred_mb json file
-hundred_mb = "/fake_dataset/parquet/hundred_mb.parquet"
-hundred_mb_rows = 15295
-generate_data(hundred_mb, hundred_mb_rows)
+two_gb = "/home/ankit_chaurasia/fake_dataset/parquet/ten_gb/eighth.parquet"
+two_gb_rows = 12929574
+generate_data(two_gb, 11313379, two_gb_rows)
 
-# create ten_mb json file
-ten_mb = "/fake_dataset/parquet/ten_mb.parquet"
-ten_mb_rows = 14061
-generate_data(ten_mb, ten_mb_rows)
+two_gb = "/home/ankit_chaurasia/fake_dataset/parquet/ten_gb/ninth.parquet"
+two_gb_rows = 14545771
+generate_data(two_gb, 12929576, two_gb_rows)
 
-# create one_mb json file
-one_mb = "/fake_dataset/parquet/one_mb.parquet"
-one_mb_rows = 1506
-# generate_data(one_mb,one_mb_rows)
-
-
-# create one_gb json file
-one_gb = "/fake_dataset/parquet/one_gb.parquet"
-one_gb_rows = 1616194
-generate_data(one_gb, one_gb_rows)
-
-# create two_gb json file
-two_gb = "/fake_dataset/parquet/two_gb.parquet"
-two_gb_rows = 3312389
-generate_data(two_gb, two_gb_rows)
+two_gb = "/home/ankit_chaurasia/fake_dataset/parquet/ten_gb/tenth.parquet"
+two_gb_rows = 16161968
+generate_data(two_gb, 14545773, two_gb_rows)


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently the CSV and PARQUET files are failing for bigquery

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #977 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Make CSV file with each row in single line


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
