### PR TITLE
Fix make local install

### DIFF
--- a/python-sdk/mk/local.mk
+++ b/python-sdk/mk/local.mk
@@ -35,7 +35,7 @@ install: virtualenv  ## Install python dependencies in existing virtualenv
 	@$(PIP) install --upgrade pip
 	@$(PIP) install nox
 	@$(PIP) install pre-commit
-	@cd .. && $(PIP) install -e .[all, tests, doc]
+	@cd .. && $(PIP) install -e .[all,tests,doc]
 
 config:  ## Create sample configuration files related to Snowflake, Amazon and Google
 	@cd .. && test -e .env && \


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, make's local install is broken. It cannot install the packages.

related: #1006

## What is the new behavior?

Fixes make local install to install all extras passed.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
