### PR TITLE
Fix tasks template to use transform_file

### DIFF
--- a/sql-cli/examples/_dags/advanced.py
+++ b/sql-cli/examples/_dags/advanced.py
@@ -6,11 +6,11 @@ from astro.sql.table import Table
 
 with DAG(
     dag_id="advanced",
-    start_date=timezone.parse("2022-10-04 14:21:33.434188"),
+    start_date=timezone.parse("2022-10-05 06:47:15.790544"),
     schedule_interval=None,
 ) as dag:
-    source__imdb_movies = aql.transform_sql(
-        sql="_target/advanced/source/imdb_movies.sql",
+    source__imdb_movies = aql.transform_file(
+        file_path="_target/advanced/source/imdb_movies.sql",
         parameters={
         },
         conn_id="postgres_conn",
@@ -21,8 +21,8 @@ with DAG(
         },
         task_id="source__imdb_movies",
     )
-    source__last_five_animations = aql.transform_sql(
-        sql="_target/advanced/source/last_five_animations.sql",
+    source__last_five_animations = aql.transform_file(
+        file_path="_target/advanced/source/last_five_animations.sql",
         parameters={
             "source__imdb_movies": source__imdb_movies,
         },
@@ -34,8 +34,8 @@ with DAG(
         },
         task_id="source__last_five_animations",
     )
-    source__top_five_animations = aql.transform_sql(
-        sql="_target/advanced/source/top_five_animations.sql",
+    source__top_five_animations = aql.transform_file(
+        file_path="_target/advanced/source/top_five_animations.sql",
         parameters={
             "source__imdb_movies": source__imdb_movies,
         },
@@ -46,8 +46,8 @@ with DAG(
         },
         task_id="source__top_five_animations",
     )
-    mart__union_top_and_last = aql.transform_sql(
-        sql="_target/advanced/mart/union_top_and_last.sql",
+    mart__union_top_and_last = aql.transform_file(
+        file_path="_target/advanced/mart/union_top_and_last.sql",
         parameters={
             "source__last_five_animations": source__last_five_animations,
             "source__top_five_animations": source__top_five_animations,

--- a/sql-cli/examples/_dags/simple.py
+++ b/sql-cli/examples/_dags/simple.py
@@ -6,11 +6,11 @@ from astro.sql.table import Table
 
 with DAG(
     dag_id="simple",
-    start_date=timezone.parse("2022-10-04 14:21:31.146165"),
+    start_date=timezone.parse("2022-10-05 06:47:20.684131"),
     schedule_interval=None,
 ) as dag:
-    imdb_movies = aql.transform_sql(
-        sql="_target/simple/imdb_movies.sql",
+    imdb_movies = aql.transform_file(
+        file_path="_target/simple/imdb_movies.sql",
         parameters={
         },
         conn_id="postgres_conn",
@@ -21,8 +21,8 @@ with DAG(
         },
         task_id="imdb_movies",
     )
-    last_five_animations = aql.transform_sql(
-        sql="_target/simple/last_five_animations.sql",
+    last_five_animations = aql.transform_file(
+        file_path="_target/simple/last_five_animations.sql",
         parameters={
             "imdb_movies": imdb_movies,
         },
@@ -33,8 +33,8 @@ with DAG(
         },
         task_id="last_five_animations",
     )
-    top_five_animations = aql.transform_sql(
-        sql="_target/simple/top_five_animations.sql",
+    top_five_animations = aql.transform_file(
+        file_path="_target/simple/top_five_animations.sql",
         parameters={
             "imdb_movies": imdb_movies,
         },
@@ -45,8 +45,8 @@ with DAG(
         },
         task_id="top_five_animations",
     )
-    union_top_and_last = aql.transform_sql(
-        sql="_target/simple/union_top_and_last.sql",
+    union_top_and_last = aql.transform_file(
+        file_path="_target/simple/union_top_and_last.sql",
         parameters={
             "last_five_animations": last_five_animations,
             "top_five_animations": top_five_animations,

--- a/sql-cli/src/sql_cli/macros/tasks.py.jinja2
+++ b/sql-cli/src/sql_cli/macros/tasks.py.jinja2
@@ -1,6 +1,6 @@
 {% macro define_task(sql_file, dag) -%}
-{{ sql_file.get_variable_name() }} = aql.transform_sql(
-    sql="{{ sql_file.get_relative_target_path() }}",
+{{ sql_file.get_variable_name() }} = aql.transform_file(
+    file_path="{{ sql_file.get_relative_target_path() }}",
     parameters={
         {%- for parameter in sql_file.get_parameters() %}
         {%- if dag.has_sql_file(parameter) %}


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, the tasks template creates `transform_sql` tasks, but we only have `transform_file`.

related: #836 

## What is the new behavior?

Fix references to `transform_sql` by replacing it with `transform_file`

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
