### PR TITLE
Fix transform_file to not depend on transform decorator

### DIFF
--- a/python-sdk/example_dags/example_transform_file.py
+++ b/python-sdk/example_dags/example_transform_file.py
@@ -1,5 +1,5 @@
-import pathlib
 from datetime import datetime
+from pathlib import Path
 
 from airflow import DAG
 
@@ -8,7 +8,6 @@ from astro.files import File
 from astro.table import Table
 
 START_DATE = datetime(2000, 1, 1)
-CWD = pathlib.Path(__file__).parent
 
 
 with DAG(
@@ -26,7 +25,8 @@ with DAG(
 
     # [START transform_file_example_1]
     table_from_query = aql.transform_file(
-        file_path=str(pathlib.Path(CWD).parents[0]) + "/example_dags/demo_parse_directory/transform.sql",
-        parameters={"input_table": imdb_movies, "output_table": target_table},
+        file_path=f"{Path(__file__).parent.as_posix()}/demo_parse_directory/transform.sql",
+        parameters={"input_table": imdb_movies},
+        op_kwargs={"output_table": target_table},
     )
     # [END transform_file_example_1]

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, cast
+from typing import Any, Sequence, cast
 
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
@@ -19,6 +19,8 @@ from astro.utils.typing_compat import Context
 
 class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
     """Handles all decorator classes that can return a SQL function"""
+
+    template_fields: Sequence[str] = ("parameters", "op_args", "op_kwargs")
 
     database_impl: BaseDatabase
 
@@ -63,6 +65,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
             op_kwargs=self.op_kwargs,
             python_callable=self.python_callable,
             parameters=self.parameters,  # type: ignore
+            context=context,
         )
         if first_table:
             self.conn_id = self.conn_id or first_table.conn_id  # type: ignore

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -148,6 +148,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
             op_kwargs=self.op_kwargs,
             python_callable=self.python_callable,
             parameters=self.parameters or {},  # type: ignore
+            context=context,
         )
         if first_table:
             self.conn_id = self.conn_id or first_table.conn_id  # type: ignore

--- a/python-sdk/src/astro/utils/table.py
+++ b/python-sdk/src/astro/utils/table.py
@@ -1,82 +1,116 @@
+from __future__ import annotations
+
 import inspect
-from typing import Callable, Optional
+from typing import Callable
 
-from astro.table import BaseTable
+from airflow.models.xcom_arg import XComArg
+
+from astro.sql.table import BaseTable
+from astro.utils.typing_compat import Context
 
 
-def _pull_first_table_from_parameters(parameters: dict) -> Optional[BaseTable]:
+def _have_same_conn_id(tables: list[BaseTable]) -> bool:
     """
-    When trying to "magically" determine the context of a decorator, we will try to find the first table.
-    This function attempts this by checking parameters
+    Check to see if all tables belong to same conn_id. Otherwise, this can go wrong for cases
+    1. When we have tables from different DBs.
+    2. When we have tables from different conn_id, since they can be configured with different database/schema etc.
 
-    :param parameters: a user-defined dictionary of parameters
-    :return: the first parameter of type BaseTable, if any. Return None otherwise.
+    :param tables: tables to check for conn_id field
+    :return: True if all tables have the same conn id, and False if not.
     """
-    first_table = None
-    params_of_table_type = [param for param in parameters.values() if isinstance(param, BaseTable)]
-    if len(params_of_table_type) == 1 or len({param.conn_id for param in params_of_table_type}) == 1:
-        first_table = params_of_table_type[0]
-    return first_table
+    return len(tables) == 1 or len({table.conn_id for table in tables}) == 1
 
 
-def _pull_first_table_from_op_kwargs(op_kwargs: dict, python_callable: Callable) -> Optional[BaseTable]:
+def _find_first_table_from_op_args(op_args: tuple, context: Context) -> BaseTable | None:
     """
-    When trying to "magically" determine the context of a decorator, we will try to find the first table.
-    This function attempts this by checking op_kwargs
-
-    :param op_kwargs: user-defined operator's kwargs
-    :return: the first kwarg declared in the decorated method which is an
-        instance of BaseTable. Return None if non-existent
-    """
-    first_table = None
-    kwargs_of_table_type = [
-        op_kwargs[kwarg.name]
-        for kwarg in inspect.signature(python_callable).parameters.values()
-        if isinstance(op_kwargs[kwarg.name], BaseTable)
-    ]
-    if len(kwargs_of_table_type) == 1 or len({kwarg.conn_id for kwarg in kwargs_of_table_type}) == 1:
-        first_table = kwargs_of_table_type[0]
-    return first_table
-
-
-def _find_first_table_from_op_args(op_args: tuple) -> Optional[BaseTable]:
-    """
-    When trying to "magically" determine the context of a decorator, we will try to find the first table.
-    This function attempts this by checking op_args
+    Read op_args and extract the tables.
 
     :param op_args: user-defined operator's args
-    :return: the first arg which is an instance of BaseTable. If there are no instances, return None.
+    :param context: the context to use for resolving XComArgs
+    :return: first valid table found in op_args.
     """
