### PR TITLE
Fix sql-cli examples

### DIFF
--- a/sql-cli/include/base/workflows/example_basic_transform/top_animations.sql
+++ b/sql-cli/include/base/workflows/example_basic_transform/top_animations.sql
@@ -1,3 +1,6 @@
+---
+conn_id: sqlite_conn
+---
 SELECT Title, Rating
 FROM movies
 WHERE Genre1=='Animation'

--- a/sql-cli/include/base/workflows/example_templating/filtered_orders.sql
+++ b/sql-cli/include/base/workflows/example_templating/filtered_orders.sql
@@ -1,2 +1,5 @@
+---
+conn_id: sqlite_conn
+---
 SELECT * FROM orders
 WHERE amount > 150

--- a/sql-cli/sql_cli/project.py
+++ b/sql-cli/sql_cli/project.py
@@ -23,16 +23,6 @@ class Project:
         self.airflow_home = airflow_home
         self.airflow_dags_folder = airflow_dags_folder
 
-    def _delete_temporary_files(self) -> None:
-        """
-        Delete files which should not be part of the user project directory structure.
-        An example are the .gitkeep files, which were added just so the default folder structure
-        can be added to Git (by default empty directories are not versioned).
-        """
-        gitkeep_files = Path(self.directory).rglob(".gitkeep")
-        for file_ in gitkeep_files:
-            file_.unlink()
-
     def _update_config(self) -> None:
         """
         Sets custom Airflow configuration in case the user is not using the default values.
@@ -53,6 +43,10 @@ class Project:
         :param airflow_home: Custom user-defined Airflow Home directory
         :param airflow_dags_folder: Custom user-defined Airflow DAGs folder
         """
-        shutil.copytree(src=BASE_SOURCE_DIR, dst=self.directory, dirs_exist_ok=True)
-        self._delete_temporary_files()
+        shutil.copytree(
+            src=BASE_SOURCE_DIR,
+            dst=self.directory,
+            ignore=shutil.ignore_patterns(".gitkeep"),
+            dirs_exist_ok=True,
+        )
         self._update_config()

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -1,5 +1,4 @@
 import pathlib
-import tempfile
 
 from typer.testing import CliRunner
 
@@ -76,24 +75,22 @@ def test_run(root_directory, dags_directory):
     assert f"Dagrun {root_directory.name} final state: success" in result_stdout
 
 
-def test_init_with_directory():
-    with tempfile.TemporaryDirectory() as dir_name:
-        result = runner.invoke(app, ["init", dir_name])
-        assert result.exit_code == 0
-        expected_msg = f"Initialized an Astro SQL project at {dir_name}"
-        assert expected_msg in get_stdout(result)
-        assert list_dir(dir_name)
+def test_init_with_directory(tmp_path):
+    result = runner.invoke(app, ["init", tmp_path.as_posix()])
+    assert result.exit_code == 0
+    expected_msg = f"Initialized an Astro SQL project at {tmp_path.as_posix()}"
+    assert expected_msg in get_stdout(result)
+    assert list_dir(tmp_path.as_posix())
 
 
-def test_init_with_custom_airflow_config():
-    with tempfile.TemporaryDirectory() as dir_name:
-        result = runner.invoke(
-            app, ["init", dir_name, "--airflow-home", "/some/home", "--airflow-dags-folder", "/tmp"]
-        )
-        assert result.exit_code == 0
-        expected_msg = f"Initialized an Astro SQL project at {dir_name}"
-        assert expected_msg in get_stdout(result)
-        assert list_dir(dir_name)
+def test_init_with_custom_airflow_config(tmp_path):
+    result = runner.invoke(
+        app, ["init", tmp_path.as_posix(), "--airflow-home", "/some/home", "--airflow-dags-folder", "/tmp"]
+    )
+    assert result.exit_code == 0
+    expected_msg = f"Initialized an Astro SQL project at {tmp_path.as_posix()}"
+    assert expected_msg in get_stdout(result)
+    assert list_dir(tmp_path.as_posix())
 
 
 def test_init_without_directory(empty_cwd):

--- a/sql-cli/tests/test_project.py
+++ b/sql-cli/tests/test_project.py
@@ -1,29 +1,45 @@
-import tempfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
-from sql_cli.project import BASE_SOURCE_DIR, Project
+from sql_cli.project import Project
 from tests.utils import list_dir
 
