### PR TITLE
Consolidate Black and isort configs

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+profile=black
+line_length=110
+combine_as_imports=true
+known_first_party=astro,tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
       - id: black
         # Exclude auto-generated example files from being changed
         exclude: ^sql-cli/examples/_dags/
+        args: ["--config", "./python-sdk/pyproject.toml"]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
@@ -76,13 +77,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-        name: Run isort for python-sdk
-        args: [ "--profile", "black" ]
-        files: ^python-sdk/
-      - id: isort
-        name: Run isort for sql-cli
-        args: [ "--profile", "black" ]
-        files: ^sql-cli/
+        name: Run isort
         # Exclude auto-generated example files from being changed
         exclude: ^sql-cli/examples/_dags/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         exclude: ^python-sdk/mk/|^python-sdk/docs/Makefile|^python-sdk/Makefile$|^python-sdk/tests/benchmark/Makefile|^sql-cli/Makefile$
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         # Exclude auto-generated example files from being changed
@@ -59,7 +59,7 @@ repos:
     hooks:
       - id: blacken-docs
         alias: black
-        additional_dependencies: [black>=22.1.0]
+        additional_dependencies: [black>=22.10.0]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
@@ -90,7 +90,7 @@ repos:
         types: [text]
         exclude: ^mk/.*\.mk$|^python-sdk/docs/Makefile|^python-sdk/Makefile$|^python-sdk/tests/benchmark/Makefile$
   -   repo: https://github.com/pre-commit/mirrors-mypy
-      rev: 'v0.981'
+      rev: 'v0.982'
       hooks:
       - id: mypy
         name: mypy-python-sdk
@@ -102,7 +102,7 @@ repos:
         files: "^sql-cli/"
 
   -   repo: https://github.com/asottile/pyupgrade
-      rev: v2.38.2
+      rev: v3.0.0
       hooks:
       -   id: pyupgrade
           args: [--py37-plus]

--- a/python-sdk/example_dags/calculate_popular_movies.py
+++ b/python-sdk/example_dags/calculate_popular_movies.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from airflow import DAG
+
 from astro import sql as aql
 from astro.files import File
 from astro.table import Table
