### PR TITLE
CI: Run 2.2.5 test in parallel

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -267,8 +267,6 @@ jobs:
         github.event_name == 'release'
       )
     runs-on: ubuntu-latest
-    needs:
-      - Run-Unit-tests-Airflow-2-4
     services:
       postgres:
         # Docker Hub image
@@ -373,6 +371,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     needs:
       - Run-Unit-tests-Airflow-2-4
+      - Run-Unit-tests-Airflow-2-2-5
       - Run-Optional-Packages-tests-python-sdk
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
Initially, we had set it to run after tests for 2.4 runs, but there is not point in waiting, it can run in parallel.

