### PR TITLE
Stop duplicate CI jobs

### DIFF
--- a/.github/workflows/ci-benchmark.yaml
+++ b/.github/workflows/ci-benchmark.yaml
@@ -6,6 +6,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# This allows a subsequently queued workflow run to interrupt and cancel previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Run-Benchmark:
     if: >-

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -24,6 +24,12 @@ on:
 defaults:
   run:
     working-directory: python-sdk
+
+# This allows a subsequently queued workflow run to interrupt and cancel previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Markdown-link-check:
     if: github.event.action != 'labeled'

--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -20,6 +20,12 @@ on:
 defaults:
   run:
     working-directory: sql-cli
+
+# This allows a subsequently queued workflow run to interrupt and cancel previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Type-Check:
     if: github.event.action != 'labeled'
@@ -90,7 +96,7 @@ jobs:
   Code-Coverage:
     if: github.event.action != 'labeled'
     needs:
-      - Run-SQL-CLI-tests-Airflow-2-3
+      - Run-SQL-CLI-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Currently, we have to manually cancel duplicate jobs when we push more commits to existing PRs.

We use GitHub action's "[concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)" feature in Airflow too for this: https://github.com/apache/airflow/pull/15944

closes https://github.com/astronomer/astro-sdk/issues/1021
