### PR TITLE
Tests: Make local runner compatible with Airflow <2.3

### DIFF
--- a/python-sdk/tests/sql/operators/utils.py
+++ b/python-sdk/tests/sql/operators/utils.py
@@ -191,7 +191,7 @@ def _run_task(ti: TaskInstance, session):
         ti: TaskInstance to run
     """
     log.info("*****************************************************")
-    if ti.map_index > 0:
+    if hasattr(ti, "map_index") and ti.map_index > 0:
         log.info("Running task %s index %d", ti.task_id, ti.map_index)
     else:
         log.info("Running task %s", ti.task_id)


### PR DESCRIPTION

# Description
## What is the current behavior?
Without it, the tests for Airflow 2.2.5 gives the following error:

```python
>       if ti.map_index > 0:
E       AttributeError: 'TaskInstance' object has no attribute 'map_index
```


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Since `map_index` was added to Airflow 2.3, this PR makes it compatible to both <2.3 and >= 2.3

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