-    first_table = None
-    args_of_table_type = [arg for arg in op_args if isinstance(arg, BaseTable)]
-    # Check to see if all tables belong to same conn_id. Otherwise, we this can go wrong for cases
-    # 1. When we have tables from different DBs.
-    # 2. When we have tables from different conn_id, since they can be configured with different
-    # database/schema etc.
-    if len(args_of_table_type) == 1 or len({arg.conn_id for arg in args_of_table_type}) == 1:
-        first_table = args_of_table_type[0]
-    return first_table
+    args = [arg.resolve(context) if isinstance(arg, XComArg) else arg for arg in op_args]
+    tables = [arg for arg in args if isinstance(arg, BaseTable)]
+
+    if _have_same_conn_id(tables):
+        return tables[0]
+    return None
+
+
+def _find_first_table_from_op_kwargs(
+    op_kwargs: dict, python_callable: Callable, context: Context
+) -> BaseTable | None:
+    """
+    Read op_kwargs and extract the tables.
+
+    :param op_kwargs: user-defined operator's kwargs
+    :param context: the context to use for resolving XComArgs
+    :return: first valid table found in op_kwargs.
+    """
+    kwargs = [
+        op_kwargs[kwarg.name].resolve(context)
+        if isinstance(op_kwargs[kwarg.name], XComArg)
+        else op_kwargs[kwarg.name]
+        for kwarg in inspect.signature(python_callable).parameters.values()
+    ]
+    tables = [kwarg for kwarg in kwargs if isinstance(kwarg, BaseTable)]
+
+    if _have_same_conn_id(tables):
+        return tables[0]
+    return None
+
+
+def _find_first_table_from_parameters(parameters: dict, context: Context) -> BaseTable | None:
+    """
+    Read parameters and extract the tables.
+
+    :param parameters: a user-defined dictionary of parameters
+    :param context: the context to use for resolving XComArgs
+    :return: first valid table found in parameters.
+    """
+    params = [
+        param.resolve(context) if isinstance(param, XComArg) else param for param in parameters.values()
+    ]
+    tables = [param for param in params if isinstance(param, BaseTable)]
+
+    if _have_same_conn_id(tables):
+        return tables[0]
+    return None
 
 
 def find_first_table(
-    op_args: tuple, op_kwargs: dict, python_callable: Callable, parameters: dict
-) -> Optional[BaseTable]:
+    op_args: tuple,
+    op_kwargs: dict,
+    python_callable: Callable,
+    parameters: dict,
+    context: Context,
+) -> BaseTable | None:
     """
     When we create our SQL operation, we run with the assumption that the first table given is the "main table".
     This means that a user doesn't need to define default conn_id, database, etc. in the function unless they want
     to create default values.
 
+    :param op_args: user-defined operator's args
+    :param op_kwargs: user-defined operator's kwargs
+    :param python_callable: user-defined operator's callable
     :param parameters: user-defined parameters to be injected into SQL statement
+    :param context: the context to use for resolving XComArgs
     :return: the first table declared as decorator arg or kwarg
     """
-    first_table: Optional[BaseTable] = None
+    first_table: BaseTable | None = None
+
     if op_args:
-        first_table = _find_first_table_from_op_args(op_args=op_args)
-
+        first_table = _find_first_table_from_op_args(op_args=op_args, context=context)
     if not first_table and op_kwargs and python_callable:
-        first_table = _pull_first_table_from_op_kwargs(op_kwargs=op_kwargs, python_callable=python_callable)
-
-    # If there is no first table via op_ags or kwargs, we check the parameters
+        first_table = _find_first_table_from_op_kwargs(
+            op_kwargs=op_kwargs,
+            python_callable=python_callable,
+            context=context,
+        )
     if not first_table and parameters:
-        first_table = _pull_first_table_from_parameters(parameters=parameters)
+        first_table = _find_first_table_from_parameters(
+            parameters=parameters,
+            context=context,
+        )
+
     return first_table

