### PR TITLE
Allow installing Python SDK without enabling pickling

### DIFF
--- a/python-sdk/src/astro/__init__.py
+++ b/python-sdk/src/astro/__init__.py
@@ -14,7 +14,6 @@ __version__ = "1.2.0.dev1"
 # astro.database, and this is what leads to the circular dependency.
 
 import astro.sql  # noqa: F401
-from airflow.configuration import conf
 
 
 # This is needed to allow Airflow to pick up specific metadata fields it needs
@@ -32,10 +31,3 @@ def get_provider_info() -> dict:
         "hook-class-names": [],
         "extra-links": [],
     }
-
-
-if not conf.getboolean(section="core", key="enable_xcom_pickling"):
-    raise OSError(
-        "AIRFLOW__CORE__ENABLE_XCOM_PICKLING environment variable needs to be set to True or enable_xcom_pickling=true "
-        "in airflow.cfg before importing astro-sdk-python."
-    )

--- a/python-sdk/tests/test_constants.py
+++ b/python-sdk/tests/test_constants.py
@@ -1,8 +1,3 @@
-import importlib
-import os
-from unittest import mock
-
-import pytest
 from astro.constants import (
     SUPPORTED_DATABASES,
     SUPPORTED_FILE_LOCATIONS,
@@ -23,19 +18,3 @@ def test_supported_file_types():
 def test_supported_databases():
     expected = ["bigquery", "postgres", "redshift", "snowflake", "sqlite"]
     assert sorted(SUPPORTED_DATABASES) == expected
-
-
-@mock.patch.dict(
-    os.environ, {"AIRFLOW__CORE__ENABLE_XCOM_PICKLING": "False"}, clear=True
-)
-def test_enable_xcom_pickling_set_false_in_env():
-    import astro
-
-    with pytest.raises(OSError) as exe_info:
-        importlib.reload(astro)
-
-    assert (
-        exe_info.value.args[0]
-        == "AIRFLOW__CORE__ENABLE_XCOM_PICKLING environment variable needs to be set to True or "
-        "enable_xcom_pickling=true in airflow.cfg before importing astro-sdk-python."
-    )


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Users can not even run Airflow if Astro SDK is installed but if they don't want to run it. For example, we can't install Astro SDK in the runtime image.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
This PR reverts https://github.com/astronomer/astro-sdk/pull/446 . Without this, users can not even run Airflow if Astro SDK is installed.

This will even allow users to use `File` and `Table` objects in `inlets` and `outlets` without using any operators or decorators.

This will also allow us to install SDK in Runtime image without impacting users who don't want to use SDK

The only caveat if users don't enable XCom pickling, the following error is raised but that is OK. We would like to get this in Astro SDK 1.2 (or 1.1.2) as we plan to tackle removal of pickling completely in https://github.com/astronomer/astro-sdk/issues/795:

```python
[2022-10-04, 23:09:10 UTC] {xcom.py:599} ERROR - Could not serialize the XCom value into JSON. If you are using pickle instead of JSON for XCom, then you need to enable pickle support for XCom in your *** config.
[2022-10-04, 23:09:10 UTC] {taskinstance.py:1851} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/airflow/utils/session.py", line 72, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 2378, in xcom_push
    XCom.set(
  File "/usr/local/lib/python3.9/site-packages/airflow/utils/session.py", line 72, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/models/xcom.py", line 206, in set
    value = cls.serialize_value(
  File "/usr/local/lib/python3.9/site-packages/airflow/models/xcom.py", line 597, in serialize_value
    return json.dumps(value).encode('UTF-8')
  File "/usr/local/lib/python3.9/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Table is not JSON serializable
```

This will allow users to use the following without pickling:

```python
import pendulum
from airflow import DAG, Dataset
from airflow.operators.bash import BashOperator

from astro.files.base import File
dag1_dataset = File(path="s3://dag1/output_1.txt")

with DAG(
    dag_id='dataset_produces_1',
    catchup=False,
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
    schedule='@daily',
    tags=['produces', 'dataset-scheduled'],
) as dag1:
    BashOperator(outlets=[dag1_dataset], task_id='producing_task_1', bash_command="sleep 5")

with DAG(
    dag_id='dataset_consumes_1',
    catchup=False,
    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
    schedule=[dag1_dataset],
    tags=['consumes', 'dataset-scheduled'],
) as dag3:
    # [END dag_dep]
    BashOperator(
        outlets=[Dataset('s3://consuming_1_task/dataset_other.txt')],
        task_id='consuming_1',
        bash_command="sleep 5",
    )
```

This works because of https://github.com/apache/airflow/commit/25a1a1b597ab20fa601a6b701f83ada02b6334a5 which we added in 2.4.0

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
