### PR TITLE
Fix nox' airflow version

### DIFF
--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -24,6 +24,7 @@ def dev(session: nox.Session) -> None:
 @nox.parametrize("airflow", ["2.2.5", "2.3"])
 def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
+    session.install(f"apache-airflow=={airflow}")
     session.install("-e", ".[all]")
     session.install("-e", ".[tests]")
     # Log all the installed dependencies


### PR DESCRIPTION
# Description

## What is the current behavior?

nox, did not use the airflow version we wanted it to use as we forgot to install it into the session.

## What is the new behavior?

Add session install command to install specific apache airflow version.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