--- a/python-sdk/tests/sql/operators/test_base_decorator.py
+++ b/python-sdk/tests/sql/operators/test_base_decorator.py
@@ -1,0 +1,9 @@
+from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
+
+
+def test_base_sql_decorated_operator_template_fields_with_parameters():
+    """
+    Test that parameters is in BaseSQLDecoratedOperator template_fields
+     as this required for taskflow to work if XCom args are being passed via parameters.
+    """
+    assert "parameters" in BaseSQLDecoratedOperator.template_fields

--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -192,9 +192,6 @@ def test_transform_with_templated_table_name(database_table_fixture, sample_dag)
 )
 def test_transform_with_file(database_table_fixture, sample_dag):
     """Test table creation via select statement in a SQL file"""
-    import pathlib  # skipcq: PYL-W0404
-
-    cwd = pathlib.Path(__file__).parent
     database, imdb_table = database_table_fixture
 
     @aql.dataframe
@@ -204,8 +201,9 @@ def test_transform_with_file(database_table_fixture, sample_dag):
     with sample_dag:
         target_table = Table(name="test_is_{{ ds_nodash }}", conn_id="sqlite_default")
         table_from_query = aql.transform_file(
-            file_path=str(pathlib.Path(cwd).parents[0]) + "/transform/test.sql",
-            parameters={"input_table": imdb_table, "output_table": target_table},
+            file_path="tests/sql/operators/transform/test.sql",
+            parameters={"input_table": imdb_table},
+            op_kwargs={"output_table": target_table},
         )
         validate(table_from_query)
     test_utils.run_dag(sample_dag)

--- a/python-sdk/tests/utils/test_table.py
+++ b/python-sdk/tests/utils/test_table.py
@@ -1,0 +1,91 @@
+from unittest import mock
+
+import pytest
+
+from astro.sql.operators.transform import TransformOperator
+from astro.table import BaseTable, Table
+from astro.utils.table import find_first_table
+
+
+@pytest.mark.parametrize(
+    "kwargs,return_type",
+    [
+        (
+            {
+                "op_args": (),
+                "op_kwargs": {},
+                "python_callable": None,
+                "parameters": {},
+            },
+            type(None),
+        ),
+        (
+            {
+                "op_args": (Table(),),
+                "op_kwargs": {},
+                "python_callable": None,
+                "parameters": {},
+            },
+            BaseTable,
+        ),
+        (
+            {
+                "op_args": (),
+                "op_kwargs": {"table": Table()},
+                "python_callable": lambda table: table,
+                "parameters": {},
+            },
+            BaseTable,
+        ),
+        (
+            {
+                "op_args": (),
+                "op_kwargs": {},
+                "python_callable": None,
+                "parameters": {"table": Table()},
+            },
+            BaseTable,
+        ),
+    ],
+    ids=["none", "op_args", "op_kwargs", "parameters"],
+)
+def test_find_first_table(kwargs, return_type):
+    assert isinstance(find_first_table(context={}, **kwargs), return_type)
+
+
+@pytest.mark.parametrize(
+    "kwargs,return_type",
+    [
+        (
+            {
+                "op_args": (TransformOperator(python_callable=lambda: "select 1").output,),
+                "op_kwargs": {},
+                "python_callable": None,
+                "parameters": {},
+            },
+            BaseTable,
+        ),
+        (
+            {
+                "op_args": (),
+                "op_kwargs": {"table": TransformOperator(python_callable=lambda: "select 1").output},
+                "python_callable": lambda table: table,
+                "parameters": {},
+            },
+            BaseTable,
+        ),
+        (
+            {
+                "op_args": (),
+                "op_kwargs": {},
+                "python_callable": None,
+                "parameters": {"table": TransformOperator(python_callable=lambda: "select 1").output},
+            },
+            BaseTable,
+        ),
+    ],
+    ids=["op_args", "op_kwargs", "parameters"],
+)
+@mock.patch("airflow.models.xcom_arg.PlainXComArg.resolve", return_value=Table())
+def test_find_first_table_with_xcom_arg(xcom_arg_resolve, kwargs, return_type):
+    assert isinstance(find_first_table(context={}, **kwargs), return_type)


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, the `transform_file` is using the `transform` decorator underneath which has a few limitations. For more information check out the issue below.

closes: #892  

## What is the new behavior?

- use TransformOperator in transform_file
- set default task_id for TransformOperator to "transform"
- fix example for transform_file
- resolve XComArgs when finding first table
- add parameters to template_fields

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
