### PR TITLE
Use bigger machine for benchmarking

### DIFF
--- a/python-sdk/tests/benchmark/infrastructure/terraform/vars.tf
+++ b/python-sdk/tests/benchmark/infrastructure/terraform/vars.tf
@@ -25,5 +25,5 @@ variable "tfstate_bucket" {
 variable "gke_node_pool_machine_type" {
   type        = string
   description = "GCP machine type used for the GKE Node Pool"
-  default     = "n2-standard-4"  # 4 vCPU and 16GB RAM, more options at https://cloud.google.com/compute/vm-instance-pricing
+  default     = "n2-standard-8"  # 8 vCPU and 32GB RAM, more options at https://cloud.google.com/compute/vm-instance-pricing
 }


### PR DESCRIPTION
# Description
Currently, benchmarking jobs fail because of fewer resources so lets `n2-standard-8` instead of `n2-standard-4`

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
