### PR TITLE
Fix documentation bold letter issue in load file

### DIFF
--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -53,6 +53,7 @@ Parameters to use when loading a file to a database table
 #. **columns_names_capitalization** - If you are working with a ``Snowflake`` database with :ref:`table_schema` and with ``if_exists=replace``, you can control whether the column names of the output table are capitalized. The default is to convert all column names to lowercase. Valid inputs are ``lower``, ``upper``, or ``original`` which will convert column names to lowercase.
 
 #. **ndjson_normalize_sep** - If your input file type is NDJSON, you can use this parameter to normalize the data to two dimensions. This makes the data suitable for loading into a table. This parameter is used as a delimiter for combining columns names if required.
+
     example:
         input JSON:
 
@@ -105,6 +106,7 @@ There are three ways to infer the schema of the table to be created, listed by p
 Parameters to use when loading a file to a Pandas dataframe
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #. **columns_names_capitalization**: Use to control the capitalization of column names in the generated dataframe. The default value is ``original``.
+
         *  **original** - Remains the same as the input file
         *  **upper** - Convert to uppercase
         *  **lower** - Convert to lowercase
@@ -121,6 +123,7 @@ Parameters for native transfer
 Refer to :ref:`load_file_working` for details on Native Path.
 
 #. **use_native_support**: Native transfer support is available for some file sources and databases. If it is available for your systems, the default is to use this support. To leverage native transfer support, certain settings may need to be modified on your destination database. If you do not wish to use native transfer support, you can turn off this behavior by specifying ``use_native_support=False``.
+
         This feature is enabled by default, to disable it refer to the example below.
 
         .. literalinclude:: ../../../../example_dags/example_load_file.py


### PR DESCRIPTION
# Description
look like sphinx expect a newline `**`.
Before
<img width="769" alt="Screenshot 2022-10-03 at 1 50 41 PM" src="https://user-images.githubusercontent.com/98807258/193535842-bc411ad1-3b36-4953-b4b4-654b69f83566.png">
now
<img width="745" alt="Screenshot 2022-10-03 at 2 12 50 PM" src="https://user-images.githubusercontent.com/98807258/193536226-534623a0-2a63-42ff-a631-b057e78442af.png">




## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
