### PR TITLE
Split larger files with page size more than 50 mb to multiple files

### DIFF
--- a/python-sdk/tests/benchmark/datasets.md
+++ b/python-sdk/tests/benchmark/datasets.md
@@ -91,9 +91,8 @@ The [script](synthetic_parquet_generator.py) is used to generate the Parquet fil
 | hundred_kb | 100 KB | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_kb.parquet |
 | ten_mb     | 10 MB  | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/ten_mb.parquet     |
 | hundred_mb | 100 MB | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_mb.parquet |
-| one_gb     | 1 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/one_gb.parquet     |
-| two_gb     | 2 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/two_gb.parquet     |
-| five_gb    | 2.8 GB | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb.parquet    |
+| one_gb     | 1 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/one_gb/            |
+| two_gb     | 2 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/two_gb/            |
 | five_gb    | 5 GB   | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb/           |
 | ten_gb     | 10 GB  | parquet    | gs://astro-sdk/benchmark/synthetic-dataset/parquet/ten_gb/            |
 
@@ -105,9 +104,8 @@ The [script](synthetic_parquet_generator.py) is used to generate the Parquet fil
 | hundred_kb | 100 KB | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_kb.parquet |
 | ten_mb     | 10 MB  | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/ten_mb.parquet     |
 | hundred_mb | 100 MB | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/hundred_mb.parquet |
-| one_gb     | 1 GB   | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/one_gb.parquet     |
-| two_gb     | 2 GB   | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/two_gb.parquet     |
-| five_gb    | 2.8 GB | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb.parquet    |
+| one_gb     | 1 GB   | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/one_gb/            |
+| two_gb     | 2 GB   | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/two_gb/            |
 | five_gb    | 5 GB   | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/five_gb/           |
 | ten_gb     | 10 GB  | parquet    | s3://astro-sdk/benchmark/synthetic-dataset/parquet/ten_gb/            |
 


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
When uploading a Parquet file with more than the range of 50 Mb of page size, loading larger records may lead to resourcesExceeded errors.
```
Resources exceeded during query execution: UDF out of memory.; Failed to read the Parquet file. This might happen if the file contains a row that is too large, or if the total size of the pages loaded for the queried columns is too large.
```

Parquet is a columnar data format, which means that loading data requires reading all columns. In [parquet](http://parquet.apache.org/documentation/latest/), columns are divided into pages. BigQuery keeps entire uncompressed pages for each column in memory while reading data from them. If the input file contains too many columns, BigQuery workers can hit Out of Memory errors.

Even when a precise [limit](https://cloud.google.com/bigquery/quotas#load_jobs) is not enforced as it happens with other formats, it is recommended that records should be in the range of 50 Mb, loading larger records may lead to resourcesExceeded errors.

[BigQuery documentation](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet#:~:text=To%20avoid%20resourcesExceeded%20errors%20when,*%201024%20*%201024%20bytes) mentions the following Input file requirements

To avoid resourcesExceeded errors when loading Parquet files into BigQuery, follow these guidelines:
- Keep record sizes to 50 MB or less. If your input data contains more than 100 columns, consider reducing the page size to - be smaller than the default page size (1 * 1024 * 1024 bytes). This is especially helpful if you are using significant compression.

Taking into account the above considerations, it would be great to clarify the following point with users facing this issue

1. What is the maximum size of rows in your Parquet file?
2. What is the maximum page size per column? 

If you think about increasing the allocated memory for queries, you need to read about [Bigquery slots](https://cloud.google.com/bigquery/docs/slots).

For synthetic dataset, it makes better sense to splitting the larger page size files into smaller files
<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #979 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Split the files into multiple files with each page size less than 50 Mb

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
