### PR TITLE
Fix `CleanupOperator` for mapped tasks

### DIFF
--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -3,6 +3,7 @@ import pathlib
 import random
 import string
 import uuid
+from copy import deepcopy
 
 import pytest
 import yaml
@@ -111,7 +112,28 @@ def schemas_fixture(request, database_table_fixture):
 
 
 @pytest.fixture
-def database_table_fixture(request):
+def database_fixture(request):
+    """
+    Given request.param in the format:
+        {
+            "database": Database.SQLITE,  # mandatory, may be any supported database
+        }
+    This fixture returns the following during setup:
+        database
+    Example:
+        astro.databases.sqlite.SqliteDatabase()
+    """
+    params = request.param
+
+    database_name = params["database"]
+    conn_id = DATABASE_NAME_TO_CONN_ID[database_name]
+    database = create_database(conn_id)
+
+    return database
+
+
+@pytest.fixture
+def database_table_fixture(request, database_fixture):
     """
     Given request.param in the format:
         {
@@ -127,55 +149,41 @@ def database_table_fixture(request):
     If the table exists, it is deleted during the tests setup and tear down.
     The table will only be created during setup if request.param contains the `file` parameter.
     """
-    params = request.param
-    file = params.get("file", None)
+    database = database_fixture
+    # We deepcopy the request param dictionary as we modify the table item directly.
+    params = deepcopy(request.param)
 
-    database_name = params["database"]
-    conn_id = DATABASE_NAME_TO_CONN_ID[database_name]
-    database = create_database(conn_id)
+    table = params.get("table", Table(conn_id=database.conn_id, metadata=database.default_metadata))
+    file = params.get("file")
 
-    table = params.get("table", Table(conn_id=conn_id, metadata=database.default_metadata))
-    table.conn_id = table.conn_id or conn_id
-    if table.metadata.is_empty():
-        table.metadata = database.default_metadata
+    database.populate_table_metadata(table)
     database.create_schema_if_needed(table.metadata.schema)
-
-    database.drop_table(table)
     if file:
-        database.load_file_to_table(file, table, {})
+        database.load_file_to_table(file, table)
     yield database, table
-
     database.drop_table(table)
 
 
 @pytest.fixture
-def database_temp_table_fixture(request):
+def database_temp_table_fixture(database_fixture):
     """
-    Given request.param in the format:
-        {
-            "database": Database.SQLITE,  # mandatory, may be any supported database
-        }
     This fixture yields the following during setup:
         (database, temp_table)
     Example:
         (astro.databases.sqlite.SqliteDatabase(), TempTable())
     """
-    params = request.param
+    database = database_fixture
 
-    database_name = params["database"]
-    conn_id = DATABASE_NAME_TO_CONN_ID[database_name]
-    database = create_database(conn_id)
+    temp_table = TempTable(conn_id=database.conn_id)
 
-    temp_table = TempTable(conn_id=conn_id, metadata=database.default_metadata)
+    database.populate_table_metadata(temp_table)
     database.create_schema_if_needed(temp_table.metadata.schema)
-
     yield database, temp_table
-
     database.drop_table(temp_table)
 
 
 @pytest.fixture
-def multiple_tables_fixture(request, database_table_fixture):
+def multiple_tables_fixture(request, database_fixture):
     """
     Given request.param in the format:
     {
@@ -191,21 +199,26 @@ def multiple_tables_fixture(request, database_table_fixture):
     For each table in the list, if the table exists, it is deleted during the tests setup and tear down.
     The table will only be created during setup if the item contains the "file" to be loaded to the table.
     """
-    database, _ = database_table_fixture
-    items = request.param.get("items", [])
-    tables_list = []
+    database = database_fixture
+    # We deepcopy the request param dictionary as we modify the table item directly.
+    params = deepcopy(request.param)
+
+    items = params.get("items", [])
+    tables = []
+
     for item in items:
         table = item.get("table", Table(conn_id=database.conn_id))
-        table = database.populate_table_metadata(table)
-        file = item.get("file", None)
-        database.drop_table(table)
+        file = item.get("file")
+
+        database.populate_table_metadata(table)
+        database.create_schema_if_needed(table.metadata.schema)
         if file:
-            database.load_file_to_table(file, table, {})
-        tables_list.append(table)
+            database.load_file_to_table(file, table)
+        tables.append(table)
 
