### PR TITLE
Add `row_count` on Table

### DIFF
--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -129,10 +129,15 @@ class BaseTable:
     @property
     def row_count(self) -> Any:
         """
-        Return the row count of table
+        Return the row count of table.
         """
-        # TODO: Implement this property
-        return 0
+        try:
+            db = create_database(self.conn_id)
+            return db.run_sql(
+                f"SELECT COUNT(*) from {db.get_table_qualified_name(self)}"  # skipcq: BAN-B608
+            ).scalar()
+        except Exception:
+            return 0
 
     def to_json(self):
         return {

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -5,7 +5,7 @@ import string
 from typing import Any
 
 from attr import define, field, fields_dict
-from sqlalchemy import Column, MetaData
+from sqlalchemy import Column, MetaData, select, func
 
 from astro.airflow.datasets import Dataset
 from astro.databases import create_database
@@ -131,8 +131,6 @@ class BaseTable:
         """
         Return the row count of table.
         """
-        from sqlalchemy import select, func
-
         db = create_database(self.conn_id)
         tb = db.get_sqla_table(table=self)
         query = select(func.count("*")).select_from(tb)

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -131,13 +131,12 @@ class BaseTable:
         """
         Return the row count of table.
         """
-        try:
-            db = create_database(self.conn_id)
-            return db.run_sql(
-                f"SELECT COUNT(*) from {db.get_table_qualified_name(self)}"  # skipcq: BAN-B608
-            ).scalar()
-        except Exception:
-            return 0
+        from sqlalchemy import select, func
+
+        db = create_database(self.conn_id)
+        tb = db.get_sqla_table(table=self)
+        query = select(func.count("*")).select_from(tb)
+        return db.run_sql(query).scalar()
 
     def to_json(self):
         return {

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -5,7 +5,7 @@ import string
 from typing import Any
 
 from attr import define, field, fields_dict
-from sqlalchemy import Column, MetaData, select, func
+from sqlalchemy import Column, MetaData, func, select
 
 from astro.airflow.datasets import Dataset
 from astro.databases import create_database

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -184,7 +184,9 @@ def test_python_sdk_transform_extract_on_complete():
     """
     imdb_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"),
+        input_file=File(
+            path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
+        ),
         output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
     ).execute({})
 

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -9,9 +9,10 @@ from astro.constants import FileType
 from astro.files import File
 from astro.lineage.extractor import PythonSDKExtractor
 from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
-from astro.sql import AppendOperator, MergeOperator
+from astro.sql import AppendOperator, MergeOperator, TransformOperator
 from astro.sql.operators.load_file import LoadFileOperator
 from astro.table import Metadata, Table
+from tests.utils.airflow import create_context
 
 TEST_FILE_LOCATION = "gs://astro-sdk/workspace/sample_pattern"
 TEST_TABLE = "test-table"
@@ -139,11 +140,20 @@ def test_merge_op_extract_on_complete():
     Test extractor ``extract_on_complete`` get called and collect lineage for merge operator
     """
     task_id = "merge"
-    src = Table(conn_id="bigquery", metadata=Metadata(schema="astro"))
-    target = Table(conn_id="bigquery", metadata=Metadata(schema="astro"))
+    src_table = LoadFileOperator(
+        task_id="load_file",
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
+    ).execute({})
+
+    target_table = LoadFileOperator(
+        task_id="load_file",
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
+    ).execute({})
     op = MergeOperator(
-        source_table=src,
-        target_table=target,
+        source_table=src_table,
+        target_table=target_table,
         target_conflict_columns=["id"],
         columns=["id", "name"],
         if_conflicts="update",
@@ -158,7 +168,7 @@ def test_merge_op_extract_on_complete():
 
     task_meta = python_sdk_extractor.extract_on_complete(task_instance)
     assert task_meta.name == f"adhoc_airflow.{task_id}"
-    assert task_meta.inputs[0].name == f"astronomer-dag-authoring.astro.{src.name}"
+    assert task_meta.inputs[0].name == f"astronomer-dag-authoring.astro.{src_table.name}"
     assert task_meta.inputs[0].namespace == "bigquery"
     assert task_meta.inputs[0].facets is not None
     assert len(task_meta.job_facets) > 0
@@ -172,8 +182,13 @@ def test_python_sdk_transform_extract_on_complete():
     operator's metadata that needs to be extracted as per OpenLineage
     for TransformOperator.
     """
-    imdb_table = (Table(name="imdb", conn_id="sqlite_default"),)
-    output_table = Table(name="test_name", conn_id="sqlite_default")
+    imdb_table = LoadFileOperator(
+        task_id="load_file",
+        input_file=File(path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"),
+        output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
+    ).execute({})
+
+    output_table = Table(name="test_name", conn_id="gcp_conn", metadata=Metadata(schema="astro"))
     task_id = "top_five_animations"
 
     @aql.transform
@@ -182,6 +197,7 @@ def test_python_sdk_transform_extract_on_complete():
 
     task = top_five_animations(input_table=imdb_table, output_table=output_table)
 
+    task.operator.execute(context=create_context(task.operator))
     tzinfo = pendulum.timezone("UTC")
     execution_date = timezone.datetime(2022, 1, 1, 1, 0, 0, tzinfo=tzinfo)
     task_instance = TaskInstance(task=task.operator, run_id=execution_date)

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -9,7 +9,7 @@ from astro.constants import FileType
 from astro.files import File
 from astro.lineage.extractor import PythonSDKExtractor
 from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
-from astro.sql import AppendOperator, MergeOperator, TransformOperator
+from astro.sql import AppendOperator, MergeOperator
 from astro.sql.operators.load_file import LoadFileOperator
 from astro.table import Metadata, Table
 from tests.utils.airflow import create_context

--- a/python-sdk/tests/utils/test_table.py
+++ b/python-sdk/tests/utils/test_table.py
@@ -2,8 +2,10 @@ from unittest import mock
 
 import pytest
 
+from astro.files import File
+from astro.sql import LoadFileOperator
 from astro.sql.operators.transform import TransformOperator
-from astro.table import BaseTable, Table
+from astro.table import BaseTable, Table, Metadata
 from astro.utils.table import find_first_table
 
 
@@ -89,3 +91,14 @@ def test_find_first_table(kwargs, return_type):
 @mock.patch("airflow.models.xcom_arg.PlainXComArg.resolve", return_value=Table())
 def test_find_first_table_with_xcom_arg(xcom_arg_resolve, kwargs, return_type):
     assert isinstance(find_first_table(context={}, **kwargs), return_type)
+
+
+@pytest.mark.integration
+def test_row_count():
+    imdb_table = LoadFileOperator(
+        task_id="load_file",
+        input_file=File(path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"),
+        output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
+    ).execute({})
+
+    assert imdb_table.row_count > 0

--- a/python-sdk/tests/utils/test_table.py
+++ b/python-sdk/tests/utils/test_table.py
@@ -95,6 +95,9 @@ def test_find_first_table_with_xcom_arg(xcom_arg_resolve, kwargs, return_type):
 
 @pytest.mark.integration
 def test_row_count():
+    """
+    Load file in bigquery and test the row count of bigquery table
+    """
     imdb_table = LoadFileOperator(
         task_id="load_file",
         input_file=File(path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"),

--- a/python-sdk/tests/utils/test_table.py
+++ b/python-sdk/tests/utils/test_table.py
@@ -5,7 +5,7 @@ import pytest
 from astro.files import File
 from astro.sql import LoadFileOperator
 from astro.sql.operators.transform import TransformOperator
-from astro.table import BaseTable, Table, Metadata
+from astro.table import BaseTable, Metadata, Table
 from astro.utils.table import find_first_table
 
 
@@ -100,7 +100,9 @@ def test_row_count():
     """
     imdb_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"),
+        input_file=File(
+            path="https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
+        ),
         output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
     ).execute({})
 


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/1073

Add row_count property in BaseTable class. 
Fixed the extractor tests accordingly 

## What is the current behavior?
We do not have a way to get table row count


## What is the new behavior?
Add row_count property in BaseTable class


## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
