### PR TITLE
Set different AIRFLOW_HOME per test instance

### DIFF
--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -69,6 +69,7 @@ def test_examples_by_dependency(session: nox.Session, extras):
     session.install("-e", ".[tests]")
     session.run("airflow", "db", "init")
 
+    # Since pytest is not installed in the nox session directly, we need to set `external=true`.
     session.run("pytest", "tests/test_example_dags.py", *pytest_args, *session.posargs, external=True)
 
 

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -38,6 +38,7 @@ def test(session: nox.Session, airflow) -> None:
     session.run("pip3", "freeze")
     AIRFLOW_HOME = f"~/airflow-{airflow}-{session.python}"
     session.run("airflow", "db", "init", env={"AIRFLOW_HOME": AIRFLOW_HOME})
+    # Since pytest is not installed in the nox session directly, we need to set `external=true`.
     session.run("pytest", *session.posargs, env={"AIRFLOW_HOME": AIRFLOW_HOME}, external=True)
 
 

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -36,8 +36,9 @@ def test(session: nox.Session, airflow) -> None:
     # Log all the installed dependencies
     session.log("Installed Dependencies:")
     session.run("pip3", "freeze")
-    session.run("airflow", "db", "init")
-    session.run("pytest", *session.posargs)
+    AIRFLOW_HOME = f"~/airflow-{airflow}-{session.python}"
+    session.run("airflow", "db", "init", env={"AIRFLOW_HOME": AIRFLOW_HOME})
+    session.run("pytest", *session.posargs, env={"AIRFLOW_HOME": AIRFLOW_HOME}, external=True)
 
 
 @nox.session(python=["3.8"])
@@ -68,7 +69,7 @@ def test_examples_by_dependency(session: nox.Session, extras):
     session.install("-e", ".[tests]")
     session.run("airflow", "db", "init")
 
-    session.run("pytest", "tests/test_example_dags.py", *pytest_args, *session.posargs)
+    session.run("pytest", "tests/test_example_dags.py", *pytest_args, *session.posargs, external=True)
 
 
 @nox.session()


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, running nox is always using the same (default) `AIRFLOW_HOME` which can result in errors when running multiple different nox test sessions as they use different airflow versions which have different database tables for example.

## What is the new behavior?

We set the AIRFLOW_HOME per test session - means per airflow and python version.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
