### PR TITLE
Add docs requirements to venv via make

### DIFF
--- a/python-sdk/mk/local.mk
+++ b/python-sdk/mk/local.mk
@@ -37,6 +37,7 @@ install: virtualenv  ## Install python dependencies in existing virtualenv
 	@$(PIP) install pre-commit
 	@cd .. && $(PIP) install -e .[all]
 	@cd .. && $(PIP) install .[tests]
+	@cd .. && $(PIP) install .[doc]
 
 config:  ## Create sample configuration files related to Snowflake, Amazon and Google
 	@cd .. && test -e .env && \


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, in our local setup we don't have docs requirement installed.

## What is the new behavior?

We add docs requirements to the venv (via make).

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
