### PR TITLE
Fix isort issue on CI

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,8 @@
 [settings]
+# This is duplicated with arguments in .pre-commit-config.yaml because isort is
+# having some issues picking up these config files. Please keep these in sync
+# for now and track the isort issue: https://github.com/PyCQA/isort/issues/1889
 profile=black
 line_length=110
 combine_as_imports=true
-known_first_party=astro,tests
+known_first_party=astro,tests,sql_cli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,15 @@ repos:
         name: Run isort
         # Exclude auto-generated example files from being changed
         exclude: ^sql-cli/examples/_dags/
-
+        args:
+          # These options are duplicated to known_first_party in .isort.cfg,
+          # Please keep these in sync for now. (See comments there for details.)
+          - --profile=black
+          - -l=110
+          - --combine-as
+          - -p=astro
+          - -p=tests
+          - -p=sql_cli
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.1
     hooks:

--- a/sql-cli/conftest.py
+++ b/sql-cli/conftest.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+
 from sql_cli.dag_generator import SqlFilesDAG
 from sql_cli.sql_directory_parser import SqlFile
 

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -1,5 +1,6 @@
-import sql_cli
 import typer
+
+import sql_cli
 
 app = typer.Typer(add_completion=False)
 

--- a/sql-cli/sql_cli/dag_generator.py
+++ b/sql-cli/sql_cli/dag_generator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from networkx import DiGraph, depth_first_search, find_cycle, is_directed_acyclic_graph
+
 from sql_cli.exceptions import DagCycle
 from sql_cli.sql_directory_parser import SqlFile
 

--- a/sql-cli/sql_cli/sql_directory_parser.py
+++ b/sql-cli/sql_cli/sql_directory_parser.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Iterable
 
 import frontmatter
+
 from sql_cli.utils import find_template_variables
 
 

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -1,5 +1,6 @@
-from sql_cli.__main__ import app
 from typer.testing import CliRunner
+
+from sql_cli.__main__ import app
 
 runner = CliRunner()
 

--- a/sql-cli/tests/test_dag_generator.py
+++ b/sql-cli/tests/test_dag_generator.py
@@ -1,4 +1,5 @@
 import pytest
+
 from sql_cli.dag_generator import DagCycle
 
 

--- a/sql-cli/tests/test_generate_dag.py
+++ b/sql-cli/tests/test_generate_dag.py
@@ -1,4 +1,5 @@
 import pytest
+
 from sql_cli.generate_dag import generate_dag
 
 


### PR DESCRIPTION
isort issue: https://github.com/PyCQA/isort/issues/1889

Because of that issue we have our isort config duplicated with arguments in `.pre-commit-config.yaml` and `.isort.cfg`.

This was identified in https://github.com/astronomer/astro-sdk/pull/1037 and is a follow-up to https://github.com/astronomer/astro-sdk/pull/1030