### PR TITLE
Track the airflow operator error in benchmark

### DIFF
--- a/python-sdk/tests/benchmark/run.sh
+++ b/python-sdk/tests/benchmark/run.sh
@@ -92,7 +92,7 @@ error_log_files=()
             echo "$GOOGLE_APPLICATION_CREDENTIALS is defined"
                 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
           fi
-          gsutil cp $results_file gs://${GCP_BUCKET}/benchmark/results/
+          # gsutil cp $results_file gs://${GCP_BUCKET}/benchmark/results/
           if command -v peekprof &> /dev/null; then
              # https://github.com/exapsy/peekprof
              peekprof -html "/tmp/$dataset-$database-$chunk_size.html" -refresh 1000ms -pid $! > /tmp/$dataset-$database-$chunk_size.csv
@@ -104,15 +104,19 @@ error_log_files=()
 
 
 # print the error log file path and exit
-if [ $error_code -ne 0 ]; then
-  echo "Benchmark test completed with error."
-  echo "More logs are available at below location"
-  for error_log_file in "${error_log_files[@]}"
-  do
-    IFS='/' list=($error_log_file)
-    echo gs://"${GCP_BUCKET}"/benchmark/"${list[2]}"/
-  done
-  exit 1
-fi
+function check_error {
+  if [ $error_code -ne 0 ]; then
+    echo "Benchmark test completed with error."
+    echo "More logs are available at below location"
+    for error_log_file in "${error_log_files[@]}"
+    do
+      IFS='/' list=($error_log_file)
+      echo gs://"${GCP_BUCKET}"/benchmark/"${list[2]}"/
+    done
+    exit 1
+  fi
+}
+
+check_error
 
 echo Benchmark test completed!

--- a/python-sdk/tests/benchmark/wait_for_completion.sh
+++ b/python-sdk/tests/benchmark/wait_for_completion.sh
@@ -10,7 +10,7 @@ while [[ $complete_status -ne 0 ]] && [[ $failed_status -ne 0 ]]; do
   complete_status=$?
 done
 
-kubectl delete job benchmark-"${GIT_HASH}" -n benchmark
+# kubectl delete job benchmark-"${GIT_HASH}" -n benchmark
 
 if [ $failed_status -eq 0 ]; then
     echo "Job failed. Please check logs."


### PR DESCRIPTION
# Description
Keep track of the GCS result file if an error occurs on any run and at the end of execution print these error result file paths and exit with error code 1. Also changed while loop to for loop since pipe run the commands in the new process so it was difficult to update the global variable error_code to track the error.


## What is the current behavior?
The Benchmark job is green even if the operator has failed since we silently ignore the error and run of the next dataset and database. https://github.com/astronomer/astro-sdk/blob/main/python-sdk/tests/benchmark/run.sh#L79


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
CI will still run for all the databases and datasets but it will fail if the operator will fail and print the GCS log path in CI


## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