@@ -24,9 +25,7 @@ with DAG(
     catchup=False,
 ) as dag:
     imdb_movies = aql.load_file(
-        File(
-            "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
-        ),
+        File("https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"),
         output_table=Table(conn_id="sqlite_default"),
     )
     top_five_animations(

--- a/python-sdk/example_dags/example_amazon_s3_postgres.py
+++ b/python-sdk/example_dags/example_amazon_s3_postgres.py
@@ -2,10 +2,11 @@ import os
 from datetime import datetime, timedelta
 
 from airflow.models import DAG
+from pandas import DataFrame
+
 from astro import sql as aql
 from astro.files import File
 from astro.table import Table
-from pandas import DataFrame
 
 s3_bucket = os.getenv("S3_BUCKET", "s3://tmp9")
 

--- a/python-sdk/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/python-sdk/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -1,9 +1,10 @@
 import os
 
-# Import Operator
-import astro.sql as aql
 from airflow.decorators import dag
 from airflow.utils import timezone
+
+# Import Operator
+import astro.sql as aql
 from astro.files import File
 from astro.table import Table
 
@@ -37,6 +38,4 @@ def example_amazon_s3_postgres_load_and_save():
     aql.cleanup()
 
 
-example_amazon_s3_postgres_load_and_save_dag = (
-    example_amazon_s3_postgres_load_and_save()
-)
+example_amazon_s3_postgres_load_and_save_dag = example_amazon_s3_postgres_load_and_save()

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 # Uses data from https://www.kaggle.com/c/shelter-animal-outcomes
 from airflow.decorators import dag
+
 from astro import sql as aql
 from astro.files import File
 from astro.table import Metadata, Table
@@ -27,9 +28,7 @@ def clean_data(input_table: Table):
 # [START dataframe_example_1]
 @aql.dataframe(columns_names_capitalization="original")
 def aggregate_data(df: pd.DataFrame):
-    new_df = df.pivot_table(
-        index="date", values="name", columns=["type"], aggfunc="count"
-    ).reset_index()
+    new_df = df.pivot_table(index="date", values="name", columns=["type"], aggfunc="count").reset_index()
     new_df.columns = new_df.columns.str.lower()
     return new_df
 

--- a/python-sdk/example_dags/example_append.py
+++ b/python-sdk/example_dags/example_append.py
@@ -2,6 +2,7 @@ import pathlib
 from datetime import datetime, timedelta
 
 from airflow.models import DAG
+
 from astro import sql as aql
 from astro.files import File
 from astro.table import Table
@@ -41,9 +42,7 @@ with dag:
     # [END append_example]
 
     # [START append_example_col_dict]
-    aql.append(
-        target_table=load_main, source_table=load_append, columns={"beds": "baths"}
-    )
+    aql.append(target_table=load_main, source_table=load_append, columns={"beds": "baths"})
     # [END append_example_col_dict]
 
     aql.cleanup()

--- a/python-sdk/example_dags/example_bigquery_dynamic_map_task.py
+++ b/python-sdk/example_dags/example_bigquery_dynamic_map_task.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.decorators import task
+
 from astro import sql as aql
 from astro.files import File
 from astro.sql import Table

--- a/python-sdk/example_dags/example_datasets.py
+++ b/python-sdk/example_dags/example_datasets.py
@@ -20,14 +20,13 @@ Pre-requisites:
 from datetime import datetime
 
 from airflow import DAG
+
 from astro import sql as aql
 from astro.files import File
 from astro.table import Table
 
 # [START dataset_file]
-input_file = File(
-    path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
-)
+input_file = File(path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv")
 # [END dataset_file]
 
 # [START dataset_table]

--- a/python-sdk/example_dags/example_dynamic_task_template.py
+++ b/python-sdk/example_dags/example_dynamic_task_template.py
@@ -14,6 +14,7 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.decorators import task
+
 from astro import sql as aql
 from astro.files import get_file_list
 from astro.sql import get_value_list
@@ -62,9 +63,7 @@ with DAG(
         rating_list = [val for val in rating_list if val]
         return sum(rating_list) / len(rating_list)
 
-    rating = custom_task.expand(
-        rating_val=get_value_list(sql=QUERY_STATEMENT, conn_id=ASTRO_GCP_CONN_ID)
-    )
+    rating = custom_task.expand(rating_val=get_value_list(sql=QUERY_STATEMENT, conn_id=ASTRO_GCP_CONN_ID))
 
     print(avg_rating(rating))
     # [END howto_operator_get_value_list]

--- a/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
+++ b/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
@@ -14,10 +14,11 @@ Pre-requisites:
 """
 import os
 
-import astro.sql as aql
 import pandas as pd
 from airflow.models.dag import DAG
 from airflow.utils import timezone
+
+import astro.sql as aql
 from astro.files import File
 from astro.table import Metadata, Table
 
@@ -32,9 +33,7 @@ with DAG(
         input_file=File(
             path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
         ),
-        output_table=Table(
-            name="imdb_movies", conn_id="bigquery", metadata=Metadata(schema="astro")
-        ),
+        output_table=Table(name="imdb_movies", conn_id="bigquery", metadata=Metadata(schema="astro")),
     )
     # [END load_file_http_example]
 
@@ -42,9 +41,9 @@ with DAG(
     @aql.dataframe(columns_names_capitalization="original")
     def extract_top_5_movies(input_df: pd.DataFrame):
         print(f"Total Number of records: {len(input_df)}")
-        top_5_movies = input_df.sort_values(by="rating", ascending=False)[
-            ["title", "rating", "genre1"]
-        ].head(5)
+        top_5_movies = input_df.sort_values(by="rating", ascending=False)[["title", "rating", "genre1"]].head(
+            5
+        )
         print(f"Top 5 Movies: {top_5_movies}")
         return top_5_movies
 

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import sqlalchemy
 from airflow.models import DAG
+
 from astro import sql as aql
 from astro.constants import FileType
 from astro.files import File
@@ -73,9 +74,7 @@ with dag:
             conn_id="postgres_conn",
             columns=[
                 sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-                sqlalchemy.Column(
-                    "name", sqlalchemy.String(60), nullable=False, key="name"
-                ),
+                sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
             ],
         ),
     )
@@ -125,9 +124,7 @@ with dag:
 
     # [START load_file_example_10]
     my_homes_table = aql.load_file(
-        input_file=File(
-            path=str(CWD.parent) + "/tests/data/homes*", filetype=FileType.CSV
-        ),
+        input_file=File(path=str(CWD.parent) + "/tests/data/homes*", filetype=FileType.CSV),
         output_table=Table(
             conn_id="postgres_conn",
         ),
@@ -136,9 +133,7 @@ with dag:
 
     # [START load_file_example_11]
     aql.load_file(
-        input_file=File(
-            "s3://astro-sdk/sample_pattern", conn_id="aws_conn", filetype=FileType.CSV
-        ),
+        input_file=File("s3://astro-sdk/sample_pattern", conn_id="aws_conn", filetype=FileType.CSV),
         output_table=Table(conn_id="bigquery", metadata=Metadata(schema="astro")),
         use_native_support=False,
     )
@@ -182,9 +177,7 @@ with dag:
 
     # [START load_file_example_15]
     aql.load_file(
-        input_file=File(
-            path=str(CWD.parent) + "/tests/data/homes*", filetype=FileType.CSV
-        ),
+        input_file=File(path=str(CWD.parent) + "/tests/data/homes*", filetype=FileType.CSV),
         output_table=Table(
             conn_id="postgres_conn",
         ),

--- a/python-sdk/example_dags/example_merge.py
+++ b/python-sdk/example_dags/example_merge.py
@@ -2,11 +2,12 @@ import pathlib
 from datetime import datetime, timedelta
 
 from airflow.models import DAG
+from pandas import DataFrame
+from sqlalchemy import Column, types
+
 from astro import sql as aql
 from astro.files import File
 from astro.table import Metadata, Table
-from pandas import DataFrame
-from sqlalchemy import Column, types
 
 CWD = pathlib.Path(__file__).parent
 DATA_DIR = str(CWD) + "/../tests/data/"

--- a/python-sdk/example_dags/example_snowflake_partial_table_with_append.py
+++ b/python-sdk/example_dags/example_snowflake_partial_table_with_append.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 import pandas as pd
 from airflow.decorators import dag
+
 from astro.files import File
 from astro.sql import append, cleanup, dataframe, load_file, run_raw_sql, transform
 from astro.table import Metadata, Table
@@ -39,9 +40,7 @@ def extract_data(homes1: Table, homes2: Table):
 @dataframe
 def transform_data(df: pd.DataFrame):
     df.columns = df.columns.str.lower()
-    melted_df = df.melt(
-        id_vars=["sell", "list"], value_vars=["living", "rooms", "beds", "baths", "age"]
-    )
+    melted_df = df.melt(id_vars=["sell", "list"], value_vars=["living", "rooms", "beds", "baths", "age"])
 
     return melted_df
 
@@ -73,9 +72,7 @@ def create_table(table: Table):
 @dag(start_date=datetime(2021, 12, 1), schedule_interval="@daily", catchup=False)
 def example_snowflake_partial_table_with_append():
     homes_reporting = Table(conn_id=SNOWFLAKE_CONN_ID)
-    create_results_table = create_table(
-        table=homes_reporting, conn_id=SNOWFLAKE_CONN_ID
-    )
+    create_results_table = create_table(table=homes_reporting, conn_id=SNOWFLAKE_CONN_ID)
     # [END howto_run_raw_sql_snowflake_1]
 
     # Initial load of homes data csv's into Snowflake
@@ -108,9 +105,7 @@ def example_snowflake_partial_table_with_append():
         output_table=Table(name="combined_homes_data"),
     )
 
-    transformed_data = transform_data(
-        df=extracted_data, output_table=Table(name="homes_data_long")
-    )
+    transformed_data = transform_data(df=extracted_data, output_table=Table(name="homes_data_long"))
 
     filtered_data = filter_data(
         homes_long=transformed_data,

--- a/python-sdk/example_dags/example_sqlite_load_transform.py
+++ b/python-sdk/example_dags/example_sqlite_load_transform.py
@@ -2,6 +2,7 @@ import time
 from datetime import datetime
 
 from airflow import DAG
+
 from astro import sql as aql
 from astro.files import File
 from astro.sql import drop_table
@@ -47,9 +48,7 @@ with DAG(
     )
     # Note - Using persistent table just to showcase drop_table operator.
     # [START drop_table_example]
-    truncate_results = drop_table(
-        table=Table(name=imdb_movies_name, conn_id="sqlite_default")
-    )
+    truncate_results = drop_table(table=Table(name=imdb_movies_name, conn_id="sqlite_default"))
     # [END drop_table_example]
     truncate_results.set_upstream(top_five_animations)
     aql.cleanup()

--- a/python-sdk/example_dags/example_transform.py
+++ b/python-sdk/example_dags/example_transform.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pandas as pd
 from airflow import DAG
+
 from astro import sql as aql
 from astro.files import File
 from astro.table import Table
@@ -56,9 +57,7 @@ def union_top_and_last(first_table: Table, second_table: Table):  # skipcq: PYL-
 
 # [START transform_example_4]
 @aql.transform
-def union_table_and_dataframe(
-    input_table: Table, input_dataframe: pd.DataFrame  # skipcq: PYL-W0613
-):
+def union_table_and_dataframe(input_table: Table, input_dataframe: pd.DataFrame):  # skipcq: PYL-W0613
     """Union `union_table` table and `input_dataframe` dataframe to create a simple dataset."""
     return """
             SELECT title, rating from {{input_table}}

--- a/python-sdk/example_dags/example_transform_file.py
+++ b/python-sdk/example_dags/example_transform_file.py
@@ -2,6 +2,7 @@ import pathlib
 from datetime import datetime
 
 from airflow import DAG
+
 from astro import sql as aql
 from astro.files import File
 from astro.table import Table
@@ -17,9 +18,7 @@ with DAG(
     catchup=False,
 ) as dag:
     imdb_movies = aql.load_file(
-        input_file=File(
-            "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
-        ),
+        input_file=File("https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"),
         task_id="load_csv",
         output_table=Table(conn_id="sqlite_default"),
     )
@@ -27,8 +26,7 @@ with DAG(
 
     # [START transform_file_example_1]
     table_from_query = aql.transform_file(
-        file_path=str(pathlib.Path(CWD).parents[0])
-        + "/example_dags/demo_parse_directory/transform.sql",
+        file_path=str(pathlib.Path(CWD).parents[0]) + "/example_dags/demo_parse_directory/transform.sql",
         parameters={"input_table": imdb_movies, "output_table": target_table},
     )
     # [END transform_file_example_1]

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -128,3 +128,7 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
+
+[tool.black]
+line-length = 110
+target-version = ['py37', 'py38', 'py39', 'py310']

--- a/python-sdk/src/astro/airflow/datasets.py
+++ b/python-sdk/src/astro/airflow/datasets.py
@@ -23,36 +23,18 @@ def kwargs_with_datasets(
     from astro import settings
 
     kwargs = kwargs or {}
-    if (
-        "inlets" in kwargs
-        or DATASET_SUPPORT
-        and settings.AUTO_ADD_INLETS_OUTLETS
-        and input_datasets
-    ):
+    if "inlets" in kwargs or DATASET_SUPPORT and settings.AUTO_ADD_INLETS_OUTLETS and input_datasets:
         # Remove non-dataset objects like Temp tables (unless passed by user)
-        input_datasets = (
-            input_datasets if isinstance(input_datasets, list) else [input_datasets]
-        )
-        input_datasets = [
-            input_ds for input_ds in input_datasets if isinstance(input_ds, Dataset)
-        ]
+        input_datasets = input_datasets if isinstance(input_datasets, list) else [input_datasets]
+        input_datasets = [input_ds for input_ds in input_datasets if isinstance(input_ds, Dataset)]
 
         inlets = kwargs.get("inlets", input_datasets)
         kwargs.update({"inlets": inlets})
 
-    if (
-        "outlets" in kwargs
-        or DATASET_SUPPORT
-        and settings.AUTO_ADD_INLETS_OUTLETS
-        and output_datasets
-    ):
+    if "outlets" in kwargs or DATASET_SUPPORT and settings.AUTO_ADD_INLETS_OUTLETS and output_datasets:
         # Remove non-dataset objects like Temp tables (unless passed by user)
-        output_datasets = (
-            output_datasets if isinstance(output_datasets, list) else [output_datasets]
-        )
-        output_datasets = [
-            output_ds for output_ds in output_datasets if isinstance(output_ds, Dataset)
-        ]
+        output_datasets = output_datasets if isinstance(output_datasets, list) else [output_datasets]
+        output_datasets = [output_ds for output_ds in output_datasets if isinstance(output_ds, Dataset)]
 
         outlets = kwargs.get("outlets", output_datasets)
         kwargs.update({"outlets": outlets})

--- a/python-sdk/src/astro/custom_backend/astro_custom_backend.py
+++ b/python-sdk/src/astro/custom_backend/astro_custom_backend.py
@@ -2,6 +2,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 from airflow.models.xcom import BaseXCom
+
 from astro.custom_backend.serializer import deserialize, serialize
 
 if TYPE_CHECKING:

--- a/python-sdk/src/astro/custom_backend/serializer.py
+++ b/python-sdk/src/astro/custom_backend/serializer.py
@@ -8,6 +8,7 @@ from pickle import UnpicklingError
 from typing import Any
 
 import pandas
+
 from astro.files import File
 from astro.table import Table, TempTable
 

--- a/python-sdk/src/astro/databases/__init__.py
+++ b/python-sdk/src/astro/databases/__init__.py
@@ -7,9 +7,7 @@ from astro.utils.path import get_class_name, get_dict_with_module_names_to_dot_n
 if TYPE_CHECKING:
     from astro.databases.base import BaseDatabase
 
-DEFAULT_CONN_TYPE_TO_MODULE_PATH = get_dict_with_module_names_to_dot_notations(
-    Path(__file__)
-)
+DEFAULT_CONN_TYPE_TO_MODULE_PATH = get_dict_with_module_names_to_dot_notations(Path(__file__))
 CUSTOM_CONN_TYPE_TO_MODULE_PATH = {
     "gcpbigquery": DEFAULT_CONN_TYPE_TO_MODULE_PATH["bigquery"],
     "google_cloud_platform": DEFAULT_CONN_TYPE_TO_MODULE_PATH["bigquery"],

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -4,18 +4,6 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 import sqlalchemy
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
-from astro.constants import (
-    DEFAULT_CHUNK_SIZE,
-    FileLocation,
-    FileType,
-    LoadExistStrategy,
-    MergeConflictStrategy,
-)
-from astro.databases.base import BaseDatabase
-from astro.exceptions import DatabaseCustomError
-from astro.files import File
-from astro.settings import REDSHIFT_SCHEMA
-from astro.table import BaseTable, Metadata, Table
 from redshift_connector.error import (
     ArrayContentNotHomogenousError,
     ArrayContentNotSupportedError,
@@ -30,6 +18,19 @@ from redshift_connector.error import (
 )
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
+
+from astro.constants import (
+    DEFAULT_CHUNK_SIZE,
+    FileLocation,
+    FileType,
+    LoadExistStrategy,
+    MergeConflictStrategy,
+)
+from astro.databases.base import BaseDatabase
+from astro.exceptions import DatabaseCustomError
+from astro.files import File
+from astro.settings import REDSHIFT_SCHEMA
+from astro.table import BaseTable, Metadata, Table
 
 DEFAULT_CONN_ID = RedshiftSQLHook.default_conn_name
 NATIVE_PATHS_SUPPORTED_FILE_TYPES = {
@@ -117,11 +118,7 @@ class RedshiftDatabase(BaseDatabase):
         :param table: Details of the table we want to check that exists
         """
         inspector = sqlalchemy.inspect(self.sqlalchemy_engine)
-        return bool(
-            inspector.dialect.has_table(
-                self.connection, table.name, schema=table.metadata.schema
-            )
-        )
+        return bool(inspector.dialect.has_table(self.connection, table.name, schema=table.metadata.schema))
 
     def load_pandas_dataframe_to_table(
         self,
@@ -195,15 +192,15 @@ class RedshiftDatabase(BaseDatabase):
                 source_to_target_map_source_columns[1:],
                 source_to_target_map_target_columns[1:],
             ):
-                update_statement += (
-                    f", {target_column}={source_table_name}.{source_column} "
-                )
+                update_statement += f", {target_column}={source_table_name}.{source_column} "
             update_statement += (
                 f"FROM {source_table_name} "
                 f"WHERE {stage_table_name}.{conflict_column}={source_table_name}.{conflict_column} "
             )
             for conflict_col in target_conflict_columns[1:]:
-                update_statement += f"AND {stage_table_name}.{conflict_col}={source_table_name}.{conflict_col} "
+                update_statement += (
+                    f"AND {stage_table_name}.{conflict_col}={source_table_name}.{conflict_col} "
+                )
             conflict_statements = [update_statement, insert_statement]
 
         return conflict_statements
@@ -231,9 +228,7 @@ class RedshiftDatabase(BaseDatabase):
         stage_table_name = self.get_table_qualified_name(Table())
 
         source_to_target_map_source_columns = list(source_to_target_columns_map.keys())
-        source_to_target_map_target_columns = list(
-            source_to_target_columns_map.values()
-        )
+        source_to_target_map_target_columns = list(source_to_target_columns_map.values())
         source_table_all_columns = self.hook.run(
             f"select col_name from pg_get_cols('{source_table_name}') "
             f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
@@ -244,24 +239,15 @@ class RedshiftDatabase(BaseDatabase):
             f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
             handler=lambda x: [y[0] for y in x.fetchall()],
         )
-        target_table_all_columns_string = ",".join(
-            map(str, source_to_target_map_target_columns)
-        )
-        source_table_all_columns_string = ",".join(
-            map(str, source_to_target_map_source_columns)
-        )
+        target_table_all_columns_string = ",".join(map(str, source_to_target_map_target_columns))
+        source_table_all_columns_string = ",".join(map(str, source_to_target_map_source_columns))
         for column in target_table_all_columns:
-            if (
-                column not in source_to_target_map_target_columns
-                and column in source_table_all_columns
-            ):
+            if column not in source_to_target_map_target_columns and column in source_table_all_columns:
                 target_table_all_columns_string += f",{column}"
                 source_table_all_columns_string += f",{column}"
 
         begin_transaction = "BEGIN TRANSACTION"
-        create_temp_table = (
-            f"CREATE TEMP TABLE {stage_table_name} (LIKE {target_table_name})"
-        )
+        create_temp_table = f"CREATE TEMP TABLE {stage_table_name} (LIKE {target_table_name})"
         insert_into_stage_table = (
             f"INSERT INTO {stage_table_name}({target_table_all_columns_string}) "
             f"SELECT {target_table_all_columns_string} FROM {target_table_name}"
@@ -277,9 +263,7 @@ class RedshiftDatabase(BaseDatabase):
             target_conflict_columns,
         )
         truncate_target_table = f"TRUNCATE {target_table_name}"
-        insert_into_target_table = (
-            f"INSERT INTO {target_table_name} SELECT * FROM {stage_table_name}"
-        )
+        insert_into_target_table = f"INSERT INTO {target_table_name} SELECT * FROM {stage_table_name}"
         drop_stage_table = f"DROP TABLE {stage_table_name}"
         end_transaction = "END TRANSACTION"
 
@@ -299,9 +283,7 @@ class RedshiftDatabase(BaseDatabase):
             for statement in statements:
                 cursor.execute(statement)
 
-    def is_native_load_file_available(
-        self, source_file: File, target_table: BaseTable
-    ) -> bool:
+    def is_native_load_file_available(self, source_file: File, target_table: BaseTable) -> bool:
         """
         Check if there is an optimised path for source to destination.
 

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -8,6 +8,12 @@ from typing import Any, Callable, Mapping
 import pandas as pd
 import sqlalchemy
 from airflow.hooks.dbapi import DbApiHook
+from pandas.io.sql import SQLDatabase
+from sqlalchemy import column, insert, select
+from sqlalchemy.sql import ClauseElement
+from sqlalchemy.sql.elements import ColumnClause
+from sqlalchemy.sql.schema import Table as SqlaTable
+
 from astro.constants import (
     DEFAULT_CHUNK_SIZE,
     ColumnCapitalization,
@@ -23,11 +29,6 @@ from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
 from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.table import BaseTable, Metadata
-from pandas.io.sql import SQLDatabase
-from sqlalchemy import column, insert, select
-from sqlalchemy.sql import ClauseElement
-from sqlalchemy.sql.elements import ColumnClause
-from sqlalchemy.sql.schema import Table as SqlaTable
 
 
 class BaseDatabase(ABC):
@@ -57,9 +58,7 @@ class BaseDatabase(ABC):
     NATIVE_PATHS: dict[Any, Any] = {}
     NATIVE_LOAD_EXCEPTIONS: Any = DatabaseCustomError
     DEFAULT_SCHEMA = SCHEMA
-    NATIVE_AUTODETECT_SCHEMA_CONFIG: Mapping[
-        FileLocation, Mapping[str, list[FileType] | Callable]
-    ] = {}
+    NATIVE_AUTODETECT_SCHEMA_CONFIG: Mapping[FileLocation, Mapping[str, list[FileType] | Callable]] = {}
     FILE_PATTERN_BASED_AUTODETECT_SCHEMA_SUPPORTED: set[FileLocation] = set()
 
     def __init__(self, conn_id: str):
@@ -131,8 +130,7 @@ class BaseDatabase(ABC):
         """
         sqla_table = self.get_sqla_table(table)
         return all(
-            any(sqla_column.name == column for sqla_column in sqla_table.columns)
-            for column in columns
+            any(sqla_column.name == column for sqla_column in sqla_table.columns) for column in columns
         )
 
     def table_exists(self, table: BaseTable) -> bool:
@@ -228,9 +226,7 @@ class BaseDatabase(ABC):
         :param table: The table to be created.
         :param file: File used to infer the new table columns.
         """
-        raise NotImplementedError(
-            "Missing implementation of native schema autodetection."
-        )
+        raise NotImplementedError("Missing implementation of native schema autodetection.")
 
     def create_table_using_schema_autodetection(
         self,
@@ -255,9 +251,7 @@ class BaseDatabase(ABC):
                 )
             source_dataframe = dataframe
         else:
-            source_dataframe = file.export_to_dataframe(
-                nrows=LOAD_TABLE_AUTODETECT_ROWS_COUNT
-            )
+            source_dataframe = file.export_to_dataframe(nrows=LOAD_TABLE_AUTODETECT_ROWS_COUNT)
 
         db = SQLDatabase(engine=self.sqlalchemy_engine)
         db.prep_table(
@@ -301,9 +295,7 @@ class BaseDatabase(ABC):
         elif file and self.is_native_autodetect_schema_available(file):
             self.create_table_using_native_schema_autodetection(table, file)
         else:
-            self.create_table_using_schema_autodetection(
-                table, file, dataframe, columns_names_capitalization
-            )
+            self.create_table_using_schema_autodetection(table, file, dataframe, columns_names_capitalization)
 
     def create_table_from_select_statement(
         self,
@@ -329,9 +321,7 @@ class BaseDatabase(ABC):
 
         :param table: The table to be deleted.
         """
-        statement = self._drop_table_statement.format(
-            self.get_table_qualified_name(table)
-        )
+        statement = self._drop_table_statement.format(self.get_table_qualified_name(table))
         self.run_sql(statement)
 
     # ---------------------------------------------------------
@@ -356,21 +346,13 @@ class BaseDatabase(ABC):
         :param if_exists:  Overwrite file if exists
         :param use_native_support: Use native support for data transfer if available on the destination
         """
-        is_schema_autodetection_supported = (
-            self.check_schema_autodetection_is_supported(source_file=file)
-        )
+        is_schema_autodetection_supported = self.check_schema_autodetection_is_supported(source_file=file)
         is_file_pattern_based_schema_autodetection_supported = (
-            self.check_file_pattern_based_schema_autodetection_is_supported(
-                source_file=file
-            )
+            self.check_file_pattern_based_schema_autodetection_is_supported(source_file=file)
         )
         if if_exists == "replace":
             self.drop_table(table)
-        if (
-            use_native_support
-            and is_schema_autodetection_supported
-            and not file.is_pattern()
-        ):
+        if use_native_support and is_schema_autodetection_supported and not file.is_pattern():
             return
         if (
             use_native_support
@@ -588,12 +570,8 @@ class BaseDatabase(ABC):
             target_columns = [column(col) for col in target_table_sqla.c.keys()]
             source_columns = target_columns
         else:
-            target_columns = [
-                column(col) for col in source_to_target_columns_map.values()
-            ]
-            source_columns = [
-                column(col) for col in source_to_target_columns_map.keys()
-            ]
+            target_columns = [column(col) for col in source_to_target_columns_map.values()]
+            source_columns = [column(col) for col in source_to_target_columns_map.keys()]
 
         sel = select(source_columns).select_from(source_table_sqla)
         # TODO: We should fix the following Type Error
@@ -650,14 +628,10 @@ class BaseDatabase(ABC):
 
         if self.table_exists(source_table):
             sqla_table = self.get_sqla_table(source_table)
-            return pd.read_sql(
-                sql=sqla_table.select(**select_kwargs), con=self.sqlalchemy_engine
-            )
+            return pd.read_sql(sql=sqla_table.select(**select_kwargs), con=self.sqlalchemy_engine)
 
         table_qualified_name = self.get_table_qualified_name(source_table)
-        raise NonExistentTableException(
-            f"The table {table_qualified_name} does not exist"
-        )
+        raise NonExistentTableException(f"The table {table_qualified_name} does not exist")
 
     def export_table_to_file(
         self,
@@ -772,9 +746,7 @@ class BaseDatabase(ABC):
 
         :param source_file: File from which we need to transfer data
         """
-        filetype_supported = self.NATIVE_AUTODETECT_SCHEMA_CONFIG.get(
-            source_file.location.location_type
-        )
+        filetype_supported = self.NATIVE_AUTODETECT_SCHEMA_CONFIG.get(source_file.location.location_type)
 
         source_filetype = (
             source_file
@@ -791,9 +763,7 @@ class BaseDatabase(ABC):
         location_type = self.NATIVE_PATHS.get(source_file.location.location_type)
         return bool(location_type and is_source_filetype_supported)
 
-    def check_file_pattern_based_schema_autodetection_is_supported(
-        self, source_file: File
-    ) -> bool:
+    def check_file_pattern_based_schema_autodetection_is_supported(self, source_file: File) -> bool:
         """
         Checks if schema autodetection is handled natively by the database for file
         patterns and prefixes.
@@ -801,7 +771,6 @@ class BaseDatabase(ABC):
         :param source_file: File from which we need to transfer data
         """
         is_file_pattern_based_schema_autodetection_supported = (
-            source_file.location.location_type
-            in self.FILE_PATTERN_BASED_AUTODETECT_SCHEMA_SUPPORTED
+            source_file.location.location_type in self.FILE_PATTERN_BASED_AUTODETECT_SCHEMA_SUPPORTED
         )
         return is_file_pattern_based_schema_autodetection_supported

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -6,30 +6,14 @@ from typing import Any, Callable, Mapping
 
 import pandas as pd
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
-from airflow.providers.google.cloud.hooks.bigquery_dts import (
-    BiqQueryDataTransferServiceHook,
-)
-from astro.constants import (
-    DEFAULT_CHUNK_SIZE,
-    FileLocation,
-    FileType,
-    LoadExistStrategy,
-    MergeConflictStrategy,
-)
-from astro.databases.base import BaseDatabase
-from astro.exceptions import DatabaseCustomError
-from astro.files import File
-from astro.settings import BIGQUERY_SCHEMA
-from astro.table import BaseTable, Metadata
+from airflow.providers.google.cloud.hooks.bigquery_dts import BiqQueryDataTransferServiceHook
 from google.api_core.exceptions import (
     ClientError,
     Conflict,
     Forbidden,
     GoogleAPIError,
     InvalidArgument,
-)
-from google.api_core.exceptions import NotFound as GoogleNotFound
-from google.api_core.exceptions import (
+    NotFound as GoogleNotFound,
     ResourceExhausted,
     RetryError,
     ServerError,
@@ -50,6 +34,19 @@ from google.resumable_media import InvalidResponse
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
 from tenacity import retry, stop_after_attempt
+
+from astro.constants import (
+    DEFAULT_CHUNK_SIZE,
+    FileLocation,
+    FileType,
+    LoadExistStrategy,
+    MergeConflictStrategy,
+)
+from astro.databases.base import BaseDatabase
+from astro.exceptions import DatabaseCustomError
+from astro.files import File
+from astro.settings import BIGQUERY_SCHEMA
+from astro.table import BaseTable, Metadata
 
 DEFAULT_CONN_ID = BigQueryHook.default_conn_name
 NATIVE_PATHS_SUPPORTED_FILE_TYPES = {
@@ -73,9 +70,7 @@ class BigqueryDatabase(BaseDatabase):
         FileLocation.LOCAL: "load_local_file_to_table",
     }
 
-    NATIVE_AUTODETECT_SCHEMA_CONFIG: Mapping[
-        FileLocation, Mapping[str, list[FileType] | Callable]
-    ] = {
+    NATIVE_AUTODETECT_SCHEMA_CONFIG: Mapping[FileLocation, Mapping[str, list[FileType] | Callable]] = {
         FileLocation.GS: {
             "filetype": [FileType.CSV, FileType.NDJSON, FileType.PARQUET],
             "method": lambda table, file: None,
@@ -210,9 +205,7 @@ class BigqueryDatabase(BaseDatabase):
         target_table_name = self.get_table_qualified_name(target_table)
         source_table_name = self.get_table_qualified_name(source_table)
 
-        insert_statement = (
-            f"INSERT ({', '.join(target_columns)}) VALUES ({', '.join(source_columns)})"
-        )
+        insert_statement = f"INSERT ({', '.join(target_columns)}) VALUES ({', '.join(source_columns)})"
         merge_statement = (
             f"MERGE {target_table_name} T USING {source_table_name} S"
             f" ON {' AND '.join(f'T.{col}=S.{col}' for col in target_conflict_columns)}"
@@ -220,17 +213,12 @@ class BigqueryDatabase(BaseDatabase):
         )
         if if_conflicts == "update":
             update_statement_map = ", ".join(
-                f"T.{col}=S.{source_columns[idx]}"
-                for idx, col in enumerate(target_columns)
+                f"T.{col}=S.{source_columns[idx]}" for idx, col in enumerate(target_columns)
             )
             if not self.columns_exist(source_table, source_columns):
-                raise ValueError(
-                    f"Not all the columns provided exist for {source_table_name}!"
-                )
+                raise ValueError(f"Not all the columns provided exist for {source_table_name}!")
             if not self.columns_exist(target_table, target_columns):
-                raise ValueError(
-                    f"Not all the columns provided exist for {target_table_name}!"
-                )
+                raise ValueError(f"Not all the columns provided exist for {target_table_name}!")
             # Note: Ignoring below sql injection warning, as we validate that the table columns exist beforehand.
             update_statement = f"UPDATE SET {update_statement_map}"  # skipcq BAN-B608
             merge_statement += f" WHEN MATCHED THEN {update_statement}"
@@ -245,9 +233,7 @@ class BigqueryDatabase(BaseDatabase):
         :param file: File used to check the file type of to decide
             whether there is a native auto detection available for it.
         """
-        supported_config = self.NATIVE_AUTODETECT_SCHEMA_CONFIG.get(
-            file.location.location_type
-        )
+        supported_config = self.NATIVE_AUTODETECT_SCHEMA_CONFIG.get(file.location.location_type)
         if supported_config and file.type.name in supported_config["filetype"]:  # type: ignore
             return True
         return False
@@ -263,14 +249,10 @@ class BigqueryDatabase(BaseDatabase):
         :param table: The table to be created.
         :param file: File used to infer the new table columns.
         """
-        supported_config = self.NATIVE_AUTODETECT_SCHEMA_CONFIG.get(
-            file.location.location_type
-        )
+        supported_config = self.NATIVE_AUTODETECT_SCHEMA_CONFIG.get(file.location.location_type)
         return supported_config["method"](table=table, file=file)  # type: ignore
 
-    def is_native_load_file_available(
-        self, source_file: File, target_table: BaseTable
-    ) -> bool:
+    def is_native_load_file_available(self, source_file: File, target_table: BaseTable) -> bool:
         """
         Check if there is an optimised path for source to destination.
 
@@ -402,9 +384,7 @@ class BigqueryDatabase(BaseDatabase):
         try:
             return str(self.hook.project_id)
         except AttributeError as exe:
-            raise DatabaseCustomError(
-                f"conn_id {target_table.conn_id} has no project id"
-            ) from exe
+            raise DatabaseCustomError(f"conn_id {target_table.conn_id} has no project id") from exe
 
     def load_local_file_to_table(
         self,
@@ -497,18 +477,14 @@ class S3ToBigqueryDataTransfer:
             run_id = self.run_transfer_now(transfer_config_id)
 
             # Poll Bigquery for status of transfer job
-            run_info = self.get_transfer_info(
-                run_id=run_id, transfer_config_id=transfer_config_id
-            )
+            run_info = self.get_transfer_info(run_id=run_id, transfer_config_id=transfer_config_id)
 
             # Note - Super set of states that indicate the job is running.
             # This needs to be a super set as this if we miss on any running state, code will go into infinite loop.
             running_states = [TransferState.PENDING, TransferState.RUNNING]
 
             while run_info.state in running_states:
-                run_info = self.get_transfer_info(
-                    run_id=run_id, transfer_config_id=transfer_config_id
-                )
+                run_info = self.get_transfer_info(run_id=run_id, transfer_config_id=transfer_config_id)
                 time.sleep(self.poll_duration)
 
             if run_info.state != TransferState.SUCCEEDED:
@@ -581,6 +557,4 @@ class S3ToBigqueryDataTransfer:
     @retry(stop=stop_after_attempt(3))
     def get_transfer_info(self, run_id: str, transfer_config_id: str):
         """Get transfer job info"""
-        return self.client.get_transfer_run(
-            run_id=run_id, transfer_config_id=transfer_config_id
-        )
+        return self.client.get_transfer_run(run_id=run_id, transfer_config_id=transfer_config_id)

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -7,12 +7,13 @@ from contextlib import closing
 import pandas as pd
 import sqlalchemy
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from psycopg2 import sql as postgres_sql
+
 from astro.constants import DEFAULT_CHUNK_SIZE, LoadExistStrategy, MergeConflictStrategy
 from astro.databases.base import BaseDatabase
 from astro.files import File
 from astro.settings import POSTGRES_SCHEMA
 from astro.table import BaseTable, Metadata
-from psycopg2 import sql as postgres_sql
 
 DEFAULT_CONN_ID = PostgresHook.default_conn_name
 
@@ -157,7 +158,9 @@ class PostgresDatabase(BaseDatabase):
             schema = table.metadata.schema
             return (schema, table.name) if schema else (table.name,)
 
-        statement = "INSERT INTO {target_table} ({target_columns}) SELECT {source_columns} FROM {source_table}"
+        statement = (
+            "INSERT INTO {target_table} ({target_columns}) SELECT {source_columns} FROM {source_table}"
+        )
 
         source_columns = list(source_to_target_columns_map.keys())
         target_columns = list(source_to_target_columns_map.values())

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -10,6 +10,20 @@ from typing import Any
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from snowflake.connector import pandas_tools
+from snowflake.connector.errors import (
+    DatabaseError,
+    DataError,
+    ForbiddenError,
+    IntegrityError,
+    InternalError,
+    NotSupportedError,
+    OperationalError,
+    ProgrammingError,
+    RequestTimeoutError,
+    ServiceUnavailableError,
+)
+
 from astro import settings
 from astro.constants import (
     DEFAULT_CHUNK_SIZE,
@@ -24,19 +38,6 @@ from astro.exceptions import DatabaseCustomError
 from astro.files import File
 from astro.settings import SNOWFLAKE_SCHEMA
 from astro.table import BaseTable, Metadata
-from snowflake.connector import pandas_tools
-from snowflake.connector.errors import (
-    DatabaseError,
-    DataError,
-    ForbiddenError,
-    IntegrityError,
-    InternalError,
-    NotSupportedError,
-    OperationalError,
-    ProgrammingError,
-    RequestTimeoutError,
-    ServiceUnavailableError,
-)
 
 DEFAULT_CONN_ID = SnowflakeHook.default_conn_name
 
@@ -99,9 +100,7 @@ class SnowflakeFileFormat:
         return (
             "file_format_"
             + random.choice(string.ascii_lowercase)
-            + "".join(
-                random.choice(string.ascii_lowercase + string.digits) for _ in range(7)
-            )
+            + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
         )
 
     def set_file_type_from_file(self, file: File) -> None:
@@ -172,9 +171,7 @@ class SnowflakeStage:
         return (
             "stage_"
             + random.choice(string.ascii_lowercase)
-            + "".join(
-                random.choice(string.ascii_lowercase + string.digits) for _ in range(7)
-            )
+            + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
         )
 
     def set_url_from_file(self, file: File) -> None:
@@ -322,9 +319,7 @@ class SnowflakeDatabase(BaseDatabase):
     # ---------------------------------------------------------
 
     @staticmethod
-    def _create_stage_auth_sub_statement(
-        file: File, storage_integration: str | None = None
-    ) -> str:
+    def _create_stage_auth_sub_statement(file: File, storage_integration: str | None = None) -> str:
         """
         Create authentication-related line for the Snowflake CREATE STAGE.
         Raise an exception if it is not defined.
@@ -380,9 +375,7 @@ class SnowflakeDatabase(BaseDatabase):
             `Snowflake official documentation on stage creation
             <https://docs.snowflake.com/en/sql-reference/sql/create-stage.html>`_
         """
-        auth = self._create_stage_auth_sub_statement(
-            file=file, storage_integration=storage_integration
-        )
+        auth = self._create_stage_auth_sub_statement(file=file, storage_integration=storage_integration)
 
         metadata = metadata or self.default_metadata
         stage = SnowflakeStage(metadata=metadata)
@@ -415,9 +408,7 @@ class SnowflakeDatabase(BaseDatabase):
         try:
             self.hook.run(sql_statement)
         except ProgrammingError:
-            logging.error(
-                "Stage '%s' does not exist or not authorized.", stage.qualified_name
-            )
+            logging.error("Stage '%s' does not exist or not authorized.", stage.qualified_name)
             return False
         return True
 
@@ -443,12 +434,9 @@ class SnowflakeDatabase(BaseDatabase):
         :param file: File used to check the file type of to decide
             whether there is a native auto detection available for it.
         """
-        is_file_type_supported = (
-            file.type.name in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_TYPES
-        )
+        is_file_type_supported = file.type.name in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_TYPES
         is_file_location_supported = (
-            file.location.location_type
-            in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_LOCATIONS
+            file.location.location_type in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_LOCATIONS
         )
         return is_file_type_supported and is_file_location_supported
 
@@ -517,18 +505,14 @@ class SnowflakeDatabase(BaseDatabase):
         # we are handling this more gracefully in a separate PR
         super().create_table_using_schema_autodetection(table, dataframe=dataframe)
 
-    def is_native_load_file_available(
-        self, source_file: File, target_table: BaseTable
-    ) -> bool:
+    def is_native_load_file_available(self, source_file: File, target_table: BaseTable) -> bool:
         """
         Check if there is an optimised path for source to destination.
 
         :param source_file: File from which we need to transfer data
         :param target_table: Table that needs to be populated with file data
         """
-        is_file_type_supported = (
-            source_file.type.name in NATIVE_LOAD_SUPPORTED_FILE_TYPES
-        )
+        is_file_type_supported = source_file.type.name in NATIVE_LOAD_SUPPORTED_FILE_TYPES
         is_file_location_supported = (
             source_file.location.location_type in NATIVE_LOAD_SUPPORTED_FILE_LOCATIONS
         )
@@ -568,15 +552,11 @@ class SnowflakeDatabase(BaseDatabase):
         """
         native_support_kwargs = native_support_kwargs or {}
         storage_integration = native_support_kwargs.get("storage_integration")
-        stage = self.create_stage(
-            file=source_file, storage_integration=storage_integration
-        )
+        stage = self.create_stage(file=source_file, storage_integration=storage_integration)
 
         table_name = self.get_table_qualified_name(target_table)
         file_path = os.path.basename(source_file.path) or ""
-        sql_statement = (
-            f"COPY INTO {table_name} FROM @{stage.qualified_name}/{file_path}"
-        )
+        sql_statement = f"COPY INTO {table_name} FROM @{stage.qualified_name}/{file_path}"
         try:
             self.hook.run(sql_statement)
         except (ValueError, AttributeError) as exe:
@@ -725,20 +705,15 @@ class SnowflakeDatabase(BaseDatabase):
         (
             source_table_identifier,
             source_table_param,
-        ) = self.get_sqlalchemy_template_table_identifier_and_parameter(
-            source_table, "source_table"
-        )
+        ) = self.get_sqlalchemy_template_table_identifier_and_parameter(source_table, "source_table")
 
         (
             target_table_identifier,
             target_table_param,
-        ) = self.get_sqlalchemy_template_table_identifier_and_parameter(
-            target_table, "target_table"
-        )
+        ) = self.get_sqlalchemy_template_table_identifier_and_parameter(target_table, "target_table")
 
         statement = (
-            f"merge into {target_table_identifier} using {source_table_identifier} "
-            + "on {merge_clauses}"
+            f"merge into {target_table_identifier} using {source_table_identifier} " + "on {merge_clauses}"
         )
 
         merge_target_dict = {
@@ -774,9 +749,7 @@ class SnowflakeDatabase(BaseDatabase):
                 ]
             )
             statement = statement.replace("{merge_vals}", merge_statement)
-        statement += (
-            " when not matched then insert({target_columns}) values ({append_columns})"
-        )
+        statement += " when not matched then insert({target_columns}) values ({append_columns})"
         statement = statement.replace(
             "{target_columns}",
             ",".join(f"{target_table_name}.{t}" for t in target_cols),

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
+from sqlalchemy import MetaData as SqlaMetaData, create_engine
+from sqlalchemy.engine.base import Engine
+from sqlalchemy.sql.schema import Table as SqlaTable
+
 from astro.constants import MergeConflictStrategy
 from astro.databases.base import BaseDatabase
 from astro.table import BaseTable, Metadata
-from sqlalchemy import MetaData as SqlaMetaData
-from sqlalchemy import create_engine
-from sqlalchemy.engine.base import Engine
-from sqlalchemy.sql.schema import Table as SqlaTable
 
 DEFAULT_CONN_ID = SqliteHook.default_conn_name
 
@@ -107,9 +107,7 @@ class SqliteDatabase(BaseDatabase):
 
         append_column_names = list(source_to_target_columns_map.keys())
         target_column_names = list(source_to_target_columns_map.values())
-        update_statements = [
-            f"{col_name}=EXCLUDED.{col_name}" for col_name in target_column_names
-        ]
+        update_statements = [f"{col_name}=EXCLUDED.{col_name}" for col_name in target_column_names]
 
         query = statement.format(
             target_columns=",".join(target_column_names),
@@ -128,6 +126,4 @@ class SqliteDatabase(BaseDatabase):
 
         :param table: Astro Table to be converted to SQLAlchemy table instance
         """
-        return SqlaTable(
-            table.name, SqlaMetaData(), autoload_with=self.sqlalchemy_engine
-        )
+        return SqlaTable(table.name, SqlaMetaData(), autoload_with=self.sqlalchemy_engine)

--- a/python-sdk/src/astro/files/__init__.py
+++ b/python-sdk/src/astro/files/__init__.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from airflow.hooks.base import BaseHook
+
 from astro.files.base import File  # noqa: F401 # skipcq: PY-W2000
 from astro.files.base import resolve_file_path_pattern  # noqa: F401 # skipcq: PY-W2000
 

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -6,12 +6,13 @@ import pathlib
 import pandas as pd
 import smart_open
 from airflow.utils.log.logging_mixin import LoggingMixin
+from attr import define, field
+
 from astro import constants
 from astro.airflow.datasets import Dataset
 from astro.files.locations import create_file_location
 from astro.files.locations.base import BaseFileLocation
 from astro.files.types import FileType, create_file_type
-from attr import define, field
 
 
 @define
@@ -80,9 +81,7 @@ class File(LoggingMixin, Dataset):
         """
         return not pathlib.PosixPath(self.path).suffix
 
-    def create_from_dataframe(
-        self, df: pd.DataFrame, store_as_dataframe: bool = True
-    ) -> None:
+    def create_from_dataframe(self, df: pd.DataFrame, store_as_dataframe: bool = True) -> None:
         """Create a file in the desired location using the values of a dataframe.
 
         :param store_as_dataframe: Whether the data should later be deserialized as a dataframe or as a file containing
@@ -90,17 +89,13 @@ class File(LoggingMixin, Dataset):
         :param df: pandas dataframe
         """
         self.is_dataframe = store_as_dataframe
-        with smart_open.open(
-            self.path, mode="wb", transport_params=self.location.transport_params
-        ) as stream:
+        with smart_open.open(self.path, mode="wb", transport_params=self.location.transport_params) as stream:
             self.type.create_from_dataframe(stream=stream, df=df)
 
     def export_to_dataframe(self, **kwargs) -> pd.DataFrame:
         """Read file from all supported location and convert them into dataframes."""
         mode = "rb" if self.is_binary() else "r"
-        with smart_open.open(
-            self.path, mode=mode, transport_params=self.location.transport_params
-        ) as stream:
+        with smart_open.open(self.path, mode=mode, transport_params=self.location.transport_params) as stream:
             return self.type.export_to_dataframe(stream, **kwargs)
 
     def _convert_remote_file_to_byte_stream(self) -> io.IOBase:
@@ -116,9 +111,7 @@ class File(LoggingMixin, Dataset):
 
         mode = "rb" if self.is_binary() else "r"
         remote_obj_buffer = io.BytesIO() if self.is_binary() else io.StringIO()
-        with smart_open.open(
-            self.path, mode=mode, transport_params=self.location.transport_params
-        ) as stream:
+        with smart_open.open(self.path, mode=mode, transport_params=self.location.transport_params) as stream:
             remote_obj_buffer.write(stream.read())
         remote_obj_buffer.seek(0)
         return remote_obj_buffer
@@ -130,9 +123,7 @@ class File(LoggingMixin, Dataset):
         before exporting to a dataframe. We've found a sizable speed improvement with this optimization.
         """
 
-        return self.type.export_to_dataframe(
-            self._convert_remote_file_to_byte_stream(), **kwargs
-        )
+        return self.type.export_to_dataframe(self._convert_remote_file_to_byte_stream(), **kwargs)
 
     def exists(self) -> bool:
         """Check if the file exists or not"""
@@ -186,9 +177,7 @@ class File(LoggingMixin, Dataset):
     @classmethod
     def from_json(cls, serialized_object: dict):
         filetype = (
-            constants.FileType(serialized_object["filetype"])
-            if serialized_object.get("filetype")
-            else None
+            constants.FileType(serialized_object["filetype"]) if serialized_object.get("filetype") else None
         )
         return File(
             conn_id=serialized_object["conn_id"],

--- a/python-sdk/src/astro/files/locations/__init__.py
+++ b/python-sdk/src/astro/files/locations/__init__.py
@@ -6,9 +6,7 @@ from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
 from astro.utils.path import get_class_name, get_dict_with_module_names_to_dot_notations
 
-DEFAULT_CONN_TYPE_TO_MODULE_PATH = get_dict_with_module_names_to_dot_notations(
-    Path(__file__)
-)
+DEFAULT_CONN_TYPE_TO_MODULE_PATH = get_dict_with_module_names_to_dot_notations(Path(__file__))
 DEFAULT_CONN_TYPE_TO_MODULE_PATH["https"] = DEFAULT_CONN_TYPE_TO_MODULE_PATH["http"]
 DEFAULT_CONN_TYPE_TO_MODULE_PATH["gs"] = DEFAULT_CONN_TYPE_TO_MODULE_PATH["gcs"]
 

--- a/python-sdk/src/astro/files/locations/amazon/s3.py
+++ b/python-sdk/src/astro/files/locations/amazon/s3.py
@@ -4,6 +4,7 @@ import os
 from urllib.parse import urlparse, urlunparse
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
 
@@ -37,9 +38,7 @@ class S3Location(BaseFileLocation):
         bucket_name = url.netloc
         prefix = url.path[1:]
         prefixes = self.hook.list_keys(bucket_name=bucket_name, prefix=prefix)
-        paths = [
-            urlunparse((url.scheme, url.netloc, keys, "", "", "")) for keys in prefixes
-        ]
+        paths = [urlunparse((url.scheme, url.netloc, keys, "", "", "")) for keys in prefixes]
         return paths
 
     @property

--- a/python-sdk/src/astro/files/locations/base.py
+++ b/python-sdk/src/astro/files/locations/base.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import smart_open
+
 from astro.constants import FileLocation
 
 
@@ -68,11 +69,7 @@ class BaseFileLocation(ABC):
             result = urlparse(path)
 
             if not (
-                (
-                    result.scheme
-                    and result.netloc
-                    and (result.port or result.port is None)
-                )
+                (result.scheme and result.netloc and (result.port or result.port is None))
                 or os.path.isfile(path)
                 or BaseFileLocation.check_non_existing_local_file_path(path)
                 or glob.glob(result.path)
@@ -106,17 +103,13 @@ class BaseFileLocation(ABC):
             try:
                 location = FileLocation(file_scheme)
             except ValueError:
-                raise ValueError(
-                    f"Unsupported scheme '{file_scheme}' from path '{path}'"
-                )
+                raise ValueError(f"Unsupported scheme '{file_scheme}' from path '{path}'")
         return location
 
     def exists(self) -> bool:
         """Check if the file exists or not"""
         try:
-            with smart_open.open(
-                self.path, mode="r", transport_params=self.transport_params
-            ):
+            with smart_open.open(self.path, mode="r", transport_params=self.transport_params):
                 return True
         except OSError:
             return False

--- a/python-sdk/src/astro/files/locations/google/gcs.py
+++ b/python-sdk/src/astro/files/locations/google/gcs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from urllib.parse import urlparse, urlunparse
 
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
 
@@ -29,9 +30,7 @@ class GCSLocation(BaseFileLocation):
         bucket_name = url.netloc
         prefix = url.path[1:]
         prefixes = self.hook.list(bucket_name=bucket_name, prefix=prefix)
-        paths = [
-            urlunparse((url.scheme, url.netloc, keys, "", "", "")) for keys in prefixes
-        ]
+        paths = [urlunparse((url.scheme, url.netloc, keys, "", "", "")) for keys in prefixes]
         return paths
 
     @property

--- a/python-sdk/src/astro/files/operators/files.py
+++ b/python-sdk/src/astro/files/operators/files.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models import BaseOperator
+
 from astro.files.base import File
 from astro.files.locations import create_file_location
 from astro.utils.typing_compat import Context
@@ -31,7 +32,5 @@ class ListFileOperator(BaseOperator):
         location = create_file_location(self.path, self.conn_id)
         # Get list of files excluding folders
         return [
-            File(path=path, conn_id=location.conn_id)
-            for path in location.paths
-            if not path.endswith("/")
+            File(path=path, conn_id=location.conn_id) for path in location.paths if not path.endswith("/")
         ]

--- a/python-sdk/src/astro/files/types/csv.py
+++ b/python-sdk/src/astro/files/types/csv.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 
 import pandas as pd
+
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
@@ -11,9 +12,7 @@ from astro.utils.dataframe import convert_columns_names_capitalization
 class CSVFileType(FileType):
     """Concrete implementation to handle CSV file type"""
 
-    def export_to_dataframe(
-        self, stream, columns_names_capitalization="original", **kwargs
-    ) -> pd.DataFrame:
+    def export_to_dataframe(self, stream, columns_names_capitalization="original", **kwargs) -> pd.DataFrame:
         """read csv file from one of the supported locations and return dataframe
 
         :param stream: file stream object

--- a/python-sdk/src/astro/files/types/json.py
+++ b/python-sdk/src/astro/files/types/json.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 
 import pandas as pd
+
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization

--- a/python-sdk/src/astro/files/types/ndjson.py
+++ b/python-sdk/src/astro/files/types/ndjson.py
@@ -4,8 +4,8 @@ import io
 import json
 
 import pandas as pd
-from astro.constants import DEFAULT_CHUNK_SIZE
-from astro.constants import FileType as FileTypeConstants
+
+from astro.constants import DEFAULT_CHUNK_SIZE, FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
 
@@ -13,9 +13,7 @@ from astro.utils.dataframe import convert_columns_names_capitalization
 class NDJSONFileType(FileType):
     """Concrete implementation to handle NDJSON file type"""
 
-    def export_to_dataframe(
-        self, stream, columns_names_capitalization="original", **kwargs
-    ):
+    def export_to_dataframe(self, stream, columns_names_capitalization="original", **kwargs):
         """read ndjson file from one of the supported locations and return dataframe
 
         :param stream: file stream object
@@ -41,9 +39,7 @@ class NDJSONFileType(FileType):
         return FileTypeConstants.NDJSON
 
     @staticmethod
-    def flatten(
-        normalize_config: dict | None, stream: io.TextIOWrapper, **kwargs
-    ) -> pd.DataFrame:
+    def flatten(normalize_config: dict | None, stream: io.TextIOWrapper, **kwargs) -> pd.DataFrame:
         """
         Flatten the nested ndjson/json.
 
@@ -76,9 +72,7 @@ class NDJSONFileType(FileType):
             else:
                 extra_rows = []
 
-            df = pd.json_normalize(
-                [json.loads(row) for row in rows], **normalize_config
-            )
+            df = pd.json_normalize([json.loads(row) for row in rows], **normalize_config)
             result_df.append(df)
 
             row_count = row_count + df.shape[0]

--- a/python-sdk/src/astro/files/types/parquet.py
+++ b/python-sdk/src/astro/files/types/parquet.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 
 import pandas as pd
+
 from astro.constants import FileType as FileTypeConstants
 from astro.files.types.base import FileType
 from astro.utils.dataframe import convert_columns_names_capitalization
@@ -11,9 +12,7 @@ from astro.utils.dataframe import convert_columns_names_capitalization
 class ParquetFileType(FileType):
     """Concrete implementation to handle Parquet file type"""
 
-    def export_to_dataframe(
-        self, stream, columns_names_capitalization="original", **kwargs
-    ):
+    def export_to_dataframe(self, stream, columns_names_capitalization="original", **kwargs):
         """read parquet file from one of the supported locations and return dataframe
 
         :param stream: file stream object

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -1,6 +1,7 @@
 import tempfile
 
 from airflow.configuration import conf
+
 from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
@@ -11,9 +12,7 @@ REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHE
 
 
 DATAFRAME_STORAGE_CONN_ID = conf.get("astro_sdk", "xcom_storage_conn_id", fallback=None)
-DATAFRAME_STORAGE_URL = conf.get(
-    "astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir()
-)
+DATAFRAME_STORAGE_URL = conf.get("astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir())
 STORE_DATA_LOCAL_DEV = conf.get("astro_sdk", "store_data_local_dev", fallback=False)
 XCOM_BACKEND = conf.get("core", "xcom_backend")
 IS_CUSTOM_XCOM_BACKEND = XCOM_BACKEND not in [
@@ -38,12 +37,8 @@ LOAD_TABLE_AUTODETECT_ROWS_COUNT = conf.getint(
 
 
 #: Reduce responses sizes returned by aql.run_raw_sql to avoid trashing the Airflow DB if the BaseXCom is used.
-RAW_SQL_MAX_RESPONSE_SIZE = conf.getint(
-    section="astro_sdk", key="run_raw_sql_response_size", fallback=-1
-)
+RAW_SQL_MAX_RESPONSE_SIZE = conf.getint(section="astro_sdk", key="run_raw_sql_response_size", fallback=-1)
 
 # Temp changes
 # Should Astro SDK automatically add inlets/outlets to take advantage of Airflow 2.4 Data-aware scheduling
-AUTO_ADD_INLETS_OUTLETS = conf.getboolean(
-    "astro_sdk", "auto_add_inlets_outlets", fallback=True
-)
+AUTO_ADD_INLETS_OUTLETS = conf.getboolean("astro_sdk", "auto_add_inlets_outlets", fallback=True)

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -1,6 +1,7 @@
 from airflow.configuration import conf
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+
 from astro.sql.operators.append import AppendOperator, append
 from astro.sql.operators.cleanup import CleanupOperator, cleanup
 from astro.sql.operators.dataframe import DataframeOperator, dataframe
@@ -38,9 +39,5 @@ def get_value_list(sql: str, conn_id: str, **kwargs) -> XComArg:
     )
     kwargs.update({"task_id": task_id})
     return RawSQLOperator(
-        sql=sql,
-        conn_id=conn_id,
-        op_kwargs=op_kwargs,
-        python_callable=(lambda *args: None),
-        **kwargs
+        sql=sql, conn_id=conn_id, op_kwargs=op_kwargs, python_callable=(lambda *args: None), **kwargs
     ).output

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
@@ -46,9 +47,7 @@ class AppendOperator(AstroSQLBaseOperator):
 
         super().__init__(
             task_id=task_id,
-            **kwargs_with_datasets(
-                kwargs=kwargs, input_datasets=source_table, output_datasets=target_table
-            ),
+            **kwargs_with_datasets(kwargs=kwargs, input_datasets=source_table, output_datasets=target_table),
         )
 
     def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613

--- a/python-sdk/src/astro/sql/operators/base_operator.py
+++ b/python-sdk/src/astro/sql/operators/base_operator.py
@@ -1,6 +1,7 @@
 from abc import ABC
 
 from airflow.models.baseoperator import BaseOperator
+
 from astro.sql.operators.upstream_task_mixin import UpstreamTaskMixin
 
 

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -10,6 +10,7 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.state import State
+
 from astro.databases import create_database
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
@@ -75,9 +76,7 @@ class CleanupOperator(AstroSQLBaseOperator):
         self.run_immediately = run_sync_mode
         task_id = task_id or get_unique_task_id("cleanup")
 
-        super().__init__(
-            task_id=task_id, retries=retries, retry_delay=retry_delay, **kwargs
-        )
+        super().__init__(task_id=task_id, retries=retries, retry_delay=retry_delay, **kwargs)
 
     def execute(self, context: Context) -> None:
         self.log.info("Execute Cleanup")
@@ -192,9 +191,7 @@ class CleanupOperator(AstroSQLBaseOperator):
         task_outputs = self.resolve_tables_from_tasks(tasks=tasks, context=context)
         return task_outputs
 
-    def resolve_tables_from_tasks(
-        self, tasks: list[BaseOperator], context: Context
-    ) -> list[BaseTable]:
+    def resolve_tables_from_tasks(self, tasks: list[BaseOperator], context: Context) -> list[BaseTable]:
         """
         For the moment, these are the only two classes that create temporary tables.
         This function allows us to only resolve xcom for those objects
@@ -208,9 +205,7 @@ class CleanupOperator(AstroSQLBaseOperator):
         """
         res = []
         for task in tasks:
-            if isinstance(
-                task, (DataframeOperator, BaseSQLDecoratedOperator, LoadFileOperator)
-            ):
+            if isinstance(task, (DataframeOperator, BaseSQLDecoratedOperator, LoadFileOperator)):
                 try:
                     t = task.output.resolve(context)
                     if isinstance(t, BaseTable):
@@ -224,9 +219,7 @@ class CleanupOperator(AstroSQLBaseOperator):
         return res
 
 
-def cleanup(
-    tables_to_cleanup: list[BaseTable] | None = None, **kwargs
-) -> CleanupOperator:
+def cleanup(tables_to_cleanup: list[BaseTable] | None = None, **kwargs) -> CleanupOperator:
     """
     Clean up temporary tables once either the DAG or upstream tasks are done
 

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
+
 from astro.airflow.datasets import kwargs_with_datasets
 
 try:
@@ -56,21 +57,13 @@ def load_op_arg_table_into_dataframe(
 
     for arg in op_args_list:
         current_arg = full_spec.args.pop(0)
-        if full_spec.annotations.get(current_arg) == pd.DataFrame and isinstance(
-            arg, BaseTable
-        ):
+        if full_spec.annotations.get(current_arg) == pd.DataFrame and isinstance(arg, BaseTable):
             log.debug("Found SQL table, retrieving dataframe from table %s", arg.name)
-            ret_args.append(
-                _get_dataframe(
-                    arg, columns_names_capitalization=columns_names_capitalization
-                )
-            )
+            ret_args.append(_get_dataframe(arg, columns_names_capitalization=columns_names_capitalization))
         elif isinstance(arg, File) and (
             full_spec.annotations.get(current_arg) == pd.DataFrame or arg.is_dataframe
         ):
-            log.debug(
-                "Found dataframe file, retrieving dataframe from file %s", arg.path
-            )
+            log.debug("Found dataframe file, retrieving dataframe from file %s", arg.path)
             ret_args.append(arg.export_to_dataframe())
         else:
             ret_args.append(arg)
@@ -94,9 +87,7 @@ def load_op_kwarg_table_into_dataframe(
     for k, v in op_kwargs.items():
         if param_types.get(k).annotation is pd.DataFrame and isinstance(v, BaseTable):  # type: ignore
             log.debug("Found SQL table, retrieving dataframe from table %s", v.name)
-            out_dict[k] = _get_dataframe(
-                v, columns_names_capitalization=columns_names_capitalization
-            )
+            out_dict[k] = _get_dataframe(v, columns_names_capitalization=columns_names_capitalization)
         elif isinstance(v, File) and (param_types.get(k).annotation is pd.DataFrame or v.is_dataframe):  # type: ignore
             log.debug("Found dataframe file, retrieving dataframe from file %s", v.path)
             out_dict[k] = v.export_to_dataframe()
@@ -195,8 +186,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
                 return pandas_dataframe
             elif isinstance(function_output, list):
                 return [
-                    convert_to_file(obj) if isinstance(obj, pd.DataFrame) else obj
-                    for obj in function_output
+                    convert_to_file(obj) if isinstance(obj, pd.DataFrame) else obj for obj in function_output
                 ]
             else:
                 return function_output

--- a/python-sdk/src/astro/sql/operators/drop.py
+++ b/python-sdk/src/astro/sql/operators/drop.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+
 from astro.databases import create_database
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.table import BaseTable

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -5,6 +5,7 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import ExportExistsStrategy
 from astro.databases import create_database
@@ -53,9 +54,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
         elif isinstance(self.input_data, pd.DataFrame):
             df = self.input_data
         else:
-            raise ValueError(
-                f"Expected input_table to be Table or dataframe. Got {type(self.input_data)}"
-            )
+            raise ValueError(f"Expected input_table to be Table or dataframe. Got {type(self.input_data)}")
         # Write file if overwrite == True or if file doesn't exist.
         if self.if_exists == "replace" or not self.output_file.exists():
             self.output_file.create_from_dataframe(df, store_as_dataframe=False)

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -5,6 +5,7 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
 from astro.databases import create_database
@@ -91,9 +92,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         Infers SQL database type based on connection then loads table to db.
         """
         if not isinstance(self.output_table, BaseTable):
-            raise ValueError(
-                "Please pass a valid Table instance in 'output_table' parameter"
-            )
+            raise ValueError("Please pass a valid Table instance in 'output_table' parameter")
         database = create_database(self.output_table.conn_id)
         self.output_table = database.populate_table_metadata(self.output_table)
         normalize_config = self._populate_normalize_config(
@@ -136,9 +135,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
                     ]
                 )
             else:
-                df = file.export_to_dataframe(
-                    columns_names_capitalization=self.columns_names_capitalization
-                )
+                df = file.export_to_dataframe(columns_names_capitalization=self.columns_names_capitalization)
 
         self.log.info("Completed loading the data into dataframe.")
         return df
@@ -179,9 +176,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         normalize_config["record_prefix"] = replace_illegal_columns_chars(
             normalize_config["record_prefix"], database
         )
-        normalize_config["sep"] = replace_illegal_columns_chars(
-            normalize_config["sep"], database
-        )
+        normalize_config["sep"] = replace_illegal_columns_chars(normalize_config["sep"], database)
 
         return normalize_config
 

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import MergeConflictStrategy
 from astro.databases import create_database

--- a/python-sdk/src/astro/sql/operators/transform.py
+++ b/python-sdk/src/astro/sql/operators/transform.py
@@ -10,6 +10,7 @@ except ImportError:
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
 from airflow.models.xcom_arg import XComArg
+
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 from astro.utils.typing_compat import Context
 

--- a/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
+++ b/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
@@ -16,6 +16,5 @@ class UpstreamTaskMixin:
                 self.set_upstream(task)
             else:
                 raise AirflowException(
-                    "Cannot upstream a non-task, please only use XcomArg or operators for this"
-                    " parameter"
+                    "Cannot upstream a non-task, please only use XcomArg or operators for this" " parameter"
                 )

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import random
 import string
 
-from astro.airflow.datasets import Dataset
 from attr import define, field, fields_dict
 from sqlalchemy import Column, MetaData
+
+from astro.airflow.datasets import Dataset
 
 MAX_TABLE_NAME_LENGTH = 62
 TEMP_PREFIX = "_tmp_"
@@ -27,10 +28,7 @@ class Metadata:
 
     def is_empty(self) -> bool:
         """Check if all the fields are None."""
-        return all(
-            getattr(self, field_name) is None
-            for field_name in fields_dict(self.__class__)
-        )
+        return all(getattr(self, field_name) is None for field_name in fields_dict(self.__class__))
 
 
 @define(slots=False)

--- a/python-sdk/src/astro/utils/dataframe.py
+++ b/python-sdk/src/astro/utils/dataframe.py
@@ -5,6 +5,7 @@ import string
 from typing import TYPE_CHECKING
 
 import pandas as pd
+
 from astro.constants import ColumnCapitalization, FileType
 from astro.settings import DATAFRAME_STORAGE_CONN_ID, DATAFRAME_STORAGE_URL
 

--- a/python-sdk/src/astro/utils/load.py
+++ b/python-sdk/src/astro/utils/load.py
@@ -35,9 +35,7 @@ def copy_remote_file_to_local(
         target_filepath = tmp_file.name
 
     with open(target_filepath, write_mode) as fp_out:
-        with smart_open.open(
-            source_filepath, mode=read_mode, transport_params=transport_params
-        ) as fp_in:
+        with smart_open.open(source_filepath, mode=read_mode, transport_params=transport_params) as fp_in:
             content = fp_in.read()
             fp_out.write(content)
 

--- a/python-sdk/src/astro/utils/path.py
+++ b/python-sdk/src/astro/utils/path.py
@@ -54,9 +54,7 @@ def get_dict_with_module_names_to_dot_notations(
     module_name_to_dot_notation = {}
     for module_path in base_path.parent.rglob("*.py"):
         if module_path.name not in ["__init__.py", "base.py"]:
-            module_name_to_dot_notation[module_path.stem] = get_module_dot_notation(
-                module_path
-            )
+            module_name_to_dot_notation[module_path.stem] = get_module_dot_notation(module_path)
     return module_name_to_dot_notation
 
 

--- a/python-sdk/src/astro/utils/table.py
+++ b/python-sdk/src/astro/utils/table.py
@@ -13,20 +13,13 @@ def _pull_first_table_from_parameters(parameters: dict) -> Optional[BaseTable]:
     :return: the first parameter of type BaseTable, if any. Return None otherwise.
     """
     first_table = None
-    params_of_table_type = [
-        param for param in parameters.values() if isinstance(param, BaseTable)
-    ]
-    if (
-        len(params_of_table_type) == 1
-        or len({param.conn_id for param in params_of_table_type}) == 1
-    ):
+    params_of_table_type = [param for param in parameters.values() if isinstance(param, BaseTable)]
+    if len(params_of_table_type) == 1 or len({param.conn_id for param in params_of_table_type}) == 1:
         first_table = params_of_table_type[0]
     return first_table
 
 
-def _pull_first_table_from_op_kwargs(
-    op_kwargs: dict, python_callable: Callable
-) -> Optional[BaseTable]:
+def _pull_first_table_from_op_kwargs(op_kwargs: dict, python_callable: Callable) -> Optional[BaseTable]:
     """
     When trying to "magically" determine the context of a decorator, we will try to find the first table.
     This function attempts this by checking op_kwargs
@@ -41,10 +34,7 @@ def _pull_first_table_from_op_kwargs(
         for kwarg in inspect.signature(python_callable).parameters.values()
         if isinstance(op_kwargs[kwarg.name], BaseTable)
     ]
-    if (
-        len(kwargs_of_table_type) == 1
-        or len({kwarg.conn_id for kwarg in kwargs_of_table_type}) == 1
-    ):
+    if len(kwargs_of_table_type) == 1 or len({kwarg.conn_id for kwarg in kwargs_of_table_type}) == 1:
         first_table = kwargs_of_table_type[0]
     return first_table
 
@@ -63,10 +53,7 @@ def _find_first_table_from_op_args(op_args: tuple) -> Optional[BaseTable]:
     # 1. When we have tables from different DBs.
     # 2. When we have tables from different conn_id, since they can be configured with different
     # database/schema etc.
-    if (
-        len(args_of_table_type) == 1
-        or len({arg.conn_id for arg in args_of_table_type}) == 1
-    ):
+    if len(args_of_table_type) == 1 or len({arg.conn_id for arg in args_of_table_type}) == 1:
         first_table = args_of_table_type[0]
     return first_table
 
@@ -87,9 +74,7 @@ def find_first_table(
         first_table = _find_first_table_from_op_args(op_args=op_args)
 
     if not first_table and op_kwargs and python_callable:
-        first_table = _pull_first_table_from_op_kwargs(
-            op_kwargs=op_kwargs, python_callable=python_callable
-        )
+        first_table = _pull_first_table_from_op_kwargs(op_kwargs=op_kwargs, python_callable=python_callable)
 
     # If there is no first table via op_ags or kwargs, we check the parameters
     if not first_table and parameters:

--- a/python-sdk/tests/airflow/test_datasets.py
+++ b/python-sdk/tests/airflow/test_datasets.py
@@ -4,6 +4,7 @@ from unittest import mock
 import airflow
 import pytest
 from airflow.models.dagbag import DagBag
+
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.table import Table
 
@@ -72,9 +73,7 @@ from astro.table import Table
         ),
     ],
 )
-def test_kwargs_with_datasets(
-    kwargs, input_datasets, output_datasets, dataset_support, expected_kwargs
-):
+def test_kwargs_with_datasets(kwargs, input_datasets, output_datasets, dataset_support, expected_kwargs):
     """
     Test that:
       1. we can extract inlets and outlets from kwargs if users pass it
@@ -82,15 +81,10 @@ def test_kwargs_with_datasets(
       3. if dataset is not supported (Airflow <2.4), we do not set inlets/outlets unless user specifies it
     """
     with mock.patch("astro.airflow.datasets.DATASET_SUPPORT", new=dataset_support):
-        assert (
-            kwargs_with_datasets(kwargs, input_datasets, output_datasets)
-            == expected_kwargs
-        )
+        assert kwargs_with_datasets(kwargs, input_datasets, output_datasets) == expected_kwargs
 
 
-@pytest.mark.skipif(
-    airflow.__version__ < "2.4.0", reason="Require Airflow version >= 2.4.0"
-)
+@pytest.mark.skipif(airflow.__version__ < "2.4.0", reason="Require Airflow version >= 2.4.0")
 def test_kwargs_with_temp_table():
     """Test that temp tables are not passed to inlets and outlets"""
     assert kwargs_with_datasets(
@@ -107,9 +101,7 @@ def test_kwargs_with_temp_table():
     }
 
 
-@pytest.mark.skipif(
-    airflow.__version__ < "2.4.0", reason="Require Airflow version >= 2.4.0"
-)
+@pytest.mark.skipif(airflow.__version__ < "2.4.0", reason="Require Airflow version >= 2.4.0")
 def test_example_dataset_dag():
     from airflow.datasets import Dataset
     from airflow.models.dataset import DatasetModel
@@ -125,9 +117,7 @@ def test_example_dataset_dag():
     # Test that dataset_triggers is only set if all the instances passed to the DAG object are Datasets
     assert consumer_dag.dataset_triggers == outlets
     assert outlets[0].uri == "astro://sqlite_default@?table=imdb_movies"
-    assert DatasetModel.from_public(outlets[0]) == Dataset(
-        "astro://sqlite_default@?table=imdb_movies"
-    )
+    assert DatasetModel.from_public(outlets[0]) == Dataset("astro://sqlite_default@?table=imdb_movies")
 
 
 def test_disable_auto_inlets_outlets():

--- a/python-sdk/tests/benchmark/analyse.py
+++ b/python-sdk/tests/benchmark/analyse.py
@@ -9,10 +9,11 @@ from urllib.parse import urlparse
 
 import pandas as pd
 import settings as benchmark_settings
-from astro.databases import create_database
-from astro.table import Metadata, Table
 from google.cloud import storage
 from sqlalchemy import text
+
+from astro.databases import create_database
+from astro.table import Metadata, Table
 
 SUMMARY_FIELDS = [
     "database",
@@ -119,9 +120,7 @@ def import_profile_data_to_bq(
     return db.export_table_to_pandas_dataframe(
         table,
         select_kwargs={
-            "whereclause": text(
-                f'{benchmark_settings.publish_benchmarks_table_grouping_col}="{bq_git_sha}"'
-            )
+            "whereclause": text(f'{benchmark_settings.publish_benchmarks_table_grouping_col}="{bq_git_sha}"')
         },
     )
 
@@ -136,27 +135,19 @@ def analyse_results(df: pd.DataFrame, output_filepath: str = None):
     mean_by_dag = df.groupby("dag_id", as_index=False).mean()
 
     # format data
-    mean_by_dag["database"] = mean_by_dag.dag_id.apply(
-        lambda text: text.split("into_")[-1]
-    )
+    mean_by_dag["database"] = mean_by_dag.dag_id.apply(lambda text: text.split("into_")[-1])
     mean_by_dag["dataset"] = mean_by_dag.dag_id.apply(
         lambda text: text.split("load_file_")[-1].split("_into")[0]
     )
 
-    mean_by_dag["memory_rss"] = mean_by_dag.memory_full_info_rss.apply(
-        lambda value: format_bytes(value)
-    )
+    mean_by_dag["memory_rss"] = mean_by_dag.memory_full_info_rss.apply(lambda value: format_bytes(value))
     if sys.platform == "linux":
-        mean_by_dag["memory_pss"] = mean_by_dag.memory_full_info_pss.apply(
-            lambda value: format_bytes(value)
-        )
+        mean_by_dag["memory_pss"] = mean_by_dag.memory_full_info_pss.apply(lambda value: format_bytes(value))
         mean_by_dag["memory_shared"] = mean_by_dag.memory_full_info_shared.apply(
             lambda value: format_bytes(value)
         )
 
-    mean_by_dag["total_time"] = mean_by_dag["duration"].apply(
-        lambda ms_time: format_time(ms_time)
-    )
+    mean_by_dag["total_time"] = mean_by_dag["duration"].apply(lambda ms_time: format_time(ms_time))
 
     mean_by_dag["cpu_time_system"] = (
         mean_by_dag["cpu_time_system"] + mean_by_dag["cpu_time_children_system"]
@@ -179,9 +170,7 @@ def get_content(summary):
     # print Markdown tables per database
     for database_name in summary["database"].unique().tolist():
         content = content + f"\n\n### Database: {database_name}\n"
-        content = content + str(
-            summary[summary["database"] == database_name].to_markdown(index=False)
-        )
+        content = content + str(summary[summary["database"] == database_name].to_markdown(index=False))
     return content
 
 

--- a/python-sdk/tests/benchmark/dags/benchmark_gcs_to_big_query.py
+++ b/python-sdk/tests/benchmark/dags/benchmark_gcs_to_big_query.py
@@ -6,12 +6,8 @@ from datetime import datetime, timedelta
 
 from airflow import models
 from airflow.operators import bash_operator
-from airflow.providers.google.cloud.operators.bigquery import (
-    BigQueryDeleteDatasetOperator,
-)
-from airflow.providers.google.cloud.transfers.gcs_to_bigquery import (
-    GCSToBigQueryOperator,
-)
+from airflow.providers.google.cloud.operators.bigquery import BigQueryDeleteDatasetOperator
+from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 
 DATASET_NAME = os.environ.get("GCP_DATASET_NAME", "gcs_to_bq_benchmarking_dataset")
 TABLE_NAME = os.environ.get("GCP_TABLE_NAME", "gcs_to_bq_table")
@@ -87,18 +83,9 @@ load_five_gb = GCSToBigQueryOperator(
     task_id="load_five_gb",
     bucket="astro-sdk",
     source_objects=[
-        (
-            "benchmark/trimmed/pypi/pypi-downloads-2021-03-28-0000000000"
-            + str(i)
-            + ".ndjson"
-        )
+        ("benchmark/trimmed/pypi/pypi-downloads-2021-03-28-0000000000" + str(i) + ".ndjson")
         if i >= 10
-        else (
-            "benchmark/trimmed/pypi/pypi-downloads-2021-03-28-0000000000"
-            + "0"
-            + str(i)
-            + ".ndjson"
-        )
+        else ("benchmark/trimmed/pypi/pypi-downloads-2021-03-28-0000000000" + "0" + str(i) + ".ndjson")
         for i in range(20)
     ],
     destination_project_dataset_table=f"{DATASET_NAME}.{TABLE_NAME}",

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -8,11 +8,12 @@ from urllib.parse import urlparse
 
 import settings as benchmark_settings
 from airflow import DAG
+from run import export_profile_data_to_bq
+
 from astro import sql as aql
 from astro.constants import DEFAULT_CHUNK_SIZE, FileType
 from astro.files import File
 from astro.table import Metadata, Table
-from run import export_profile_data_to_bq
 
 START_DATE = datetime(2000, 1, 1)
 
@@ -136,9 +137,7 @@ def create_dag(database_name, table_args, dataset, global_db_kwargs):
     dataset_databases_kwargs = dataset.get("database_kwargs", {})
     local_db_kwargs = dataset_databases_kwargs.get(database_name, {})
 
-    dag_name = (
-        f"load_file_{dataset_name}_{dataset_filetype}_{location}_into_{database_name}"
-    )
+    dag_name = f"load_file_{dataset_name}_{dataset_filetype}_{location}_into_{database_name}"
 
     def get_git_sha():
         output_stream = os.popen("git rev-parse --short HEAD")

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -13,6 +13,7 @@ from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
+
 from astro.databases import create_database
 from astro.table import Metadata, Table
 
@@ -100,16 +101,12 @@ def profile(func, *args, **kwargs):  # noqa: C901
 
             profile = {
                 "duration": get_load_task_duration(dag=dag),
-                "memory_full_info": subtract(
-                    memory_full_info_after, memory_full_info_before
-                ),
+                "memory_full_info": subtract(memory_full_info_after, memory_full_info_before),
                 "cpu_time": subtract(cpu_time_after, cpu_time_before),
                 "disk_usage": disk_usage_after - disk_usage_before,
             }
             if sys.platform == "linux":
-                profile["io_counters"] = (
-                    subtract(io_counters_after, io_counters_before),
-                )
+                profile["io_counters"] = (subtract(io_counters_after, io_counters_before),)
 
             profile = {**profile, **kwargs, "error": "False", "error_context": None}
 

--- a/python-sdk/tests/benchmark/settings.py
+++ b/python-sdk/tests/benchmark/settings.py
@@ -1,13 +1,7 @@
 import os
 
 publish_benchmarks = os.getenv("ASTRO_PUBLISH_BENCHMARK_DATA", False)
-publish_benchmarks_db_conn_id = os.getenv(
-    "ASTRO_PUBLISH_BENCHMARK_DB_CONN_ID", "bigquery"
-)
+publish_benchmarks_db_conn_id = os.getenv("ASTRO_PUBLISH_BENCHMARK_DB_CONN_ID", "bigquery")
 publish_benchmarks_schema = os.getenv("ASTRO_PUBLISH_BENCHMARK_SCHEMA", "benchmark")
-publish_benchmarks_table = os.getenv(
-    "ASTRO_PUBLISH_BENCHMARK_TABLE", "load_files_to_databaseV3"
-)
-publish_benchmarks_table_grouping_col = os.getenv(
-    "ASTRO_PUBLISH_BENCHMARK_GROUPING_COL", "revision"
-)
+publish_benchmarks_table = os.getenv("ASTRO_PUBLISH_BENCHMARK_TABLE", "load_files_to_databaseV3")
+publish_benchmarks_table_grouping_col = os.getenv("ASTRO_PUBLISH_BENCHMARK_GROUPING_COL", "revision")

--- a/python-sdk/tests/databases/test_all_databases.py
+++ b/python-sdk/tests/databases/test_all_databases.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pandas as pd
 import pytest
+
 from astro.constants import Database
 from astro.files import File
 from astro.settings import SCHEMA

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -2,13 +2,14 @@ import pathlib
 from unittest import mock
 
 import pytest
+from pandas import DataFrame
+
 from astro.constants import Database, FileType
 from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.files import File
 from astro.settings import SCHEMA
 from astro.table import Metadata, Table
-from pandas import DataFrame
 
 CWD = pathlib.Path(__file__).parent
 
@@ -38,9 +39,7 @@ def test_subclass_missing_not_implemented_methods_raise_exception():
 def test_create_table_using_native_schema_autodetection_not_implemented():
     db = DatabaseSubclass(conn_id="fake_conn_id")
     with pytest.raises(NotImplementedError):
-        db.create_table_using_native_schema_autodetection(
-            table=Table(), file=File(path="s3://bucket/key")
-        )
+        db.create_table_using_native_schema_autodetection(table=Table(), file=File(path="s3://bucket/key"))
 
 
 def test_subclass_missing_load_pandas_dataframe_to_table_raises_exception():
@@ -68,14 +67,10 @@ def test_check_schema_autodetection_is_supported():
         source_file=File(path="gs://bucket/prefix", filetype=FileType.CSV)
     )
 
-    assert db.check_schema_autodetection_is_supported(
-        source_file=File(path="gs://bucket/prefix/key.csv")
-    )
+    assert db.check_schema_autodetection_is_supported(source_file=File(path="gs://bucket/prefix/key.csv"))
 
     assert not (
-        db.check_schema_autodetection_is_supported(
-            source_file=File(path="s3://bucket/prefix/key.csv")
-        )
+        db.check_schema_autodetection_is_supported(source_file=File(path="s3://bucket/prefix/key.csv"))
     )
 
 
@@ -117,9 +112,7 @@ def is_dict_subset(superset: dict, subset: dict) -> bool:
     indirect=True,
     ids=["bigquery"],
 )
-def test_load_file_to_table_natively(
-    sample_dag, database_table_fixture, remote_files_fixture
-):
+def test_load_file_to_table_natively(sample_dag, database_table_fixture, remote_files_fixture):
     """
     Verify the correct method is getting called for specific source and destination.
     """
@@ -160,9 +153,7 @@ def test_load_file_to_table_natively(
             source_file=file,
             target_table=test_table,
         )
-        assert database.is_native_load_file_available(
-            source_file=file, target_table=test_table
-        )
+        assert database.is_native_load_file_available(source_file=file, target_table=test_table)
         assert method.called
         assert is_dict_subset(superset=method.call_args.kwargs, subset=expected_kwargs)
         assert method.call_args.args == expected_args
@@ -171,9 +162,7 @@ def test_load_file_to_table_natively(
 @mock.patch("astro.databases.base.BaseDatabase.drop_table")
 @mock.patch("astro.databases.base.BaseDatabase.create_schema_if_needed")
 @mock.patch("astro.databases.base.BaseDatabase.create_table")
-@mock.patch(
-    "astro.databases.base.BaseDatabase.load_file_to_table_natively_with_fallback"
-)
+@mock.patch("astro.databases.base.BaseDatabase.load_file_to_table_natively_with_fallback")
 @mock.patch("astro.databases.base.resolve_file_path_pattern")
 def test_load_file_calls_resolve_file_path_pattern_with_filetype(
     resolve_file_path_pattern,

--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -7,6 +7,12 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 import sqlalchemy
+from google.cloud.bigquery_datatransfer_v1.types import (
+    StartManualTransferRunsResponse,
+    TransferConfig,
+    TransferRun,
+)
+
 from astro.constants import Database
 from astro.databases import create_database
 from astro.databases.google.bigquery import BigqueryDatabase, S3ToBigqueryDataTransfer
@@ -15,11 +21,6 @@ from astro.files import File
 from astro.settings import SCHEMA
 from astro.table import Metadata, Table
 from astro.utils.load import copy_remote_file_to_local
-from google.cloud.bigquery_datatransfer_v1.types import (
-    StartManualTransferRunsResponse,
-    TransferConfig,
-    TransferRun,
-)
 from tests.sql.operators import utils as test_utils
 
 DEFAULT_CONN_ID = "google_cloud_default"
@@ -47,9 +48,7 @@ def test_create_database(conn_id):
     ],
     ids=SUPPORTED_CONN_IDS,
 )
-@mock.patch(
-    "astro.databases.google.bigquery.BigQueryHook.provide_gcp_credential_file_as_context"
-)
+@mock.patch("astro.databases.google.bigquery.BigQueryHook.provide_gcp_credential_file_as_context")
 def test_bigquery_sqlalchemy_engine(mock_credentials, conn_id, expected_uri):
     """Test getting a bigquery based sqla engine."""
     database = BigqueryDatabase(conn_id)
@@ -87,9 +86,7 @@ def test_table_exists_raises_exception():
                 metadata=Metadata(schema=SCHEMA),
                 columns=[
                     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-                    sqlalchemy.Column(
-                        "name", sqlalchemy.String(60), nullable=False, key="name"
-                    ),
+                    sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
                 ],
             ),
         }
@@ -163,15 +160,9 @@ def test_is_native_autodetect_schema_available():
     Test if native autodetect schema is available for S3 and GCS.
     """
     db = BigqueryDatabase(conn_id="fake_conn_id")
-    assert (
-        db.is_native_autodetect_schema_available(file=File(path="s3://bucket/key.csv"))
-        is False
-    )
+    assert db.is_native_autodetect_schema_available(file=File(path="s3://bucket/key.csv")) is False
 
-    assert (
-        db.is_native_autodetect_schema_available(file=File(path="gs://bucket/key.csv"))
-        is True
-    )
+    assert db.is_native_autodetect_schema_available(file=File(path="gs://bucket/key.csv")) is True
 
 
 @pytest.mark.integration
@@ -192,9 +183,7 @@ def test_load_file_to_table(database_table_fixture):
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
     database.load_file_to_table(File(filepath), target_table, {})
 
-    df = database.hook.get_pandas_df(
-        f"SELECT * FROM {database.get_table_qualified_name(target_table)}"
-    )
+    df = database.hook.get_pandas_df(f"SELECT * FROM {database.get_table_qualified_name(target_table)}")
     assert len(df) == 3
     expected = pd.DataFrame(
         [
@@ -238,19 +227,13 @@ def test_load_file_to_table_natively_for_not_optimised_path(database_table_fixtu
     indirect=True,
     ids=["bigquery"],
 )
-@mock.patch(
-    "astro.databases.google.bigquery.BigqueryDatabase.load_file_to_table_natively"
-)
-def test_load_file_to_table_natively_for_fallback(
-    mock_load_file, database_table_fixture
-):
+@mock.patch("astro.databases.google.bigquery.BigqueryDatabase.load_file_to_table_natively")
+def test_load_file_to_table_natively_for_fallback(mock_load_file, database_table_fixture):
     """Test loading on files to bigquery natively for fallback."""
     mock_load_file.side_effect = DatabaseCustomError
     database, target_table = database_table_fixture
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
-    response = database.load_file_to_table_natively_with_fallback(
-        File(filepath), target_table
-    )
+    response = database.load_file_to_table_natively_with_fallback(File(filepath), target_table)
     assert response is None
 
 
@@ -417,9 +400,7 @@ def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
     indirect=True,
     ids=["google"],
 )
-def test_export_table_to_file_in_the_cloud(
-    database_table_fixture, remote_files_fixture
-):
+def test_export_table_to_file_in_the_cloud(database_table_fixture, remote_files_fixture):
     """Test export_table_to_file_file() where end file location is in cloud object stores"""
     object_path = remote_files_fixture[0]
     database, populated_table = database_table_fixture
@@ -461,15 +442,11 @@ def test_create_table_from_select_statement(database_table_fixture):
     """Test table creation via select statement"""
     database, original_table = database_table_fixture
 
-    statement = "SELECT * FROM {} WHERE id = 1;".format(
-        database.get_table_qualified_name(original_table)
-    )
+    statement = f"SELECT * FROM {database.get_table_qualified_name(original_table)} WHERE id = 1;"
     target_table = Table(metadata=Metadata(schema=SCHEMA))
     database.create_table_from_select_statement(statement, target_table)
 
-    df = database.hook.get_pandas_df(
-        f"SELECT * FROM {database.get_table_qualified_name(target_table)}"
-    )
+    df = database.hook.get_pandas_df(f"SELECT * FROM {database.get_table_qualified_name(target_table)}")
     assert len(df) == 1
     expected = pd.DataFrame([{"id": 1, "name": "First"}])
     test_utils.assert_dataframes_are_equal(df, expected)
@@ -479,10 +456,7 @@ def test_create_table_from_select_statement(database_table_fixture):
 def test_get_transfer_config_id():
     config = TransferConfig()
     config.name = "projects/103191871648/locations/us/transferConfigs/6302bf19-0000-26cf-a568-94eb2c0a61ee"
-    assert (
-        S3ToBigqueryDataTransfer.get_transfer_config_id(config)
-        == "6302bf19-0000-26cf-a568-94eb2c0a61ee"
-    )
+    assert S3ToBigqueryDataTransfer.get_transfer_config_id(config) == "6302bf19-0000-26cf-a568-94eb2c0a61ee"
 
 
 def test_get_run_id():
@@ -493,10 +467,7 @@ def test_get_run_id():
         "62d38894-0000-239c-a4d8-089e08325b54/runs/62d6a4df-0000-2fad-8752-d4f547e68ef4"
     )
     config.runs.append(run)
-    assert (
-        S3ToBigqueryDataTransfer.get_run_id(config)
-        == "62d6a4df-0000-2fad-8752-d4f547e68ef4"
-    )
+    assert S3ToBigqueryDataTransfer.get_run_id(config) == "62d6a4df-0000-2fad-8752-d4f547e68ef4"
 
 
 @pytest.mark.integration
@@ -512,9 +483,7 @@ def test_get_run_id():
     ids=["bigquery"],
 )
 @mock.patch("astro.databases.google.bigquery.pd.DataFrame")
-def test_load_pandas_dataframe_to_table_with_service_account(
-    mock_df, database_table_fixture
-):
+def test_load_pandas_dataframe_to_table_with_service_account(mock_df, database_table_fixture):
     """Test loading a pandas dataframe to a table with service account authentication."""
     database, target_table = database_table_fixture
     # Skip running _get_credentials. We assume we always will get a Credentials object back.

--- a/python-sdk/tests/databases/test_postgres.py
+++ b/python-sdk/tests/databases/test_postgres.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 import sqlalchemy
+
 from astro.constants import Database
 from astro.databases import create_database
 from astro.databases.postgres import PostgresDatabase
@@ -75,9 +76,7 @@ def test_table_exists_raises_exception():
                 metadata=Metadata(schema=SCHEMA),
                 columns=[
                     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-                    sqlalchemy.Column(
-                        "name", sqlalchemy.String(60), nullable=False, key="name"
-                    ),
+                    sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
                 ],
             ),
         }
@@ -89,9 +88,7 @@ def test_postgres_create_table_with_columns(database_table_fixture):
     """Test table creation with columns data"""
     database, table = database_table_fixture
 
-    statement = (
-        f"SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
-    )
+    statement = f"SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
     response = database.run_sql(statement)
     assert response.first() is None
 
@@ -153,9 +150,7 @@ def test_load_file_to_table(database_table_fixture):
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
     database.load_file_to_table(File(filepath), target_table, {})
 
-    df = database.hook.get_pandas_df(
-        f"SELECT * FROM {database.get_table_qualified_name(target_table)}"
-    )
+    df = database.hook.get_pandas_df(f"SELECT * FROM {database.get_table_qualified_name(target_table)}")
     assert len(df) == 3
     expected = pd.DataFrame(
         [
@@ -262,9 +257,7 @@ def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
     indirect=True,
     ids=["google"],
 )
-def test_export_table_to_file_in_the_cloud(
-    database_table_fixture, remote_files_fixture
-):
+def test_export_table_to_file_in_the_cloud(database_table_fixture, remote_files_fixture):
     """Test export_table_to_file_file() where end file location is in cloud object stores"""
     object_path = remote_files_fixture[0]
     database, populated_table = database_table_fixture
@@ -305,15 +298,11 @@ def test_create_table_from_select_statement(database_table_fixture):
     """Test table creation via select statement"""
     database, original_table = database_table_fixture
 
-    statement = "SELECT * FROM {} WHERE id = 1;".format(
-        database.get_table_qualified_name(original_table)
-    )
+    statement = f"SELECT * FROM {database.get_table_qualified_name(original_table)} WHERE id = 1;"
     target_table = original_table.create_similar_table()
     database.create_table_from_select_statement(statement, target_table)
 
-    df = database.hook.get_pandas_df(
-        f"SELECT * FROM {database.get_table_qualified_name(target_table)}"
-    )
+    df = database.hook.get_pandas_df(f"SELECT * FROM {database.get_table_qualified_name(target_table)}")
     assert len(df) == 1
     expected = pd.DataFrame([{"id": 1, "name": "First"}])
     test_utils.assert_dataframes_are_equal(df, expected)

--- a/python-sdk/tests/databases/test_redshift.py
+++ b/python-sdk/tests/databases/test_redshift.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 import sqlalchemy
+
 from astro.constants import Database, FileType
 from astro.databases import create_database
 from astro.databases.aws.redshift import RedshiftDatabase
@@ -79,9 +80,7 @@ def test_inexistent_table_returns_false_on_table_exists_check():
                 metadata=Metadata(schema=SCHEMA),
                 columns=[
                     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-                    sqlalchemy.Column(
-                        "name", sqlalchemy.String(60), nullable=False, key="name"
-                    ),
+                    sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
                 ],
             ),
         }
@@ -93,9 +92,7 @@ def test_redshift_create_table_with_columns(database_table_fixture):
     """Test table creation with columns data"""
     database, table = database_table_fixture
 
-    statement = (
-        f"SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
-    )
+    statement = f"SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
     response = database.run_sql(statement)
     assert response.first() is None
 
@@ -252,9 +249,7 @@ def test_export_table_to_file_overrides_existing_file(database_table_fixture):
     """
     filepath = "/tmp/file_to_override.csv"
 
-    previous_dataframe = pd.DataFrame(
-        [{"id": 1, "name": "xyz"}, {"id": 2, "name": "abc"}]
-    )
+    previous_dataframe = pd.DataFrame([{"id": 1, "name": "xyz"}, {"id": 2, "name": "abc"}])
     previous_dataframe.to_csv(filepath)
 
     df = test_utils.load_to_dataframe(filepath, "csv").sort_values(by="id")
@@ -323,9 +318,7 @@ def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
     indirect=True,
     ids=["amazon_s3"],
 )
-def test_export_table_to_file_in_the_cloud(
-    database_table_fixture, remote_files_fixture
-):
+def test_export_table_to_file_in_the_cloud(database_table_fixture, remote_files_fixture):
     """Test export_table_to_file_file() where end file location is in cloud object stores"""
     object_path = remote_files_fixture[0]
     database, populated_table = database_table_fixture

--- a/python-sdk/tests/databases/test_sqlite.py
+++ b/python-sdk/tests/databases/test_sqlite.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 import sqlalchemy
 from airflow.hooks.base import BaseHook
+
 from astro.constants import Database
 from astro.databases import create_database
 from astro.databases.sqlite import SqliteDatabase
@@ -93,9 +94,7 @@ def test_table_exists_raises_exception():
             "table": Table(
                 columns=[
                     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-                    sqlalchemy.Column(
-                        "name", sqlalchemy.String(60), nullable=False, key="name"
-                    ),
+                    sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
                 ]
             ),
         }
@@ -160,9 +159,7 @@ def test_sqlite_create_table_autodetection_without_file(database_table_fixture):
 
     with pytest.raises(ValueError) as exc_info:
         database.create_table(table)
-    assert exc_info.match(
-        "File or Dataframe is required for creating table using schema autodetection"
-    )
+    assert exc_info.match("File or Dataframe is required for creating table using schema autodetection")
 
 
 @pytest.mark.integration
@@ -306,9 +303,7 @@ def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
     indirect=True,
     ids=["google"],
 )
-def test_export_table_to_file_in_the_cloud(
-    database_table_fixture, remote_files_fixture
-):
+def test_export_table_to_file_in_the_cloud(database_table_fixture, remote_files_fixture):
     """Export a SQL tale to a file in the cloud"""
     object_path = remote_files_fixture[0]
     database, populated_table = database_table_fixture
@@ -349,9 +344,7 @@ def test_create_table_from_select_statement(database_table_fixture):
     """Create a table given a SQL select statement"""
     database, original_table = database_table_fixture
 
-    statement = "SELECT * FROM {} WHERE id = 1;".format(
-        database.get_table_qualified_name(original_table)
-    )
+    statement = f"SELECT * FROM {database.get_table_qualified_name(original_table)} WHERE id = 1;"
     target_table = Table()
     database.create_table_from_select_statement(statement, target_table)
 

--- a/python-sdk/tests/files/locations/test_gcs.py
+++ b/python-sdk/tests/files/locations/test_gcs.py
@@ -1,7 +1,8 @@
 from unittest.mock import patch
 
-from astro.files.locations import create_file_location
 from google.cloud.storage import Client
+
+from astro.files.locations import create_file_location
 
 
 def test_get_transport_params_for_gcs():  # skipcq: PYL-W0612, PTC-W0065
@@ -19,9 +20,7 @@ def test_get_transport_params_for_gcs():  # skipcq: PYL-W0612, PTC-W0065
 def test_remote_object_store_prefix(remote_file):
     """with remote filepath having prefix"""
     location = create_file_location("gs://tmp/house")
-    assert sorted(location.paths) == sorted(
-        ["gs://tmp/house1.csv", "gs://tmp/house2.csv"]
-    )
+    assert sorted(location.paths) == sorted(["gs://tmp/house1.csv", "gs://tmp/house2.csv"])
 
 
 def test_size():

--- a/python-sdk/tests/files/locations/test_http.py
+++ b/python-sdk/tests/files/locations/test_http.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 from astro.constants import FileLocation
 from astro.files.locations import create_file_location
 from astro.files.locations.base import BaseFileLocation
@@ -20,17 +21,13 @@ sample_filepaths_ids = [items[0].value for items in sample_filepaths_per_locatio
     sample_filepaths_per_location,
     ids=sample_filepaths_ids,
 )  # skipcq: PTC-W0065
-def test_get_location_type_with_supported_location(
-    expected_location, filepath
-):  # skipcq: PTC-W0065
+def test_get_location_type_with_supported_location(expected_location, filepath):  # skipcq: PTC-W0065
     """test get_location_type() with all the supported locations"""
     location = BaseFileLocation.get_location_type(filepath)
     assert location == expected_location
 
 
-@pytest.mark.parametrize(
-    "path", ["http://domain/file", "https://domain/file"], ids=["http", "https"]
-)
+@pytest.mark.parametrize("path", ["http://domain/file", "https://domain/file"], ids=["http", "https"])
 def test_get_transport_params(path):  # skipcq: PYL-W0612, PTC-W0065
     """test get_transport_params() with API endpoint"""
     location = create_file_location(path)

--- a/python-sdk/tests/files/locations/test_local.py
+++ b/python-sdk/tests/files/locations/test_local.py
@@ -4,6 +4,7 @@ import shutil
 import uuid
 
 import pytest
+
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
 from astro.files.locations.local import LocalLocation
@@ -18,9 +19,7 @@ LOCAL_DIR_FILE_2 = str(pathlib.Path(LOCAL_DIR, "file_2.txt"))
 sample_filepaths_per_location = [
     (FileLocation.LOCAL, LOCAL_FILEPATH),
 ]
-sample_file = pathlib.Path(
-    pathlib.Path(__file__).parent.parent.parent, "data/sample.csv"
-)
+sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent.parent, "data/sample.csv")
 
 
 @pytest.fixture()
@@ -54,9 +53,7 @@ def test_get_transport_params_with_local():  # skipcq: PYL-W0612
     assert location.transport_params is None
 
 
-@pytest.mark.parametrize(
-    "path", [LOCAL_DIR, LOCAL_DIR + "file_*"], ids=["without-prefix", "with-prefix"]
-)
+@pytest.mark.parametrize("path", [LOCAL_DIR, LOCAL_DIR + "file_*"], ids=["without-prefix", "with-prefix"])
 def test_get_paths_with_local_dir(local_dir, path):  # skipcq: PYL-W0612
     """with local filepath"""
     location = LocalLocation(path)

--- a/python-sdk/tests/files/locations/test_location_base.py
+++ b/python-sdk/tests/files/locations/test_location_base.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 import pytest
+
 from astro.constants import FileLocation
 from astro.files.locations import create_file_location, get_class_name
 from astro.files.locations.local import LocalLocation
@@ -57,7 +58,9 @@ def test_get_class_name_method_invalid_name():
     with pytest.raises(ValueError) as exc_info:
         get_class_name(Test)
 
-    expected_msg = "No expected class name found, please note that the class names should an expected formats."
+    expected_msg = (
+        "No expected class name found, please note that the class names should an expected formats."
+    )
     assert exc_info.value.args[0] == expected_msg
 
 

--- a/python-sdk/tests/files/locations/test_s3.py
+++ b/python-sdk/tests/files/locations/test_s3.py
@@ -1,9 +1,10 @@
 import os
 from unittest.mock import patch
 
+from botocore.client import BaseClient
+
 from astro.files.locations import create_file_location
 from astro.files.locations.amazon.s3 import S3Location
-from botocore.client import BaseClient
 
 
 def test_get_transport_params_with_s3():  # skipcq: PYL-W0612
@@ -21,9 +22,7 @@ def test_get_transport_params_with_s3():  # skipcq: PYL-W0612
 def test_remote_object_store_prefix(remote_file):
     """with remote filepath having prefix"""
     location = create_file_location("s3://tmp/house")
-    assert sorted(location.paths) == sorted(
-        ["s3://tmp/house1.csv", "s3://tmp/house2.csv"]
-    )
+    assert sorted(location.paths) == sorted(["s3://tmp/house1.csv", "s3://tmp/house2.csv"])
 
 
 def test_size():

--- a/python-sdk/tests/files/operators/test_files.py
+++ b/python-sdk/tests/files/operators/test_files.py
@@ -2,6 +2,7 @@ import pathlib
 from unittest.mock import patch
 
 from airflow.models.connection import Connection
+
 from astro.files.operators.files import ListFileOperator
 
 

--- a/python-sdk/tests/files/test_file.py
+++ b/python-sdk/tests/files/test_file.py
@@ -6,11 +6,12 @@ from unittest.mock import mock_open, patch
 import pandas as pd
 import pytest
 from airflow import DAG
+from botocore.client import BaseClient
+from google.cloud.storage import Client
+
 from astro import constants
 from astro.constants import SUPPORTED_FILE_TYPES, FileType
 from astro.files import File, get_file_list, resolve_file_path_pattern
-from botocore.client import BaseClient
-from google.cloud.storage import Client
 
 sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent, "data/sample.csv")
 sample_filepaths_per_filetype = [
@@ -90,9 +91,7 @@ def test_exists(mocked_smart_open, files):
     assert files["path"] == args[0]
 
 
-@pytest.mark.parametrize(
-    "type_method_map_fixture", [{"method": "create_from_dataframe"}], indirect=True
-)
+@pytest.mark.parametrize("type_method_map_fixture", [{"method": "create_from_dataframe"}], indirect=True)
 @pytest.mark.parametrize(
     "locations",
     [
@@ -113,9 +112,7 @@ def test_exists(mocked_smart_open, files):
 )
 @pytest.mark.parametrize("filetype", SUPPORTED_FILE_TYPES)
 @patch("astro.files.base.smart_open.open")
-def test_create_from_dataframe(
-    mocked_smart_open, filetype, locations, type_method_map_fixture
-):
+def test_create_from_dataframe(mocked_smart_open, filetype, locations, type_method_map_fixture):
     """Test create_from_dataframe() for all locations and filetypes"""
     data = {"id": [1, 2, 3], "name": ["First", "Second", "Third with unicode पांचाल"]}
     df = pd.DataFrame(data=data)
@@ -128,18 +125,14 @@ def test_create_from_dataframe(
         kwargs = mocked_smart_open.call_args.kwargs
         args = mocked_smart_open.call_args.args
         if kwargs["transport_params"]:
-            assert isinstance(
-                kwargs["transport_params"]["client"], locations["instance"]
-            )
+            assert isinstance(kwargs["transport_params"]["client"], locations["instance"])
         assert path == args[0]
 
         mocked_write.assert_called()
         mocked_write.stop()
 
 
-@pytest.mark.parametrize(
-    "type_method_map_fixture", [{"method": "export_to_dataframe"}], indirect=True
-)
+@pytest.mark.parametrize("type_method_map_fixture", [{"method": "export_to_dataframe"}], indirect=True)
 @pytest.mark.parametrize(
     "locations",
     [
@@ -176,16 +169,12 @@ def test_export_to_dataframe(filetype, locations, type_method_map_fixture):
         kwargs = mocked_smart_open.call_args.kwargs
         args = mocked_smart_open.call_args.args
         if kwargs["transport_params"]:
-            assert isinstance(
-                kwargs["transport_params"]["client"], locations["instance"]
-            )
+            assert isinstance(kwargs["transport_params"]["client"], locations["instance"])
         assert path == args[0]
         mocked_read.assert_called()
 
 
-@pytest.mark.parametrize(
-    "type_method_map_fixture", [{"method": "export_to_dataframe"}], indirect=True
-)
+@pytest.mark.parametrize("type_method_map_fixture", [{"method": "export_to_dataframe"}], indirect=True)
 @pytest.mark.parametrize(
     "locations",
     [
@@ -217,16 +206,12 @@ def test_read_with_explicit_valid_type(filetype, locations, type_method_map_fixt
 
         path = locations["path"]
 
-        File(path=path, filetype=FileType(filetype)).export_to_dataframe(
-            normalize_config=None
-        )
+        File(path=path, filetype=FileType(filetype)).export_to_dataframe(normalize_config=None)
         mocked_smart_open.assert_called()
         kwargs = mocked_smart_open.call_args.kwargs
         args = mocked_smart_open.call_args.args
         if kwargs["transport_params"]:
-            assert isinstance(
-                kwargs["transport_params"]["client"], locations["instance"]
-            )
+            assert isinstance(kwargs["transport_params"]["client"], locations["instance"])
         assert path == args[0]
         mocked_read.assert_called()
 
@@ -317,19 +302,11 @@ def test_file_hash():
             "astro+gs://test_conn@bucket/object/path?filetype=csv",
         ),
         (
-            File(
-                path=str(
-                    pathlib.Path(
-                        pathlib.Path(__file__).parent.parent, "data/sample.csv"
-                    )
-                )
-            ),
+            File(path=str(pathlib.Path(pathlib.Path(__file__).parent.parent, "data/sample.csv"))),
             f"astro+file:{str(pathlib.Path(pathlib.Path(__file__).parent.parent, 'data/sample.csv'))}",
         ),
         (
-            File(
-                path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
-            ),
+            File(path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"),
             "astro+https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv",
         ),
     ],
@@ -369,9 +346,7 @@ def test_smart_open_file_stream_only_conveted_to_BytesIO_buffer_for_parquet(file
      is only applied in case of parquet files
     """
     file = files["path"]
-    _convert_remote_file_to_byte_stream_called = files[
-        "_convert_remote_file_to_byte_stream"
-    ]
+    _convert_remote_file_to_byte_stream_called = files["_convert_remote_file_to_byte_stream"]
     path = str(pathlib.Path(pathlib.Path(__file__).parent.parent, file))
     sample_file_object = File(path)
     with patch(

--- a/python-sdk/tests/files/type/test_csv.py
+++ b/python-sdk/tests/files/type/test_csv.py
@@ -2,11 +2,10 @@ import pathlib
 import tempfile
 
 import pandas as pd
+
 from astro.files.types import CSVFileType
 
-sample_file = pathlib.Path(
-    pathlib.Path(__file__).parent.parent.parent, "data/sample.csv"
-)
+sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent.parent, "data/sample.csv")
 
 
 def test_read_csv_file():

--- a/python-sdk/tests/files/type/test_json.py
+++ b/python-sdk/tests/files/type/test_json.py
@@ -2,11 +2,10 @@ import pathlib
 import tempfile
 
 import pandas as pd
+
 from astro.files.types import JSONFileType
 
-sample_file = pathlib.Path(
-    pathlib.Path(__file__).parent.parent.parent, "data/sample.json"
-)
+sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent.parent, "data/sample.json")
 
 
 def test_read_json_file():

--- a/python-sdk/tests/files/type/test_ndjson.py
+++ b/python-sdk/tests/files/type/test_ndjson.py
@@ -3,11 +3,10 @@ import pathlib
 import tempfile
 
 import pandas as pd
+
 from astro.files.types import NDJSONFileType
 
-sample_file = pathlib.Path(
-    pathlib.Path(__file__).parent.parent.parent, "data/sample.ndjson"
-)
+sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent.parent, "data/sample.ndjson")
 
 
 def test_read_ndjson_file():
@@ -41,9 +40,7 @@ def test_write_ndjson_file():
 
 
 def test_ndjson_file_nrows():
-    sample_file = pathlib.Path(
-        pathlib.Path(__file__).parent.parent.parent, "data/sample.ndjson"
-    )
+    sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent.parent, "data/sample.ndjson")
 
     file = NDJSONFileType(sample_file)
     # Case 1 : when the file have sufficient rows
@@ -66,18 +63,14 @@ def test_the_order_of_rows_getting_loaded_ndjson_file_nrows():
     """
     Verify that the rows of a dataframe loaded from a file are top n rows.
     """
-    sample_file = pathlib.Path(
-        pathlib.Path(__file__).parent.parent.parent, "data/order_check_nrows.ndjson"
-    )
+    sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent.parent, "data/order_check_nrows.ndjson")
     file = NDJSONFileType(sample_file)
     with open(sample_file) as stream:
         df = file.export_to_dataframe(stream, nrows=5)
         df = df.sort_values(by="id")
         assert (df["id"] == [1, 2, 3, 4, 5]).all()
 
-    sample_file = pathlib.Path(
-        pathlib.Path(__file__).parent.parent.parent, "data/sample.ndjson"
-    )
+    sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent.parent, "data/sample.ndjson")
     file = NDJSONFileType(sample_file)
     with open(sample_file) as stream:
         df = file.export_to_dataframe(stream, nrows=5)

--- a/python-sdk/tests/files/type/test_parquet.py
+++ b/python-sdk/tests/files/type/test_parquet.py
@@ -2,11 +2,10 @@ import pathlib
 import tempfile
 
 import pandas as pd
+
 from astro.files.types import ParquetFileType
 
-sample_file = pathlib.Path(
-    pathlib.Path(__file__).parent.parent.parent, "data/sample.parquet"
-)
+sample_file = pathlib.Path(pathlib.Path(__file__).parent.parent.parent, "data/sample.parquet")
 
 
 def test_read_parquet_file():

--- a/python-sdk/tests/files/type/test_type_base.py
+++ b/python-sdk/tests/files/type/test_type_base.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 from astro.constants import FileType
 from astro.files.types import get_filetype
 

--- a/python-sdk/tests/integration_test_dag.py
+++ b/python-sdk/tests/integration_test_dag.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 from airflow.decorators import task, task_group
 from airflow.utils import timezone
+
 from astro import sql as aql
 from astro.constants import Database
 from astro.databases import create_database

--- a/python-sdk/tests/sql/operators/test_append.py
+++ b/python-sdk/tests/sql/operators/test_append.py
@@ -4,13 +4,14 @@ from unittest import mock
 
 import pandas as pd
 import pytest
+from sqlalchemy.exc import NoSuchTableError
+
 from astro import sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
 from astro.files import File
 from astro.sql.operators.append import AppendOperator
 from astro.table import Metadata, Table
-from sqlalchemy.exc import NoSuchTableError
 from tests.sql.operators import utils as test_utils
 
 CWD = pathlib.Path(__file__).parent
@@ -64,21 +65,15 @@ def test_columns_params(test_columns, expected_columns):
     Test that the columns param in AppendOperator takes list/tuple/dict and converts them to dict
     before sending over to db.append_table()
     """
-    source_table = Table(
-        name="source_table", conn_id="test1", metadata=Metadata(schema="test")
-    )
-    target_table = Table(
-        name="target_table", conn_id="test2", metadata=Metadata(schema="test")
-    )
+    source_table = Table(name="source_table", conn_id="test1", metadata=Metadata(schema="test"))
+    target_table = Table(name="target_table", conn_id="test2", metadata=Metadata(schema="test"))
     append_task = AppendOperator(
         source_table=source_table,
         target_table=target_table,
         columns=test_columns,
     )
     assert append_task.columns == expected_columns
-    with mock.patch(
-        "astro.databases.base.BaseDatabase.append_table"
-    ) as mock_append, mock.patch.dict(
+    with mock.patch("astro.databases.base.BaseDatabase.append_table") as mock_append, mock.patch.dict(
         os.environ,
         {"AIRFLOW_CONN_TEST1": "sqlite://", "AIRFLOW_CONN_TEST2": "sqlite://"},
     ):
@@ -92,12 +87,8 @@ def test_columns_params(test_columns, expected_columns):
 
 def test_invalid_columns_param():
     """Test that an error is raised when an invalid columns type is passed"""
-    source_table = Table(
-        name="source_table", conn_id="test1", metadata=Metadata(schema="test")
-    )
-    target_table = Table(
-        name="target_table", conn_id="test2", metadata=Metadata(schema="test")
-    )
+    source_table = Table(name="source_table", conn_id="test1", metadata=Metadata(schema="test"))
+    target_table = Table(name="target_table", conn_id="test2", metadata=Metadata(schema="test"))
     with pytest.raises(ValueError) as exec_info:
         AppendOperator(
             source_table=source_table,
@@ -143,9 +134,7 @@ def test_invalid_columns_param():
     ],
     indirect=True,
 )
-def test_append(
-    database_table_fixture, sample_dag, multiple_tables_fixture, append_params
-):
+def test_append(database_table_fixture, sample_dag, multiple_tables_fixture, append_params):
     app_param, validate_append = append_params
     main_table, append_table = multiple_tables_fixture
     with sample_dag:
@@ -184,9 +173,7 @@ def test_append_on_tables_on_different_db(sample_dag, database_table_fixture):
         test_utils.run_dag(sample_dag)
 
 
-@pytest.mark.skipif(
-    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_supported_ds():
     """Test Datasets are set as inlets and outlets"""
     input_file = File("gs://bucket/object.csv")
@@ -199,9 +186,7 @@ def test_inlets_outlets_supported_ds():
     assert task.operator.outlets == [output_table]
 
 
-@pytest.mark.skipif(
-    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_non_supported_ds():
     """Test inlets and outlets are not set if Datasets are not supported"""
     input_file = File("gs://bucket/object.csv")

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -2,7 +2,6 @@ import os
 import pathlib
 from unittest import mock
 
-import astro.sql as aql
 import pandas
 import pytest
 from airflow import DAG, AirflowException
@@ -16,6 +15,8 @@ from airflow.operators.bash import BashOperator
 from airflow.settings import Session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
+
+import astro.sql as aql
 from astro.constants import Database
 from astro.files import File
 from astro.sql.operators.cleanup import CleanupOperator
@@ -42,9 +43,7 @@ SUPPORTED_DATABASES = [
         "database": Database.SNOWFLAKE,
     },
 ]
-SUPPORTED_DATABASES_WITH_FILE = [
-    dict(x, **{"file": File(DEFAULT_FILEPATH)}) for x in SUPPORTED_DATABASES
-]
+SUPPORTED_DATABASES_WITH_FILE = [dict(x, **{"file": File(DEFAULT_FILEPATH)}) for x in SUPPORTED_DATABASES]
 
 
 @pytest.mark.integration
@@ -186,9 +185,7 @@ def test_cleanup_multiple_table(database_table_fixture, multiple_tables_fixture)
     indirect=True,
     ids=["two_tables"],
 )
-def test_cleanup_default_all_tables(
-    sample_dag, database_table_fixture, multiple_tables_fixture
-):
+def test_cleanup_default_all_tables(sample_dag, database_table_fixture, multiple_tables_fixture):
     @aql.transform
     def foo(input_table: Table):
         return "SELECT * FROM {{input_table}}"
@@ -236,9 +233,7 @@ def test_error_raised_with_blocking_op_executors(
     mock_is_dag_running.side_effect = [True, False]
     mock_is_single_worker_mode.return_value = single_worker_mode
 
-    dag = DAG(
-        "test_error_raised_with_blocking_op_executors", start_date=datetime(2022, 1, 1)
-    )
+    dag = DAG("test_error_raised_with_blocking_op_executors", start_date=datetime(2022, 1, 1))
     cleanup_task = CleanupOperator(dag=dag)
     dr = DagRun(dag_id=dag.dag_id)
 

--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -2,11 +2,12 @@ import os
 import pathlib
 from unittest import mock
 
-import astro.sql as aql
 import pandas
 import pytest
 from airflow.models.xcom import BaseXCom
 from airflow.utils import timezone
+
+import astro.sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
 from astro.custom_backend.astro_custom_backend import AstroCustomXcomBackend as XCom
@@ -59,10 +60,7 @@ def test_dataframe_from_sql_basic(sample_dag, database_table_fixture):
 
     test_utils.run_dag(sample_dag)
 
-    assert (
-        XCom.get_one(execution_date=DEFAULT_DATE, key=f.key, task_id=f.operator.task_id)
-        == 5
-    )
+    assert XCom.get_one(execution_date=DEFAULT_DATE, key=f.key, task_id=f.operator.task_id) == 5
 
 
 @pytest.mark.parametrize(
@@ -153,12 +151,7 @@ def test_dataframe_from_sql_basic_op_arg(sample_dag, database_table_fixture):
         res = my_df_func(test_table)
     test_utils.run_dag(sample_dag)
 
-    assert (
-        XCom.get_one(
-            execution_date=DEFAULT_DATE, key=res.key, task_id=res.operator.task_id
-        )
-        == 5
-    )
+    assert XCom.get_one(execution_date=DEFAULT_DATE, key=res.key, task_id=res.operator.task_id) == 5
 
 
 @pytest.mark.parametrize(
@@ -206,12 +199,7 @@ def test_dataframe_from_sql_basic_op_arg_and_kwarg(
         res = my_df_func(test_table, df_2=test_table)
     test_utils.run_dag(sample_dag)
 
-    assert (
-        XCom.get_one(
-            execution_date=DEFAULT_DATE, key=res.key, task_id=res.operator.task_id
-        )
-        == 10
-    )
+    assert XCom.get_one(execution_date=DEFAULT_DATE, key=res.key, task_id=res.operator.task_id) == 10
 
 
 def test_postgres_dataframe_without_table_arg(sample_dag):
@@ -223,9 +211,7 @@ def test_postgres_dataframe_without_table_arg(sample_dag):
 
     @aql.dataframe
     def sample_df():  # skipcq: PY-D0003
-        return pandas.DataFrame(
-            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
-        )
+        return pandas.DataFrame({"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]})
 
     @aql.transform
     def sample_pg(input_table: Table):  # skipcq: PY-D0003
@@ -233,9 +219,7 @@ def test_postgres_dataframe_without_table_arg(sample_dag):
 
     with sample_dag:
         plain_df = sample_df()
-        pg_df = sample_pg(
-            conn_id="postgres_conn", database="pagila", input_table=plain_df
-        )
+        pg_df = sample_pg(conn_id="postgres_conn", database="pagila", input_table=plain_df)
         validate_result(pg_df)
     test_utils.run_dag(sample_dag)
 
@@ -245,21 +229,15 @@ def test_columns_names_capitalization(sample_dag):
 
     @aql.dataframe(columns_names_capitalization="lower")
     def sample_df_1():  # skipcq: PY-D0003
-        return pandas.DataFrame(
-            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
-        )
+        return pandas.DataFrame({"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]})
 
     @aql.dataframe(columns_names_capitalization="upper")
     def sample_df_2():  # skipcq: PY-D0003
-        return pandas.DataFrame(
-            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
-        )
+        return pandas.DataFrame({"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]})
 
     @aql.dataframe(columns_names_capitalization="original")
     def sample_df_3():  # skipcq: PY-D0003
-        return pandas.DataFrame(
-            {"numbers": [1, 2, 3], "COLORS": ["red", "white", "blue"]}
-        )
+        return pandas.DataFrame({"numbers": [1, 2, 3], "COLORS": ["red", "white", "blue"]})
 
     with sample_dag:
         res_1 = sample_df_1()
@@ -267,19 +245,13 @@ def test_columns_names_capitalization(sample_dag):
         res_3 = sample_df_3()
     test_utils.run_dag(sample_dag)
 
-    columns = XCom.get_one(
-        execution_date=DEFAULT_DATE, key=res_1.key, task_id=res_1.operator.task_id
-    )
+    columns = XCom.get_one(execution_date=DEFAULT_DATE, key=res_1.key, task_id=res_1.operator.task_id)
     assert all(x.islower() for x in columns)
 
-    columns = XCom.get_one(
-        execution_date=DEFAULT_DATE, key=res_2.key, task_id=res_2.operator.task_id
-    )
+    columns = XCom.get_one(execution_date=DEFAULT_DATE, key=res_2.key, task_id=res_2.operator.task_id)
     assert all(x.isupper() for x in columns)
 
-    columns = XCom.get_one(
-        execution_date=DEFAULT_DATE, key=res_3.key, task_id=res_3.operator.task_id
-    )
+    columns = XCom.get_one(execution_date=DEFAULT_DATE, key=res_3.key, task_id=res_3.operator.task_id)
     cols = list(columns.columns)
     cols.sort()
     assert cols[1].islower()
@@ -295,43 +267,33 @@ def test_pass_kwargs_to_base_operator(kwargs):
 
     @aql.dataframe(**kwargs)
     def sample_df_1():  # skipcq: PY-D0003
-        return pandas.DataFrame(
-            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
-        )
+        return pandas.DataFrame({"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]})
 
     task1 = sample_df_1()
     assert all(getattr(task1.operator, k) == v for k, v in kwargs.items())
 
 
-@pytest.mark.skipif(
-    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_supported_ds():
     """Test Datasets are set as inlets and outlets"""
     output_table = Table("test_name")
 
     @aql.dataframe()
     def sample_df_1(**kwargs):
-        return pandas.DataFrame(
-            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
-        )
+        return pandas.DataFrame({"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]})
 
     task = sample_df_1(output_table=output_table)
     assert task.operator.outlets == [output_table]
 
 
-@pytest.mark.skipif(
-    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_non_supported_ds():
     """Test inlets and outlets are not set if Datasets are not supported"""
     output_table = Table("test_name")
 
     @aql.dataframe()
     def sample_df_1(**kwargs):
-        return pandas.DataFrame(
-            {"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}
-        )
+        return pandas.DataFrame({"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]})
 
     task = sample_df_1(output_table=output_table)
     assert task.operator.outlets == []
@@ -388,7 +350,4 @@ def test_dataframe_no_storage_option_raises_warning(mock_warning, sample_dag):
             count_df(validate_file(df=File(path=str(CWD) + "/../../data/homes2.csv")))
         test_utils.run_dag(sample_dag)
     mock_warning.assert_called()
-    assert (
-        "Since you have not provided a remote object storage conn_id"
-        in mock_warning.call_args[0][0]
-    )
+    assert "Since you have not provided a remote object storage conn_id" in mock_warning.call_args[0][0]

--- a/python-sdk/tests/sql/operators/test_drop_table.py
+++ b/python-sdk/tests/sql/operators/test_drop_table.py
@@ -2,10 +2,11 @@
 
 import pathlib
 
-import astro.sql as aql
 import pandas
 import pytest
 from airflow.decorators import task
+
+import astro.sql as aql
 from astro.constants import Database
 from astro.files import File
 from astro.table import Table

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -14,11 +14,12 @@ import pathlib
 import tempfile
 from pathlib import Path
 
-import astro.sql as aql
 import boto3
 import pandas as pd
 import pytest
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+import astro.sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import SUPPORTED_FILE_TYPES, Database
 from astro.files import File
@@ -62,9 +63,7 @@ def test_save_dataframe_to_local(sample_dag):
     assert df.equals(pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]}))
 
 
-@pytest.mark.parametrize(
-    "database_table_fixture", [{"database": Database.SQLITE}], indirect=True
-)
+@pytest.mark.parametrize("database_table_fixture", [{"database": Database.SQLITE}], indirect=True)
 def test_save_temp_table_to_local(sample_dag, database_table_fixture):
     _, test_table = database_table_fixture
     data_path = str(CWD) + "/../../data/homes.csv"
@@ -82,9 +81,7 @@ def test_save_temp_table_to_local(sample_dag, database_table_fixture):
     assert input_df.equals(output_df)
 
 
-@pytest.mark.parametrize(
-    "database_table_fixture", [{"database": Database.SQLITE}], indirect=True
-)
+@pytest.mark.parametrize("database_table_fixture", [{"database": Database.SQLITE}], indirect=True)
 def test_save_returns_output_file(sample_dag, database_table_fixture):
     _, test_table = database_table_fixture
 
@@ -239,13 +236,9 @@ def test_save_all_db_tables_to_gcs(sample_dag, database_table_fixture):
     indirect=True,
     ids=["snowflake", "bigquery", "postgresql", "sqlite", "redshift"],
 )
-def test_save_all_db_tables_to_local_file_exists_overwrite_false(
-    sample_dag, database_table_fixture
-):
+def test_save_all_db_tables_to_local_file_exists_overwrite_false(sample_dag, database_table_fixture):
     _, test_table = database_table_fixture
-    with tempfile.NamedTemporaryFile(suffix=".csv") as temp_file, pytest.raises(
-        FileExistsError
-    ):
+    with tempfile.NamedTemporaryFile(suffix=".csv") as temp_file, pytest.raises(FileExistsError):
         with sample_dag:
             export_file(
                 input_data=test_table,
@@ -433,9 +426,7 @@ def test_populate_table_metadata(sample_dag, database_table_fixture):
     test_utils.run_dag(sample_dag)
 
 
-@pytest.mark.skipif(
-    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_supported_ds():
     """Test Datasets are set as inlets and outlets"""
     input_data = Table("test_name")
@@ -448,9 +439,7 @@ def test_inlets_outlets_supported_ds():
     assert task.operator.outlets == [output_file]
 
 
-@pytest.mark.skipif(
-    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_non_supported_ds():
     """Test inlets and outlets are not set if Datasets are not supported"""
     input_data = Table("test_name")

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -18,6 +18,8 @@ import pytest
 from airflow.exceptions import AirflowNotFoundException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from pandas.testing import assert_frame_equal
+
 from astro import sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database, FileType
@@ -25,7 +27,6 @@ from astro.files import File
 from astro.settings import SCHEMA
 from astro.sql.operators.load_file import load_file
 from astro.table import Metadata, Table
-from pandas.testing import assert_frame_equal
 from tests.sql.operators import utils as test_utils
 
 OUTPUT_TABLE_NAME = test_utils.get_table_name("load_file_test_table")
@@ -99,16 +100,12 @@ def test_load_file_with_http_path_file(sample_dag, database_table_fixture):
     indirect=True,
     ids=["snowflake", "bigquery", "postgresql", "sqlite", "redshift"],
 )
-def test_aql_load_remote_file_to_dbs(
-    sample_dag, database_table_fixture, remote_files_fixture
-):
+def test_aql_load_remote_file_to_dbs(sample_dag, database_table_fixture, remote_files_fixture):
     db, test_table = database_table_fixture
     file_uri = remote_files_fixture[0]
 
     with sample_dag:
-        load_file(
-            input_file=File(file_uri), output_table=test_table, use_native_support=False
-        )
+        load_file(input_file=File(file_uri), output_table=test_table, use_native_support=False)
     test_utils.run_dag(sample_dag)
 
     df = db.export_table_to_pandas_dataframe(test_table)
@@ -210,9 +207,7 @@ def test_unique_task_id_for_same_path(sample_dag):
         for index in range(4):
             params = {
                 "input_file": File(path=str(CWD) + "/../../data/homes.csv"),
-                "output_table": Table(
-                    conn_id="postgres_conn", metadata=Metadata(database="pagila")
-                ),
+                "output_table": Table(conn_id="postgres_conn", metadata=Metadata(database="pagila")),
             }
             if index == 3:
                 params["task_id"] = "task_id"
@@ -242,9 +237,7 @@ def test_load_file_templated_filename(sample_dag, database_table_fixture):
     db, test_table = database_table_fixture
     with sample_dag:
         load_file(
-            input_file=File(
-                path=str(CWD) + "/../../data/{{ var.value.foo }}/example.csv"
-            ),
+            input_file=File(path=str(CWD) + "/../../data/{{ var.value.foo }}/example.csv"),
             output_table=test_table,
         )
     test_utils.run_dag(sample_dag)
@@ -270,9 +263,7 @@ def test_load_file_templated_filename(sample_dag, database_table_fixture):
     indirect=True,
     ids=["sqlite"],
 )
-def test_aql_load_file_pattern(
-    remote_files_fixture, sample_dag, database_table_fixture
-):
+def test_aql_load_file_pattern(remote_files_fixture, sample_dag, database_table_fixture):
     remote_object_uri = remote_files_fixture[0]
     filename = pathlib.Path(CWD.parent, "../data/sample.csv")
     db, test_table = database_table_fixture
@@ -309,9 +300,7 @@ def test_aql_load_file_local_file_pattern(sample_dag, database_table_fixture):
 
     with sample_dag:
         load_file(
-            input_file=File(
-                path=str(CWD.parent) + "/../data/homes_pattern_*", filetype=FileType.CSV
-            ),
+            input_file=File(path=str(CWD.parent) + "/../data/homes_pattern_*", filetype=FileType.CSV),
             output_table=test_table,
         )
     test_utils.run_dag(sample_dag)
@@ -340,9 +329,7 @@ def test_aql_load_file_local_file_pattern_dataframe(sample_dag):
 
     with sample_dag:
         loaded_df = load_file(
-            input_file=File(
-                path=str(CWD.parent) + "/../data/homes_pattern_*", filetype=FileType.CSV
-            ),
+            input_file=File(path=str(CWD.parent) + "/../data/homes_pattern_*", filetype=FileType.CSV),
         )
         validate(loaded_df)
 
@@ -366,9 +353,7 @@ def test_aql_load_file_local_file_pattern_dataframe(sample_dag):
     indirect=True,
     ids=["google", "amazon"],
 )
-def test_load_file_using_file_connection(
-    sample_dag, remote_files_fixture, database_table_fixture
-):
+def test_load_file_using_file_connection(sample_dag, remote_files_fixture, database_table_fixture):
     db, test_table = database_table_fixture
     file_uri = remote_files_fixture[0]
     if file_uri.startswith("s3"):
@@ -396,9 +381,7 @@ def test_load_file_using_file_connection(
     indirect=True,
     ids=["postgresql"],
 )
-def test_load_file_using_file_connection_fails_nonexistent_conn(
-    sample_dag, database_table_fixture
-):
+def test_load_file_using_file_connection_fails_nonexistent_conn(sample_dag, database_table_fixture):
     database_name = "postgres"
     file_conn_id = "fake_conn"
     file_uri = "s3://fake-bucket/fake-object.csv"
@@ -409,9 +392,7 @@ def test_load_file_using_file_connection_fails_nonexistent_conn(
         "input_file": File(path=file_uri, conn_id=file_conn_id),
         "output_table": Table(name=OUTPUT_TABLE_NAME, **sql_server_params),
     }
-    with pytest.raises(
-        AirflowNotFoundException, match=r"The conn_id `fake_conn` isn't defined"
-    ):
+    with pytest.raises(AirflowNotFoundException, match=r"The conn_id `fake_conn` isn't defined"):
         with sample_dag:
             load_file(**task_params)
         test_utils.run_dag(sample_dag)
@@ -447,9 +428,7 @@ def test_load_file(sample_dag, database_table_fixture, file_type):
     # used requires other optional params by local to Bigquery native path.
     with sample_dag:
         load_file(
-            input_file=File(
-                path=str(pathlib.Path(CWD.parent, f"../data/sample.{file_type}"))
-            ),
+            input_file=File(path=str(pathlib.Path(CWD.parent, f"../data/sample.{file_type}"))),
             output_table=test_table,
             use_native_support=False,
         )
@@ -499,9 +478,7 @@ def test_load_file_with_named_schema(sample_dag, database_table_fixture, file_ty
 
     with sample_dag:
         load_file(
-            input_file=File(
-                path=str(pathlib.Path(CWD.parent, f"../data/sample.{file_type}"))
-            ),
+            input_file=File(path=str(pathlib.Path(CWD.parent, f"../data/sample.{file_type}"))),
             output_table=test_table,
         )
     test_utils.run_dag(sample_dag)
@@ -556,9 +533,7 @@ def test_load_file_chunks(sample_dag, database_table_fixture):
     with mock.patch(chunk_function) as mock_chunk_function:
         with sample_dag:
             load_file(
-                input_file=File(
-                    path=str(pathlib.Path(CWD.parent, f"../data/sample.{file_type}"))
-                ),
+                input_file=File(path=str(pathlib.Path(CWD.parent, f"../data/sample.{file_type}"))),
                 output_table=test_table,
                 use_native_support=False,
             )
@@ -590,18 +565,14 @@ def test_load_file_chunks(sample_dag, database_table_fixture):
     indirect=True,
     ids=["snowflake", "bigquery", "postgresql", "sqlite", "redshift"],
 )
-def test_aql_nested_ndjson_file_with_default_sep_param(
-    sample_dag, database_table_fixture
-):
+def test_aql_nested_ndjson_file_with_default_sep_param(sample_dag, database_table_fixture):
     """Test the flattening of single level nested ndjson, with default separator '_'."""
     db, test_table = database_table_fixture
     with sample_dag:
         # Using the use_native_support=False here since the dataset
         # used requires other optional params by local to Bigquery native path.
         load_file(
-            input_file=File(
-                path=str(CWD) + "/../../data/github_single_level_nested.ndjson"
-            ),
+            input_file=File(path=str(CWD) + "/../../data/github_single_level_nested.ndjson"),
             output_table=test_table,
             use_native_support=False,
         )
@@ -625,18 +596,14 @@ def test_aql_nested_ndjson_file_with_default_sep_param(
     indirect=True,
     ids=["bigquery", "redshift"],
 )
-def test_aql_nested_ndjson_file_to_database_explicit_sep_params(
-    sample_dag, database_table_fixture
-):
+def test_aql_nested_ndjson_file_to_database_explicit_sep_params(sample_dag, database_table_fixture):
     """Test the flattening of single level nested ndjson, with explicit separator '___'."""
     db, test_table = database_table_fixture
     with sample_dag:
         # Using the use_native_support=False here since the dataset
         # used requires other optional params by local to Bigquery native path.
         load_file(
-            input_file=File(
-                path=str(CWD) + "/../../data/github_single_level_nested.ndjson"
-            ),
+            input_file=File(path=str(CWD) + "/../../data/github_single_level_nested.ndjson"),
             output_table=test_table,
             use_native_support=False,
             ndjson_normalize_sep="___",
@@ -664,9 +631,7 @@ def test_aql_nested_ndjson_file_to_database_explicit_sep_params(
         "redshift",
     ],
 )
-def test_aql_nested_ndjson_file_to_database_explicit_illegal_sep_params(
-    sample_dag, database_table_fixture
-):
+def test_aql_nested_ndjson_file_to_database_explicit_illegal_sep_params(sample_dag, database_table_fixture):
     """Test the flattening of single level nested ndjson, with explicit separator illegal '.',
     since '.' is not acceptable in col names in bigquery.
     """
@@ -675,9 +640,7 @@ def test_aql_nested_ndjson_file_to_database_explicit_illegal_sep_params(
         # Using the use_native_support=False here since the dataset
         # used requires other optional params by local to Bigquery native path.
         load_file(
-            input_file=File(
-                path=str(CWD) + "/../../data/github_single_level_nested.ndjson"
-            ),
+            input_file=File(path=str(CWD) + "/../../data/github_single_level_nested.ndjson"),
             output_table=test_table,
             ndjson_normalize_sep=".",
             use_native_support=False,
@@ -759,9 +722,7 @@ def is_dict_subset(superset: dict, subset: dict) -> bool:
     indirect=True,
     ids=["bigquery"],
 )
-def test_aql_load_file_optimized_path_method_called(
-    sample_dag, database_table_fixture, remote_files_fixture
-):
+def test_aql_load_file_optimized_path_method_called(sample_dag, database_table_fixture, remote_files_fixture):
     """
     Verify the correct method is getting called for specific source and destination.
     """
@@ -906,9 +867,7 @@ def test_aql_load_file_optimized_path_method_is_not_called(
     indirect=["database_table_fixture"],
     ids=["Bigquery", "Redshift"],
 )
-def test_aql_load_file_s3_native_path(
-    sample_dag, database_table_fixture, native_support_kwargs
-):
+def test_aql_load_file_s3_native_path(sample_dag, database_table_fixture, native_support_kwargs):
     """
     Verify that the optimised path method is skipped in case use_native_support is set to False.
     """
@@ -1010,9 +969,7 @@ def test_aql_load_file_columns_names_capitalization_dataframe(sample_dag):
     indirect=["database_table_fixture"],
     ids=["redshift"],
 )
-def test_aql_load_column_name_mixed_case_json_file_to_dbs(
-    database_table_fixture, native_support_kwargs
-):
+def test_aql_load_column_name_mixed_case_json_file_to_dbs(database_table_fixture, native_support_kwargs):
     """Test that json with mixed column name case loads fine natively to the database."""
     db, test_table = database_table_fixture
 
@@ -1030,9 +987,7 @@ def test_aql_load_column_name_mixed_case_json_file_to_dbs(
     assert df.shape == (2, 2)
 
 
-@pytest.mark.skipif(
-    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_supported_ds():
     """Test Datasets are set as inlets and outlets"""
     input_file = File("gs://bucket/object.csv")
@@ -1045,9 +1000,7 @@ def test_inlets_outlets_supported_ds():
     assert task.operator.outlets == [output_table]
 
 
-@pytest.mark.skipif(
-    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_non_supported_ds():
     """Test inlets and outlets are not set if Datasets are not supported"""
     input_file = File("gs://bucket/object.csv")
@@ -1111,9 +1064,7 @@ def test_tables_creation_if_they_dont_exist(database_table_fixture, if_exists):
     """
     path = str(CWD) + "/../../data/homes_main.csv"
     db, test_table = database_table_fixture
-    load_file(
-        input_file=File(path), output_table=test_table, if_exists=if_exists
-    ).operator.execute({})
+    load_file(input_file=File(path), output_table=test_table, if_exists=if_exists).operator.execute({})
 
     database_df = db.export_table_to_pandas_dataframe(test_table)
     assert database_df.shape == (3, 9)

--- a/python-sdk/tests/sql/operators/test_merge.py
+++ b/python-sdk/tests/sql/operators/test_merge.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pandas as pd
 import pytest
 from airflow.decorators import task_group
+
 from astro import sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
@@ -124,25 +125,15 @@ def run_merge(target_table: Table, source_table: Table, merge_parameters, mode):
     [
         {
             "items": [
-                {
-                    "file": File(
-                        str(pathlib.Path(CWD.parent.parent, "data/homes_merge_1.csv"))
-                    )
-                },
-                {
-                    "file": File(
-                        str(pathlib.Path(CWD.parent.parent, "data/homes_merge_2.csv"))
-                    )
-                },
+                {"file": File(str(pathlib.Path(CWD.parent.parent, "data/homes_merge_1.csv")))},
+                {"file": File(str(pathlib.Path(CWD.parent.parent, "data/homes_merge_2.csv")))},
             ]
         }
     ],
     indirect=True,
     ids=["two_tables_same_schema"],
 )
-def test_merge(
-    database_table_fixture, multiple_tables_fixture, sample_dag, merge_parameters
-):
+def test_merge(database_table_fixture, multiple_tables_fixture, sample_dag, merge_parameters):
     target_table, merge_table = multiple_tables_fixture
     merge_params, mode = merge_parameters
     with sample_dag:
@@ -172,20 +163,14 @@ def test_merge(
         {
             "items": [
                 {"file": File(str(pathlib.Path(CWD.parent.parent, "data/sample.csv")))},
-                {
-                    "file": File(
-                        str(pathlib.Path(CWD.parent.parent, "data/sample_part2.csv"))
-                    )
-                },
+                {"file": File(str(pathlib.Path(CWD.parent.parent, "data/sample_part2.csv")))},
             ]
         }
     ],
     indirect=True,
     ids=["two_tables_same_schema"],
 )
-def test_merge_with_the_same_schema(
-    database_table_fixture, multiple_tables_fixture, sample_dag
-):
+def test_merge_with_the_same_schema(database_table_fixture, multiple_tables_fixture, sample_dag):
     """
     Validate that the output of merge is what we expect.
     """
@@ -233,18 +218,14 @@ def test_merge_with_the_same_schema(
                         conn_id="bigquery",
                         metadata=Metadata(schema="first_table_schema"),
                     ),
-                    "file": File(
-                        str(pathlib.Path(CWD.parent.parent, "data/sample.csv"))
-                    ),
+                    "file": File(str(pathlib.Path(CWD.parent.parent, "data/sample.csv"))),
                 },
                 {
                     "table": Table(
                         conn_id="bigquery",
                         metadata=Metadata(schema="second_table_schema"),
                     ),
-                    "file": File(
-                        str(pathlib.Path(CWD.parent.parent, "data/sample_part2.csv"))
-                    ),
+                    "file": File(str(pathlib.Path(CWD.parent.parent, "data/sample_part2.csv"))),
                 },
             ]
         }
@@ -252,9 +233,7 @@ def test_merge_with_the_same_schema(
     indirect=True,
     ids=["two_tables"],
 )
-def test_merge_with_different_schemas(
-    database_table_fixture, multiple_tables_fixture, sample_dag
-):
+def test_merge_with_different_schemas(database_table_fixture, multiple_tables_fixture, sample_dag):
     """
     Validate that the output of merge is what we expect.
     """
@@ -301,12 +280,8 @@ def test_columns_params(test_columns, expected_columns):
     Test that the columns param in MergeOperator takes list/tuple/dict and converts them to dict
     before sending over to db.merge_table()
     """
-    source_table = Table(
-        name="source_table", conn_id="test1", metadata=Metadata(schema="test")
-    )
-    target_table = Table(
-        name="target_table", conn_id="test2", metadata=Metadata(schema="test")
-    )
+    source_table = Table(name="source_table", conn_id="test1", metadata=Metadata(schema="test"))
+    target_table = Table(name="target_table", conn_id="test2", metadata=Metadata(schema="test"))
     merge_task = MergeOperator(
         source_table=source_table,
         target_table=target_table,
@@ -315,9 +290,7 @@ def test_columns_params(test_columns, expected_columns):
         columns=test_columns,
     )
     assert merge_task.columns == expected_columns
-    with mock.patch(
-        "astro.databases.sqlite.SqliteDatabase.merge_table"
-    ) as mock_merge, mock.patch.dict(
+    with mock.patch("astro.databases.sqlite.SqliteDatabase.merge_table") as mock_merge, mock.patch.dict(
         os.environ,
         {"AIRFLOW_CONN_TEST1": "sqlite://", "AIRFLOW_CONN_TEST2": "sqlite://"},
     ):
@@ -333,12 +306,8 @@ def test_columns_params(test_columns, expected_columns):
 
 def test_invalid_columns_param():
     """Test that an error is raised when an invalid columns type is passed"""
-    source_table = Table(
-        name="source_table", conn_id="test1", metadata=Metadata(schema="test")
-    )
-    target_table = Table(
-        name="target_table", conn_id="test2", metadata=Metadata(schema="test")
-    )
+    source_table = Table(name="source_table", conn_id="test1", metadata=Metadata(schema="test"))
+    target_table = Table(name="target_table", conn_id="test2", metadata=Metadata(schema="test"))
     with pytest.raises(ValueError) as exec_info:
         MergeOperator(
             source_table=source_table,
@@ -353,17 +322,11 @@ def test_invalid_columns_param():
     )
 
 
-@pytest.mark.skipif(
-    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_supported_ds():
     """Test Datasets are set as inlets and outlets"""
-    source_table = Table(
-        name="source_table", conn_id="test1", metadata=Metadata(schema="test")
-    )
-    target_table = Table(
-        name="target_table", conn_id="test2", metadata=Metadata(schema="test")
-    )
+    source_table = Table(name="source_table", conn_id="test1", metadata=Metadata(schema="test"))
+    target_table = Table(name="target_table", conn_id="test2", metadata=Metadata(schema="test"))
     task = aql.merge(
         source_table=source_table,
         target_table=target_table,
@@ -375,17 +338,11 @@ def test_inlets_outlets_supported_ds():
     assert task.operator.outlets == [target_table]
 
 
-@pytest.mark.skipif(
-    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_non_supported_ds():
     """Test inlets and outlets are not set if Datasets are not supported"""
-    source_table = Table(
-        name="source_table", conn_id="test1", metadata=Metadata(schema="test")
-    )
-    target_table = Table(
-        name="target_table", conn_id="test2", metadata=Metadata(schema="test")
-    )
+    source_table = Table(name="source_table", conn_id="test1", metadata=Metadata(schema="test"))
+    target_table = Table(name="target_table", conn_id="test2", metadata=Metadata(schema="test"))
     task = aql.merge(
         source_table=source_table,
         target_table=target_table,

--- a/python-sdk/tests/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_raw_sql.py
@@ -3,6 +3,7 @@ import pathlib
 
 import pytest
 from airflow.decorators import task
+
 from astro import sql as aql
 from astro.constants import Database
 from astro.files import File
@@ -45,9 +46,7 @@ def test_run_raw_sql_without_limit(caplog, sample_dag, database_table_fixture):
 
     test_utils.run_dag(sample_dag)
 
-    expected_warning = (
-        "excessive amount of data being recorded to the Airflow metadata database"
-    )
+    expected_warning = "excessive amount of data being recorded to the Airflow metadata database"
     assert expected_warning in caplog.text
 
 

--- a/python-sdk/tests/sql/operators/test_snowflake_merge_func.py
+++ b/python-sdk/tests/sql/operators/test_snowflake_merge_func.py
@@ -29,12 +29,8 @@ class TestSnowflakeMerge(unittest.TestCase):
         )
         self.snowflake_db: SnowflakeDatabase = create_database(conn_id="snowflake_conn")
 
-        self.target_table_full_name = self.snowflake_db.get_table_qualified_name(
-            self.target_table
-        )
-        self.source_table_full_name = self.snowflake_db.get_table_qualified_name(
-            self.source_table
-        )
+        self.target_table_full_name = self.snowflake_db.get_table_qualified_name(self.target_table)
+        self.source_table_full_name = self.snowflake_db.get_table_qualified_name(self.source_table)
 
     def test_merge_func(self):
         sql, parameters = self.snowflake_db._build_merge_sql(
@@ -46,8 +42,7 @@ class TestSnowflakeMerge(unittest.TestCase):
         )
 
         assert (
-            sql
-            == "merge into IDENTIFIER(:target_table) using IDENTIFIER(:source_table) "
+            sql == "merge into IDENTIFIER(:target_table) using IDENTIFIER(:source_table) "
             "on Identifier(:merge_clause_target_0)=Identifier(:merge_clause_source_0) "
             f"when matched then UPDATE SET {self.target_table_name}.sell={self.source_table_name}.sell "
             f"when not matched then insert({self.target_table_name}.sell) values ({self.source_table_name}.sell)"
@@ -73,8 +68,7 @@ class TestSnowflakeMerge(unittest.TestCase):
         )
 
         assert (
-            sql
-            == "merge into IDENTIFIER(:target_table) using IDENTIFIER(:source_table) "
+            sql == "merge into IDENTIFIER(:target_table) using IDENTIFIER(:source_table) "
             "on Identifier(:merge_clause_target_0)=Identifier(:merge_clause_source_0) AND "
             "Identifier(:merge_clause_target_1)=Identifier(:merge_clause_source_1) "
             f"when matched then UPDATE SET {self.target_table_name}.list={self.source_table_name}.list,"
@@ -103,8 +97,7 @@ class TestSnowflakeMerge(unittest.TestCase):
         )
 
         assert (
-            sql
-            == "merge into IDENTIFIER(:target_table) using IDENTIFIER(:source_table) "
+            sql == "merge into IDENTIFIER(:target_table) using IDENTIFIER(:source_table) "
             "on Identifier(:merge_clause_target_0)=Identifier(:merge_clause_source_0) "
             f"when not matched then insert({self.target_table_name}.sell) values ({self.source_table_name}.sell)"
         )

--- a/python-sdk/tests/sql/operators/test_upstream_tasks.py
+++ b/python-sdk/tests/sql/operators/test_upstream_tasks.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 from astro import sql as aql
 from astro.constants import Database
 from astro.files import File
@@ -50,15 +51,11 @@ def test_raw_sql_chained_queries(database_table_fixture, sample_dag):
         last_task = homes_file
         for _ in range(5):
             n_table = test_table.create_similar_table()
-            n_task = raw_sql_no_deps(
-                new_table=n_table, t_table=test_table, upstream_tasks=[last_task]
-            )
+            n_task = raw_sql_no_deps(new_table=n_table, t_table=test_table, upstream_tasks=[last_task])
             generated_tables.append(n_table)
             last_task = n_task
 
-        validated = validate(
-            df1=test_table, df2=generated_tables[-1], upstream_tasks=[last_task]
-        )
+        validated = validate(df1=test_table, df2=generated_tables[-1], upstream_tasks=[last_task])
         for table in generated_tables:
             aql.drop_table(table, upstream_tasks=[validated])
 

--- a/python-sdk/tests/sql/operators/transform/test_postgres_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_postgres_transform.py
@@ -1,10 +1,10 @@
-import astro.sql as aql
 import pandas as pd
 import pytest
-from airflow.models import DAG, DagRun
-from airflow.models import TaskInstance as TI
+from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.utils import timezone
 from airflow.utils.session import create_session
+
+import astro.sql as aql
 from astro.constants import Database
 from astro.table import Metadata, Table
 from tests.sql.operators import utils as test_utils
@@ -83,11 +83,11 @@ def pg_query_result(request):
     if query_name == "semicolon":
         return "SELECT * FROM {{input_table}} WHERE last_name LIKE 'G%%';   "
     if query_name == "with_param":
-        return "SELECT * FROM {{input_table}} WHERE last_name LIKE {{last_name}}", {
-            "last_name": "G%%"
-        }
+        return "SELECT * FROM {{input_table}} WHERE last_name LIKE {{last_name}}", {"last_name": "G%%"}
     if query_name == "with_jinja":
-        return "SELECT * FROM {{input_table}} WHERE last_update > '{{execution_date}}' AND last_name LIKE 'G%%'"
+        return (
+            "SELECT * FROM {{input_table}} WHERE last_update > '{{execution_date}}' AND last_name LIKE 'G%%'"
+        )
     if query_name == "with_jinja_template_params":
         return (
             "SELECT * FROM {{input_table}} WHERE last_update > {{r_date}} AND last_name LIKE 'G%%'",
@@ -147,12 +147,8 @@ def test_postgres_join(sample_dag, database_table_fixture):
 
     with sample_dag:
         ret = sample_pg(
-            actor=Table(
-                name="actor", conn_id="postgres_conn_pagila", metadata=Metadata()
-            ),
-            film_actor_join=Table(
-                name="film_actor", metadata=Metadata(schema="public")
-            ),
+            actor=Table(name="actor", conn_id="postgres_conn_pagila", metadata=Metadata()),
+            film_actor_join=Table(name="film_actor", metadata=Metadata(schema="public")),
             unsafe_parameter="G%%",
             output_table=test_table,
         )

--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -3,6 +3,7 @@ import pathlib
 import pandas as pd
 import pytest
 from airflow.decorators import task
+
 from astro import sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
@@ -40,9 +41,7 @@ def test_dataframe_transform(database_table_fixture, sample_dag):
     def validate_dataframe(df: pd.DataFrame):
         df.columns = df.columns.str.lower()
         df = df.sort_values(by=df.columns.tolist()).reset_index(drop=True)
-        assert df.equals(
-            pd.DataFrame({"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]})
-        )
+        assert df.equals(pd.DataFrame({"numbers": [1, 2, 3], "colors": ["red", "white", "blue"]}))
 
     with sample_dag:
         my_df = get_dataframe(output_table=test_table)
@@ -217,9 +216,7 @@ def test_transform_with_file(database_table_fixture, sample_dag):
     assert not database.table_exists(expected_target_table)
 
 
-@pytest.mark.skipif(
-    not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(not DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_supported_ds():
     """Test Datasets are set as inlets and outlets"""
     imdb_table = (Table(name="imdb", conn_id="sqlite_default"),)
@@ -233,9 +230,7 @@ def test_inlets_outlets_supported_ds():
     assert task.operator.outlets == [output_table]
 
 
-@pytest.mark.skipif(
-    DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4"
-)
+@pytest.mark.skipif(DATASET_SUPPORT, reason="Inlets/Outlets will only be added for Airflow >= 2.4")
 def test_inlets_outlets_non_supported_ds():
     """Test inlets and outlets are not set if Datasets are not supported"""
     imdb_table = (Table(name="imdb", conn_id="sqlite_default"),)

--- a/python-sdk/tests/sql/operators/utils.py
+++ b/python-sdk/tests/sql/operators/utils.py
@@ -19,10 +19,11 @@ from airflow.utils import timezone
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State
 from airflow.utils.types import DagRunType
-from astro.sql.operators.cleanup import AstroCleanupException
-from astro.table import Metadata
 from pandas.testing import assert_frame_equal
 from sqlalchemy.orm.session import Session
+
+from astro.sql.operators.cleanup import AstroCleanupException
+from astro.table import Metadata
 
 log = logging.getLogger(__name__)
 
@@ -119,9 +120,7 @@ def test_dag(
     """
 
     execution_date = execution_date or timezone.utcnow()
-    dag.log.debug(
-        "Clearing existing task instances for execution date %s", execution_date
-    )
+    dag.log.debug("Clearing existing task instances for execution date %s", execution_date)
     dag.clear(
         start_date=execution_date,
         end_date=execution_date,
@@ -169,9 +168,7 @@ def add_logger_if_needed(dag: DAG, ti: TaskInstance):
         ti: The taskinstance that will receive a logger
 
     """
-    logging_format = logging.Formatter(
-        "[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"
-    )
+    logging_format = logging.Formatter("[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s")
     handler = logging.StreamHandler(sys.stdout)
     handler.level = logging.INFO
     handler.setFormatter(logging_format)

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import pytest
 from airflow import DAG
+
 from astro.sql import get_value_list
 from astro.table import Metadata, Table, TempTable
 
@@ -126,9 +127,7 @@ def test_table_to_datasets_uri(table, dataset_uri):
 
 def test_table_to_datasets_extra():
     """Verify that extra is set"""
-    table = Table(
-        name="test_table", conn_id="test_conn", metadata=Metadata(schema="schema")
-    )
+    table = Table(name="test_table", conn_id="test_conn", metadata=Metadata(schema="schema"))
     assert table.extra == {}
 
 

--- a/python-sdk/tests/test_constants.py
+++ b/python-sdk/tests/test_constants.py
@@ -1,8 +1,4 @@
-from astro.constants import (
-    SUPPORTED_DATABASES,
-    SUPPORTED_FILE_LOCATIONS,
-    SUPPORTED_FILE_TYPES,
-)
+from astro.constants import SUPPORTED_DATABASES, SUPPORTED_FILE_LOCATIONS, SUPPORTED_FILE_TYPES
 
 
 def test_supported_file_locations():

--- a/python-sdk/tests/test_example_dags.py
+++ b/python-sdk/tests/test_example_dags.py
@@ -10,12 +10,8 @@ from airflow.utils import timezone
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session
 from packaging.version import Version
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
 from tests.sql.operators import utils as test_utils
 
 RETRY_ON_EXCEPTIONS = []

--- a/python-sdk/tests/utils/test_dataframe.py
+++ b/python-sdk/tests/utils/test_dataframe.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from astro.utils.dataframe import convert_to_file
 
 

--- a/python-sdk/tests/utils/test_path.py
+++ b/python-sdk/tests/utils/test_path.py
@@ -2,19 +2,14 @@ import pathlib
 
 from astro import databases, settings
 from astro.databases import sqlite
-from astro.utils.path import (
-    get_dict_with_module_names_to_dot_notations,
-    get_module_dot_notation,
-)
+from astro.utils.path import get_dict_with_module_names_to_dot_notations, get_module_dot_notation
 
 
 def test_get_dict_with_module_names_to_dot_notations():
     databases_path = pathlib.Path(databases.__file__)
     paths = get_dict_with_module_names_to_dot_notations(databases_path)
     assert paths["sqlite"] == "astro.databases.sqlite"  # a module in the base folder
-    assert (
-        paths["bigquery"] == "astro.databases.google.bigquery"
-    )  # a path in a subfolder
+    assert paths["bigquery"] == "astro.databases.google.bigquery"  # a path in a subfolder
 
 
 def test_get_module_dot_notation():

--- a/sql-cli/conftest.py
+++ b/sql-cli/conftest.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-
 from sql_cli.dag_generator import SqlFilesDAG
 from sql_cli.sql_directory_parser import SqlFile
 
@@ -70,9 +69,7 @@ def sql_file_with_cycle(root_directory_cycle, target_directory):
 
 @pytest.fixture()
 def sql_files_dag(sql_file):
-    return SqlFilesDAG(
-        dag_id="sql_files_dag", start_date=datetime(2022, 10, 4), sql_files=[sql_file]
-    )
+    return SqlFilesDAG(dag_id="sql_files_dag", start_date=datetime(2022, 10, 4), sql_files=[sql_file])
 
 
 @pytest.fixture()

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -32,9 +32,7 @@ def test(session: nox.Session) -> None:
     # Log all the installed dependencies
     session.log("Installed Dependencies:")
     session.run("pip3", "freeze")
-    session.run(
-        "pytest", *session.posargs, "--cov=sql_cli", "--cov-report=xml", "--cov-branch"
-    )
+    session.run("pytest", *session.posargs, "--cov=sql_cli", "--cov-report=xml", "--cov-branch")
 
 
 @nox.session(python=["3.8"])

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -1,6 +1,5 @@
-import typer
-
 import sql_cli
+import typer
 
 app = typer.Typer(add_completion=False)
 

--- a/sql-cli/sql_cli/dag_generator.py
+++ b/sql-cli/sql_cli/dag_generator.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from networkx import DiGraph, depth_first_search, find_cycle, is_directed_acyclic_graph
-
 from sql_cli.exceptions import DagCycle
 from sql_cli.sql_directory_parser import SqlFile
 
@@ -31,9 +30,7 @@ class SqlFilesDAG:
 
         :returns: True if there is any SQL file with the given variable name.
         """
-        return any(
-            sql_file.get_variable_name() == variable_name for sql_file in self.sql_files
-        )
+        return any(sql_file.get_variable_name() == variable_name for sql_file in self.sql_files)
 
     def find_sql_file(self, variable_name: str) -> SqlFile:
         """
@@ -45,9 +42,7 @@ class SqlFilesDAG:
         """
         try:
             return next(
-                sql_file
-                for sql_file in self.sql_files
-                if sql_file.get_variable_name() == variable_name
+                sql_file for sql_file in self.sql_files if sql_file.get_variable_name() == variable_name
             )
         except StopIteration:
             raise ValueError("No sql file has been found for variable name!")
@@ -75,12 +70,8 @@ class SqlFilesDAG:
 
         if not is_directed_acyclic_graph(graph):
             cycle_edges = " and ".join(
-                " and ".join(edge.get_variable_name() for edge in edges)
-                for edges in find_cycle(graph)
+                " and ".join(edge.get_variable_name() for edge in edges) for edges in find_cycle(graph)
             )
-            raise DagCycle(
-                "Could not generate DAG!"
-                f" A cycle between {cycle_edges} has been detected!"
-            )
+            raise DagCycle("Could not generate DAG!" f" A cycle between {cycle_edges} has been detected!")
 
         return list(depth_first_search.dfs_postorder_nodes(graph))

--- a/sql-cli/sql_cli/sql_directory_parser.py
+++ b/sql-cli/sql_cli/sql_directory_parser.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Iterable
 
 import frontmatter
-
 from sql_cli.utils import find_template_variables
 
 
@@ -17,9 +16,7 @@ class SqlFile:
     :param target_directory: The target directory path for the executable sql.
     """
 
-    def __init__(
-        self, root_directory: Path, path: Path, target_directory: Path
-    ) -> None:
+    def __init__(self, root_directory: Path, path: Path, target_directory: Path) -> None:
         self.root_directory = root_directory
         self.path = path
         self.target_directory = target_directory
@@ -37,9 +34,7 @@ class SqlFile:
         :returns: True if this sql file is equal to the other one.
         """
         if isinstance(other, SqlFile):
-            return (
-                self.root_directory == other.root_directory and self.path == other.path
-            )
+            return self.root_directory == other.root_directory and self.path == other.path
         return False
 
     def __gt__(self, other: SqlFile) -> bool:
@@ -103,9 +98,7 @@ class SqlFile:
 
         :returns: the path where sql files without any headers are being placed.
         """
-        target_full_directory = self.target_directory / "/".join(
-            self.get_sub_directories()
-        )
+        target_full_directory = self.target_directory / "/".join(self.get_sub_directories())
         target_full_directory.mkdir(parents=True, exist_ok=True)
 
         target_path = target_full_directory / self.path.name

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -1,6 +1,5 @@
-from typer.testing import CliRunner
-
 from sql_cli.__main__ import app
+from typer.testing import CliRunner
 
 runner = CliRunner()
 

--- a/sql-cli/tests/test_dag_generator.py
+++ b/sql-cli/tests/test_dag_generator.py
@@ -1,16 +1,11 @@
 import pytest
-
 from sql_cli.dag_generator import DagCycle
 
 
-def test_sql_files_dag(
-    sql_files_dag, sql_files_dag_with_parameters, sql_file, sql_file_with_parameters
-):
+def test_sql_files_dag(sql_files_dag, sql_files_dag_with_parameters, sql_file, sql_file_with_parameters):
     """Test that a simple build will return the sql files."""
     assert sql_files_dag.sorted_sql_files() == [sql_file]
-    assert sql_files_dag_with_parameters.sorted_sql_files() == [
-        sql_file_with_parameters
-    ]
+    assert sql_files_dag_with_parameters.sorted_sql_files() == [sql_file_with_parameters]
 
 
 def test_sql_files_dag_raises_exception(sql_files_dag_with_cycle):

--- a/sql-cli/tests/test_generate_dag.py
+++ b/sql-cli/tests/test_generate_dag.py
@@ -1,5 +1,4 @@
 import pytest
-
 from sql_cli.generate_dag import generate_dag
 
 

--- a/sql-cli/tests/test_sql_directory_parser.py
+++ b/sql-cli/tests/test_sql_directory_parser.py
@@ -27,16 +27,12 @@ def test_sql_file_get_variable_name(sql_file, sql_file_in_sub_directory):
 def test_sql_file_get_relative_target_path(sql_file, sql_file_in_sub_directory):
     """Test that relative target path can be retrieved."""
     assert sql_file.get_relative_target_path() == "_target/a.sql"
-    assert (
-        sql_file_in_sub_directory.get_relative_target_path() == "_target/sub_dir/a.sql"
-    )
+    assert sql_file_in_sub_directory.get_relative_target_path() == "_target/sub_dir/a.sql"
 
 
 def test_get_sql_files(root_directory, target_directory):
     """Test that get_sql_files gets all sql files within a directory."""
-    assert get_sql_files(
-        directory=root_directory, target_directory=target_directory
-    ) == {
+    assert get_sql_files(directory=root_directory, target_directory=target_directory) == {
         SqlFile(
             root_directory=root_directory,
             path=root_directory / path,
@@ -48,6 +44,4 @@ def test_get_sql_files(root_directory, target_directory):
 
 def test_get_sql_files_with_symlink(root_directory_symlink, target_directory):
     """Test that get_sql_files ignores symlinks."""
-    assert not get_sql_files(
-        directory=root_directory_symlink, target_directory=target_directory
-    )
+    assert not get_sql_files(directory=root_directory_symlink, target_directory=target_directory)


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
For some days now there have been a lot of conflicts between `isort` and `black` when run via pre-commit hook on local vs CI (pre-commit.ci).

Example:
- https://github.com/astronomer/astro-sdk/pull/1024
- https://github.com/astronomer/astro-sdk/pull/1001
- https://github.com/astronomer/astro-sdk/pull/994
- https://github.com/astronomer/astro-sdk/pull/990


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR fixes the conflicts and uses https://pycqa.github.io/isort/docs/configuration/black_compatibility.html and https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#isort .

The default line-length for black is 88 ([reference](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html?highlight=length#line-length))

Whereas it is 79 for isort ([reference](https://pycqa.github.io/isort/docs/configuration/options.html#line-length))

This PR changes it to `110` which is what we had added to Airflow too ([reference](https://github.com/apache/airflow/blob/7efdeed5eccbf5cb709af40c8c66757e59c957ed/pyproject.toml#L18))

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
