### PR TITLE
Read target machine architecture from env 

### DIFF
--- a/python-sdk/tests/benchmark/Makefile
+++ b/python-sdk/tests/benchmark/Makefile
@@ -5,7 +5,7 @@ GCP_PROJECT ?= astronomer-dag-authoring
 GIT_HASH = $(shell git log -1 --format=%h)
 APP ?= benchmark
 CONTAINER_REGISTRY=gcr.io/$(GCP_PROJECT)/$(APP)
-PLATFORM="linux/amd64"
+ASTRO_TARGET_PLATFORM ?= "linux/amd64"
 
 check_google_credentials:
 ifndef GOOGLE_APPLICATION_CREDENTIALS
@@ -36,14 +36,14 @@ run: clean
 container: clean check_google_credentials
 	@echo "Building and pushing container $(CONTAINER_REGISTRY)"
 	@gcloud auth configure-docker gcr.io
-	@docker build --platform=$(PLATFORM) --build-arg=GIT_HASH=$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) -f ./Dockerfile  ../../
+	@docker build --platform=$(ASTRO_TARGET_PLATFORM) --build-arg=GIT_HASH=$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) --tag=$(CONTAINER_REGISTRY):$(GIT_HASH) -f ./Dockerfile  ../../
 	@gcloud auth activate-service-account --key-file $(GOOGLE_APPLICATION_CREDENTIALS)
 	@docker push $(CONTAINER_REGISTRY):$(GIT_HASH)
 
 local: clean check_google_credentials
 	@echo "Building and pushing container $(CONTAINER_REGISTRY)"
 	@gcloud auth configure-docker gcr.io
-	@docker build -t benchmark -f ./Dockerfile ../../ --platform=$(PLATFORM) --build-arg=GIT_HASH=$(GIT_HASH)
+	@docker build -t benchmark -f ./Dockerfile ../../ --platform=$(ASTRO_TARGET_PLATFORM) --build-arg=GIT_HASH=$(GIT_HASH)
 	@mkdir -p /tmp/docker
 	@sudo chmod a+rwx /tmp/docker/
 	@docker run -it \


### PR DESCRIPTION
# Description
currently, the target platform for running the benchmark image is hardcoded


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
Read the target platform value to run benchmark image from env if env is not defined then build image for default target platform `linux/amd64`


## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
