### PR TITLE
Bump astro-runtime image to `6.0.2`

### DIFF
--- a/python-sdk/dev/Dockerfile
+++ b/python-sdk/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:6.0.0-base
+FROM quay.io/astronomer/astro-runtime:6.0.2-base
 
 USER root
 RUN apt-get update -y && apt-get install -y git


### PR DESCRIPTION
New runtime image was released few days back, we should use that
