### PR TITLE
Run CI tests for Airflow 2.4 instead of 2.3

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -161,7 +161,7 @@ jobs:
       AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE: True
       FORCE_COLOR: "true"
 
-  Run-Unit-tests-Airflow-2-3:
+  Run-Unit-tests-Airflow-2-4:
     if: >-
       github.event_name == 'push' ||
       (
@@ -217,7 +217,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.3')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.4')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:
@@ -268,7 +268,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     needs:
-      - Run-Unit-tests-Airflow-2-3
+      - Run-Unit-tests-Airflow-2-4
     services:
       postgres:
         # Docker Hub image
@@ -340,7 +340,7 @@ jobs:
   Code-Coverage:
     if: github.event.action != 'labeled'
     needs:
-      - Run-Unit-tests-Airflow-2-3
+      - Run-Unit-tests-Airflow-2-4
       - Run-Optional-Packages-tests-python-sdk
     runs-on: ubuntu-latest
     steps:
@@ -372,7 +372,7 @@ jobs:
     if: github.event_name == 'release'
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     needs:
-      - Run-Unit-tests-Airflow-2-3
+      - Run-Unit-tests-Airflow-2-4
       - Run-Optional-Packages-tests-python-sdk
     runs-on: ubuntu-18.04
     steps:

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -21,7 +21,7 @@ def dev(session: nox.Session) -> None:
 
 
 @nox.session(python=["3.7", "3.8", "3.9"])
-@nox.parametrize("airflow", ["2.2.5", "2.3"])
+@nox.parametrize("airflow", ["2.2.5", "2.4"])
 def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
     session.install(f"apache-airflow=={airflow}")


### PR DESCRIPTION
We should run our CI test on Airflow 2.2.5 and 2.4. I don't think we should run tests against 2.3 anymore

