### PR TITLE
Skip certain example DAGs by using `.airflowignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ sql-cli/tests/_dags/*
 !sql-cli/tests/_dags/.gitkeep
 sql-cli/tests/_target/*
 !sql-cli/tests/_target/.gitkeep
+
+# Airflow
+**/.airflowignore

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -27,7 +27,8 @@ def test(session: nox.Session, airflow) -> None:
     # Otherwise it fails with
     # Pandas requires version '1.4.0' or newer of 'sqlalchemy' (version '1.3.24' currently installed).
     constraints_url = (
-        f"https://raw.githubusercontent.com/apache/airflow/constraints-{airflow}/constraints-{session.python}.txt",
+        "https://raw.githubusercontent.com/apache/airflow/"
+        f"constraints-{airflow}/constraints-{session.python}.txt"
     )
     constraints = ["-c", constraints_url] if airflow == "2.2.5" else []
     session.install(f"apache-airflow=={airflow}", *constraints)

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -24,7 +24,17 @@ def dev(session: nox.Session) -> None:
 @nox.parametrize("airflow", ["2.2.5", "2.4"])
 def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
-    session.install(f"apache-airflow=={airflow}")
+    if airflow == "2.2.5":
+        # 2.2.5 requires a certain version of pandas and sqlalchemy
+        # Otherwise it fails with
+        # Pandas requires version '1.4.0' or newer of 'sqlalchemy' (version '1.3.24' currently installed).
+        session.install(
+            f"apache-airflow=={airflow}",
+            "-c",
+            f"https://raw.githubusercontent.com/apache/airflow/constraints-{airflow}/constraints-{session.python}.txt",
+        )
+    else:
+        session.install(f"apache-airflow=={airflow}")
     session.install("-e", ".[all]")
     session.install("-e", ".[tests]")
     # Log all the installed dependencies

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -16,27 +16,22 @@ def dev(session: nox.Session) -> None:
     development environment to ``.nox/dev``.
     """
     session.install("nox")
-    session.install("-e", ".[all]")
-    session.install("-e", ".[tests]")
+    session.install("-e", ".[all,tests]")
 
 
 @nox.session(python=["3.7", "3.8", "3.9"])
 @nox.parametrize("airflow", ["2.2.5", "2.4"])
 def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
-    if airflow == "2.2.5":
-        # 2.2.5 requires a certain version of pandas and sqlalchemy
-        # Otherwise it fails with
-        # Pandas requires version '1.4.0' or newer of 'sqlalchemy' (version '1.3.24' currently installed).
-        session.install(
-            f"apache-airflow=={airflow}",
-            "-c",
-            f"https://raw.githubusercontent.com/apache/airflow/constraints-{airflow}/constraints-{session.python}.txt",
-        )
-    else:
-        session.install(f"apache-airflow=={airflow}")
-    session.install("-e", ".[all]")
-    session.install("-e", ".[tests]")
+    # 2.2.5 requires a certain version of pandas and sqlalchemy
+    # Otherwise it fails with
+    # Pandas requires version '1.4.0' or newer of 'sqlalchemy' (version '1.3.24' currently installed).
+    constraints_url = (
+        f"https://raw.githubusercontent.com/apache/airflow/constraints-{airflow}/constraints-{session.python}.txt",
+    )
+    constraints = ["-c", constraints_url] if airflow == "2.2.5" else []
+    session.install(f"apache-airflow=={airflow}", *constraints)
+    session.install("-e", ".[all,tests]", *constraints)
     # Log all the installed dependencies
     session.log("Installed Dependencies:")
     session.run("pip3", "freeze")
@@ -47,8 +42,7 @@ def test(session: nox.Session, airflow) -> None:
 @nox.session(python=["3.8"])
 def type_check(session: nox.Session) -> None:
     """Run MyPy checks."""
-    session.install("-e", ".[all]")
-    session.install("-e", ".[tests]")
+    session.install("-e", ".[all,tests]")
     session.run("mypy", "--version")
     session.run("mypy")
 

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -41,7 +41,6 @@ classifiers = [
 
 [project.optional-dependencies]
 tests = [
-    "click==8.0.0",
     "pytest>=6.0",
     "pytest-split",
     "pytest-dotenv",

--- a/python-sdk/tests/test_example_dags.py
+++ b/python-sdk/tests/test_example_dags.py
@@ -16,7 +16,6 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
-
 from tests.sql.operators import utils as test_utils
 
 RETRY_ON_EXCEPTIONS = []

--- a/python-sdk/tests/test_example_dags.py
+++ b/python-sdk/tests/test_example_dags.py
@@ -73,9 +73,6 @@ def get_dag_bag() -> DagBag:
             if Version(airflow.__version__) < min_version:
                 print(f"Adding {files} to .airflowignore")
                 file.writelines(files)
-                # We want to find a version in the map that is less than the installed version
-                # but greater than other versions
-                break
 
     dag_bag = DagBag(example_dags_dir, include_examples=False)
     return dag_bag

--- a/python-sdk/tests/test_example_dags.py
+++ b/python-sdk/tests/test_example_dags.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterator
 
 import airflow
 import pytest
@@ -10,12 +9,14 @@ from airflow.models.dagbag import DagBag
 from airflow.utils import timezone
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session
+from packaging.version import Version
 from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
+
 from tests.sql.operators import utils as test_utils
 
 RETRY_ON_EXCEPTIONS = []
@@ -51,44 +52,45 @@ def session():
     return get_session()
 
 
-DAG_BAG = DagBag(Path(__file__).parent.parent / "example_dags", include_examples=False)
-AIRFLOW_VERSION_INDICATOR = "airflow_version:"
-MINIMUM_AIRFLOW_VERSION = "2.2.5"
+MIN_VER_DAG_FILE: dict[str, list[str]] = {
+    "2.3": ["example_dynamic_task_template.py"],
+    "2.4": ["example_datasets.py"],
+}
+
+# Sort descending based on Versions and convert string to an actual version
+MIN_VER_DAG_FILE_VER: dict[Version, list[str]] = {
+    Version(version): MIN_VER_DAG_FILE[version]
+    for version in sorted(MIN_VER_DAG_FILE, key=Version, reverse=True)
+}
 
 
-def get_airflow_version(dag: DAG) -> str:
-    for tag in dag.tags:
-        if tag.startswith(AIRFLOW_VERSION_INDICATOR):
-            return tag[len(AIRFLOW_VERSION_INDICATOR) :]
-    return MINIMUM_AIRFLOW_VERSION
+def get_dag_bag() -> DagBag:
+    """Create a DagBag by adding the files that are not supported to .airflowignore"""
+    example_dags_dir = Path(__file__).parent.parent / "example_dags"
+    airflow_ignore_file = example_dags_dir / ".airflowignore"
 
+    with open(airflow_ignore_file, "w+") as file:
+        for min_version, files in MIN_VER_DAG_FILE_VER.items():
+            if Version(airflow.__version__) < min_version:
+                print(f"Adding {files} to .airflowignore")
+                file.writelines(files)
+                # We want to find a version in the map that is less than the installed version
+                # but greater than other versions
+                break
 
-def get_airflow_dags() -> Iterator[tuple[str, str]]:
-    for dag_id, dag in DAG_BAG.dags.items():
-        yield dag_id, dag, get_airflow_version(dag)
+    dag_bag = DagBag(example_dags_dir, include_examples=False)
+    return dag_bag
 
 
 @pytest.mark.parametrize(
     "dag",
-    [
-        pytest.param(
-            dag,
-            id=dag_id,
-            marks=pytest.mark.skipif(
-                airflow.__version__ < dag_airflow_version,
-                reason=f"Require Airflow version >= {dag_airflow_version}",
-            ),
-        )
-        for dag_id, dag, dag_airflow_version in get_airflow_dags()
-    ],
+    [pytest.param(dag, id=dag_id) for dag_id, dag in get_dag_bag().dags.items()],
 )
 def test_example_dag(session, dag: DAG):
     wrapper_run_dag(dag)
 
 
-def test_example_dags_loaded():
-    assert DAG_BAG.dags
-
-
-def test_example_dags_no_import_errors():
-    assert not DAG_BAG.import_errors
+def test_example_dags_loaded_with_no_errors():
+    dag_bag = get_dag_bag()
+    assert dag_bag.dags
+    assert not dag_bag.import_errors

--- a/python-sdk/tests/test_example_dags.py
+++ b/python-sdk/tests/test_example_dags.py
@@ -52,7 +52,7 @@ def session():
 
 
 MIN_VER_DAG_FILE: dict[str, list[str]] = {
-    "2.3": ["example_dynamic_task_template.py"],
+    "2.3": ["example_dynamic_task_template.py", "example_bigquery_dynamic_map_task.py"],
     "2.4": ["example_datasets.py"],
 }
 
@@ -72,8 +72,10 @@ def get_dag_bag() -> DagBag:
         for min_version, files in MIN_VER_DAG_FILE_VER.items():
             if Version(airflow.__version__) < min_version:
                 print(f"Adding {files} to .airflowignore")
-                file.writelines(files)
+                file.writelines([f"{file}\n" for file in files])
 
+    print(".airflowignore contents: ")
+    print(airflow_ignore_file.read_text())
     dag_bag = DagBag(example_dags_dir, include_examples=False)
     return dag_bag
 


### PR DESCRIPTION
This is an alternative to https://github.com/astronomer/astro-sdk/pull/1016

The main benefit is it is clear which dags will be skipped, is completely automated without any user-facing changes