-BASE_PATHS_COUNT = 19
-BASE_PATHS = [obj for obj in list_dir(str(BASE_SOURCE_DIR)) if not obj.stem == ".gitkeep"]
+BASE_PATHS = [
+    Path(".airflow"),
+    Path(".airflow/dags"),
+    Path(".airflow/dags/sql"),
+    Path(".airflow/default"),
+    Path(".airflow/dev"),
+    Path("config"),
+    Path("config/default"),
+    Path("config/default/configuration.yml"),
+    Path("config/dev"),
+    Path("config/dev/configuration.yml"),
+    Path("data"),
+    Path("data/movies.db"),
+    Path("data/retail.db"),
+    Path("workflows"),
+    Path("workflows/example_basic_transform"),
+    Path("workflows/example_basic_transform/top_animations.sql"),
+    Path("workflows/example_templating"),
+    Path("workflows/example_templating/filtered_orders.sql"),
+    Path("workflows/example_templating/joint_orders_customers.sql"),
+]
 
 
 def test_initialise_project_with_dirname():
-    with tempfile.TemporaryDirectory() as dir_name:
-        assert not list_dir(dir_name)
+    with TemporaryDirectory() as dir_name:
         Project(dir_name).initialise()
-        new_dir_files_list = list_dir(dir_name)
-        assert new_dir_files_list == BASE_PATHS
-        assert len(new_dir_files_list) == BASE_PATHS_COUNT
+        paths = list_dir(dir_name)
+        assert all(base_path in paths for base_path in BASE_PATHS)
 
 
 def test_initialise_project_in_previously_initialised_dir():
-    with tempfile.TemporaryDirectory() as dir_name:
-        assert not list_dir(dir_name)
+    with TemporaryDirectory() as dir_name:
         Project(dir_name).initialise()
-        new_dir_files_list = list_dir(dir_name)
-        assert new_dir_files_list == BASE_PATHS
-        assert len(new_dir_files_list) == BASE_PATHS_COUNT
+        paths = list_dir(dir_name)
+        assert all(base_path in paths for base_path in BASE_PATHS)
         Project(dir_name).initialise()
-        assert new_dir_files_list == BASE_PATHS
-        assert len(new_dir_files_list) == BASE_PATHS_COUNT
+        paths = list_dir(dir_name)
+        assert all(base_path in paths for base_path in BASE_PATHS)
         # TODO: make sure we did not override the content of existing files!

--- a/sql-cli/tests/test_project.py
+++ b/sql-cli/tests/test_project.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from sql_cli.project import Project
 from tests.utils import list_dir
@@ -27,19 +26,17 @@ BASE_PATHS = [
 ]
 
 
-def test_initialise_project_with_dirname():
-    with TemporaryDirectory() as dir_name:
-        Project(dir_name).initialise()
-        paths = list_dir(dir_name)
-        assert all(base_path in paths for base_path in BASE_PATHS)
+def test_initialise_project_with_dirname(tmp_path):
+    Project(tmp_path).initialise()
+    paths = list_dir(tmp_path.as_posix())
+    assert all(base_path in paths for base_path in BASE_PATHS)
 
 
-def test_initialise_project_in_previously_initialised_dir():
-    with TemporaryDirectory() as dir_name:
-        Project(dir_name).initialise()
-        paths = list_dir(dir_name)
-        assert all(base_path in paths for base_path in BASE_PATHS)
-        Project(dir_name).initialise()
-        paths = list_dir(dir_name)
-        assert all(base_path in paths for base_path in BASE_PATHS)
-        # TODO: make sure we did not override the content of existing files!
+def test_initialise_project_in_previously_initialised_dir(tmp_path):
+    Project(tmp_path).initialise()
+    paths = list_dir(tmp_path.as_posix())
+    assert all(base_path in paths for base_path in BASE_PATHS)
+    Project(tmp_path).initialise()
+    paths = list_dir(tmp_path.as_posix())
+    assert all(base_path in paths for base_path in BASE_PATHS)
+    # TODO: make sure we did not override the content of existing files!


### PR DESCRIPTION
# Description

## What is the current behavior?

The current examples didn't work end-to-end e.g. via `flow run`, because the `conn_id` was missing.

## What is the new behavior?

- add sqlite_conn
- specify exact paths for test_project tests
- ignore .gitkeep files in copytree
- use tmp_path fixture instead of tempfile.TemporaryDirectory

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