-    yield tables_list if len(tables_list) > 1 else tables_list[0]
+    yield tables if len(tables) > 1 else tables[0]
 
-    for table in tables_list:
+    for table in tables:
         database.drop_table(table)
 
 

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -10,6 +10,7 @@ import sqlalchemy
 from airflow.hooks.dbapi import DbApiHook
 from pandas.io.sql import SQLDatabase
 from sqlalchemy import column, insert, select
+from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
@@ -92,7 +93,7 @@ class BaseDatabase(ABC):
         sql: str | ClauseElement = "",
         parameters: dict | None = None,
         **kwargs,
-    ):
+    ) -> CursorResult:
         """
         Return the results to running a SQL statement.
 

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import logging
 import warnings
 from abc import ABC
-from typing import Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 
 import pandas as pd
 import sqlalchemy
 from airflow.hooks.dbapi import DbApiHook
 from pandas.io.sql import SQLDatabase
 from sqlalchemy import column, insert, select
-from sqlalchemy.engine.cursor import CursorResult
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -8,7 +8,15 @@ from airflow.decorators.base import get_unique_task_id
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagrun import DagRun
-from airflow.models.mappedoperator import MappedOperator
+
+try:
+    # Airflow >= 2.3
+    from airflow.models.mappedoperator import MappedOperator
+except ImportError:
+    # Airflow < 2.3
+    MappedOperator = None
+
+
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.state import State
 
@@ -213,7 +221,11 @@ class CleanupOperator(AstroSQLBaseOperator):
                     t = task.output.resolve(context)
                     if isinstance(t, BaseTable):
                         res.append(t)
-                elif isinstance(task, MappedOperator) and task.operator_class is LoadFileOperator:
+                elif (
+                    MappedOperator
+                    and isinstance(task, MappedOperator)
+                    and task.operator_class is LoadFileOperator
+                ):
                     for t in task.output.resolve(context):
                         if isinstance(t, BaseTable):
                             res.append(t)

--- a/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
+++ b/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
@@ -1,5 +1,5 @@
 from airflow.exceptions import AirflowException
-from airflow.models.baseoperator import BaseOperator
+from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.xcom_arg import XComArg
 
 
@@ -12,7 +12,7 @@ class UpstreamTaskMixin:
         for task in upstream_tasks:
             if isinstance(task, XComArg):
                 self.set_upstream(task.operator)
-            elif isinstance(task, BaseOperator):
+            elif isinstance(task, AbstractOperator):
                 self.set_upstream(task)
             else:
                 raise AirflowException(

--- a/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
+++ b/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
@@ -1,5 +1,12 @@
 from airflow.exceptions import AirflowException
-from airflow.models.abstractoperator import AbstractOperator
+
+try:
+    # Airflow >= 2.3
+    from airflow.models.abstractoperator import AbstractOperator
+except ImportError:
+    # Airflow < 2.3
+    from airflow.models.baseoperator import BaseOperator as AbstractOperator
+
 from airflow.models.xcom_arg import XComArg
 
 

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -17,41 +17,37 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 
 import astro.sql as aql
-from astro.constants import Database
+from astro.constants import SUPPORTED_DATABASES, Database
 from astro.files import File
 from astro.sql.operators.cleanup import CleanupOperator
+from astro.sql.operators.load_file import LoadFileOperator
 from astro.table import Table
 from tests.sql.operators import utils as test_utils
 
 CWD = pathlib.Path(__file__).parent
 
 DEFAULT_FILEPATH = str(pathlib.Path(CWD.parent.parent, "data/sample.csv").absolute())
-SQLITE_ONLY = [
-    {"database": Database.SQLITE, "file": File(DEFAULT_FILEPATH)},
+SUPPORTED_DATABASES_OBJECTS = [
+    {
+        "database": database,
+    }
+    for database in Database
 ]
-SUPPORTED_DATABASES = [
+SUPPORTED_DATABASES_OBJECTS_WITH_FILE = [
     {
-        "database": Database.SQLITE,
-    },
-    {
-        "database": Database.POSTGRES,
-    },
-    {
-        "database": Database.BIGQUERY,
-    },
-    {
-        "database": Database.SNOWFLAKE,
-    },
+        "database": database,
+        "file": File(DEFAULT_FILEPATH),
+    }
+    for database in Database
 ]
-SUPPORTED_DATABASES_WITH_FILE = [dict(x, **{"file": File(DEFAULT_FILEPATH)}) for x in SUPPORTED_DATABASES]
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",
-    SQLITE_ONLY,
+    SUPPORTED_DATABASES_OBJECTS_WITH_FILE,
     indirect=True,
-    ids=["sqlite"],
+    ids=SUPPORTED_DATABASES,
 )
 def test_cleanup_one_table(database_table_fixture):
     db, test_table = database_table_fixture
@@ -63,9 +59,9 @@ def test_cleanup_one_table(database_table_fixture):
 
 @pytest.mark.parametrize(
     "database_table_fixture",
-    SQLITE_ONLY,
+    SUPPORTED_DATABASES_OBJECTS_WITH_FILE,
     indirect=True,
-    ids=["sqlite"],
+    ids=SUPPORTED_DATABASES,
 )
 @pytest.mark.parametrize(
     "multiple_tables_fixture",
@@ -102,9 +98,9 @@ def test_cleanup_non_temp_table(database_table_fixture, multiple_tables_fixture)
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",
-    SQLITE_ONLY,
+    SUPPORTED_DATABASES_OBJECTS_WITH_FILE,
     indirect=True,
-    ids=["sqlite"],
+    ids=SUPPORTED_DATABASES,
 )
 def test_cleanup_non_table(database_table_fixture):
     db, test_table = database_table_fixture
@@ -122,9 +118,9 @@ def test_cleanup_non_table(database_table_fixture):
 
 @pytest.mark.parametrize(
     "database_table_fixture",
-    SQLITE_ONLY,
+    SUPPORTED_DATABASES_OBJECTS_WITH_FILE,
     indirect=True,
-    ids=["sqlite"],
+    ids=SUPPORTED_DATABASES,
 )
 @pytest.mark.parametrize(
     "multiple_tables_fixture",
@@ -164,9 +160,9 @@ def test_cleanup_multiple_table(database_table_fixture, multiple_tables_fixture)
 
 @pytest.mark.parametrize(
     "database_table_fixture",
-    SQLITE_ONLY,
+    SUPPORTED_DATABASES_OBJECTS_WITH_FILE,
     indirect=True,
-    ids=["sqlite"],
+    ids=SUPPORTED_DATABASES,
 )
 @pytest.mark.parametrize(
     "multiple_tables_fixture",
@@ -186,17 +182,72 @@ def test_cleanup_multiple_table(database_table_fixture, multiple_tables_fixture)
     ids=["two_tables"],
 )
 def test_cleanup_default_all_tables(sample_dag, database_table_fixture, multiple_tables_fixture):
-    @aql.transform
+    @aql.transform()
     def foo(input_table: Table):
         return "SELECT * FROM {{input_table}}"
 
+    db, _ = database_table_fixture
     table_1, table_2 = multiple_tables_fixture
-    with sample_dag:
-        foo(table_1)
-        foo(table_2)
+    assert db.table_exists(table_1)
+    assert db.table_exists(table_2)
 
-        aql.cleanup([])
+    with sample_dag:
+        foo(table_1, output_table=table_2)
+
+        aql.cleanup()
     test_utils.run_dag(sample_dag)
+
+    assert not db.table_exists(table_2)
+
+
+@pytest.mark.parametrize(
+    "database_temp_table_fixture",
+    SUPPORTED_DATABASES_OBJECTS,
+    indirect=True,
+    ids=SUPPORTED_DATABASES,
+)
+def test_cleanup_mapped_task(sample_dag, database_temp_table_fixture):
+    db, temp_table = database_temp_table_fixture
+
+    with sample_dag:
+        load_file_mapped = LoadFileOperator.partial(task_id="load_file_mapped").expand_kwargs(
+            [
+                {
+                    "input_file": File(path=(CWD.parent.parent / "data/sample.csv").as_posix()),
+                    "output_table": temp_table,
+                }
+            ]
+        )
+
+        aql.cleanup(upstream_tasks=[load_file_mapped])
+    test_utils.run_dag(sample_dag)
+
+    assert not db.table_exists(temp_table)
+
+
+@pytest.mark.parametrize(
+    "database_temp_table_fixture",
+    SUPPORTED_DATABASES_OBJECTS,
+    indirect=True,
+    ids=SUPPORTED_DATABASES,
+)
+def test_cleanup_default_all_tables_mapped_task(sample_dag, database_temp_table_fixture):
+    db, temp_table = database_temp_table_fixture
+
+    with sample_dag:
+        LoadFileOperator.partial(task_id="load_file_mapped").expand_kwargs(
+            [
+                {
+                    "input_file": File(path=(CWD.parent.parent / "data/sample.csv").as_posix()),
+                    "output_table": temp_table,
+                }
+            ]
+        )
+
+        aql.cleanup()
+    test_utils.run_dag(sample_dag)
+
+    assert not db.table_exists(temp_table)
 
 
 def test_is_dag_running():

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 from unittest import mock
 
+import airflow
 import pandas
 import pytest
 from airflow import DAG, AirflowException
@@ -200,6 +201,7 @@ def test_cleanup_default_all_tables(sample_dag, database_table_fixture, multiple
     assert not db.table_exists(table_2)
 
 
+@pytest.mark.skipif(airflow.__version__ < "2.3.0", reason="Require Airflow version >= 2.3.0")
 @pytest.mark.parametrize(
     "database_temp_table_fixture",
     SUPPORTED_DATABASES_OBJECTS,
@@ -225,6 +227,7 @@ def test_cleanup_mapped_task(sample_dag, database_temp_table_fixture):
     assert not db.table_exists(temp_table)
 
 
+@pytest.mark.skipif(airflow.__version__ < "2.3.0", reason="Require Airflow version >= 2.3.0")
 @pytest.mark.parametrize(
     "database_temp_table_fixture",
     SUPPORTED_DATABASES_OBJECTS,

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -59,8 +59,8 @@ def test_cleanup_one_table(database_table_fixture):
 
 
 @pytest.mark.parametrize(
-    "database_table_fixture",
-    SUPPORTED_DATABASES_OBJECTS_WITH_FILE,
+    "database_fixture",
+    SUPPORTED_DATABASES_OBJECTS,
     indirect=True,
     ids=SUPPORTED_DATABASES,
 )
@@ -83,8 +83,8 @@ def test_cleanup_one_table(database_table_fixture):
     indirect=True,
     ids=["named_table"],
 )
-def test_cleanup_non_temp_table(database_table_fixture, multiple_tables_fixture):
-    db, _ = database_table_fixture
+def test_cleanup_non_temp_table(database_fixture, multiple_tables_fixture):
+    db = database_fixture
     test_table, test_temp_table = multiple_tables_fixture
     assert db.table_exists(test_table)
     assert db.table_exists(test_temp_table)

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -59,7 +59,7 @@ def test_cleanup_one_table(database_table_fixture):
 
 
 @pytest.mark.parametrize(
-    "database_fixture",
+    "database_table_fixture",
     SUPPORTED_DATABASES_OBJECTS,
     indirect=True,
     ids=SUPPORTED_DATABASES,
@@ -83,8 +83,8 @@ def test_cleanup_one_table(database_table_fixture):
     indirect=True,
     ids=["named_table"],
 )
-def test_cleanup_non_temp_table(database_fixture, multiple_tables_fixture):
-    db = database_fixture
+def test_cleanup_non_temp_table(database_table_fixture, multiple_tables_fixture):
+    db, _ = database_table_fixture
     test_table, test_temp_table = multiple_tables_fixture
     assert db.table_exists(test_table)
     assert db.table_exists(test_temp_table)


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, `aql.cleanup()` does not cleanup/remove all temp tables.

We know this for sure for Snowflake:

The following [CI logs](https://github.com/astronomer/astro-sdk/actions/runs/3236060888/jobs/5309951211#step:11:967) were giving us the hint that the tables are not being deleted after running the tests.
```
E       sqlalchemy.exc.ProgrammingError: (snowflake.connector.errors.ProgrammingError) 090153 (22000): 01a7981b-0605-9c81-0000-68211381e012: The result set size exceeded the max number of rows(10000) supported for SHOW statements. Use LIMIT option to limit result set to a smaller number.
E       [SQL: SHOW /* sqlalchemy:get_table_names */ TABLES IN astroflow_ci]
E       (Background on this error at: https://sqlalche.me/e/14/f405)
```
The schema where we write the tables to exceeded 10000 tables.

closes: #963 

## What is the new behavior?

Cleanup mapped tasks

- run cleanup tests on all databases

## Does this introduce a breaking change?

No, but we will remove temp tables when the issue is fixed.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
