### PR TITLE
Fix file size property

### DIFF
--- a/python-sdk/src/astro/files/locations/amazon/s3.py
+++ b/python-sdk/src/astro/files/locations/amazon/s3.py
@@ -43,7 +43,9 @@ class S3Location(BaseFileLocation):
 
     @property
     def size(self) -> int:
-        return -1
+        url = urlparse(self.path)
+        bucket_name = url.netloc
+        return self.hook.head_object(key=self.path, bucket_name=bucket_name).get("ContentLength") or -1
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/src/astro/files/locations/amazon/s3.py
+++ b/python-sdk/src/astro/files/locations/amazon/s3.py
@@ -43,6 +43,7 @@ class S3Location(BaseFileLocation):
 
     @property
     def size(self) -> int:
+        """Return file size for S3 location"""
         url = urlparse(self.path)
         bucket_name = url.netloc
         return self.hook.head_object(key=self.path, bucket_name=bucket_name).get("ContentLength") or -1

--- a/python-sdk/src/astro/files/locations/amazon/s3.py
+++ b/python-sdk/src/astro/files/locations/amazon/s3.py
@@ -47,7 +47,7 @@ class S3Location(BaseFileLocation):
         url = urlparse(self.path)
         bucket_name = url.netloc
         object_name = url.path
-        if object_name[0] == "/":
+        if object_name.startswith("/"):
             object_name = object_name[1:]
         return self.hook.head_object(key=object_name, bucket_name=bucket_name).get("ContentLength") or -1
 

--- a/python-sdk/src/astro/files/locations/amazon/s3.py
+++ b/python-sdk/src/astro/files/locations/amazon/s3.py
@@ -46,7 +46,10 @@ class S3Location(BaseFileLocation):
         """Return file size for S3 location"""
         url = urlparse(self.path)
         bucket_name = url.netloc
-        return self.hook.head_object(key=self.path, bucket_name=bucket_name).get("ContentLength") or -1
+        object_name = url.path
+        if object_name[0] == "/":
+            object_name = object_name[1:]
+        return self.hook.head_object(key=object_name, bucket_name=bucket_name).get("ContentLength") or -1
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/src/astro/files/locations/base.py
+++ b/python-sdk/src/astro/files/locations/base.py
@@ -49,7 +49,7 @@ class BaseFileLocation(ABC):
 
     @property
     @abstractmethod
-    def size(self):
+    def size(self) -> int:
         """Return the size in bytes of the given file"""
         raise NotImplementedError
 

--- a/python-sdk/src/astro/files/locations/google/gcs.py
+++ b/python-sdk/src/astro/files/locations/google/gcs.py
@@ -35,7 +35,12 @@ class GCSLocation(BaseFileLocation):
 
     @property
     def size(self) -> int:
-        return -1
+        url = urlparse(self.path)
+        bucket_name = url.netloc
+        object_name = url.path
+        if object_name[0] == "/":
+            object_name = object_name[1:]
+        return self.hook.get_size(bucket_name=bucket_name, object_name=object_name)
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/src/astro/files/locations/google/gcs.py
+++ b/python-sdk/src/astro/files/locations/google/gcs.py
@@ -41,7 +41,7 @@ class GCSLocation(BaseFileLocation):
         object_name = url.path
         if object_name[0] == "/":
             object_name = object_name[1:]
-        return self.hook.get_size(bucket_name=bucket_name, object_name=object_name)
+        return int(self.hook.get_size(bucket_name=bucket_name, object_name=object_name))
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/src/astro/files/locations/google/gcs.py
+++ b/python-sdk/src/astro/files/locations/google/gcs.py
@@ -35,6 +35,7 @@ class GCSLocation(BaseFileLocation):
 
     @property
     def size(self) -> int:
+        """Return file size for GCS location"""
         url = urlparse(self.path)
         bucket_name = url.netloc
         object_name = url.path

--- a/python-sdk/src/astro/files/locations/google/gcs.py
+++ b/python-sdk/src/astro/files/locations/google/gcs.py
@@ -39,7 +39,7 @@ class GCSLocation(BaseFileLocation):
         url = urlparse(self.path)
         bucket_name = url.netloc
         object_name = url.path
-        if object_name[0] == "/":
+        if object_name.startswith("/"):
             object_name = object_name[1:]
         return int(self.hook.get_size(bucket_name=bucket_name, object_name=object_name))
 

--- a/python-sdk/src/astro/files/locations/http.py
+++ b/python-sdk/src/astro/files/locations/http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from urllib.parse import urlparse
+import requests
 
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
@@ -18,7 +19,10 @@ class HTTPLocation(BaseFileLocation):
 
     @property
     def size(self) -> int:
-        return -1
+        print("self.pathself.pathself.pathself.path", self.path)
+        response = requests.head(self.path, allow_redirects=True)
+
+        return int(response.headers.get('content-length', -1))
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/src/astro/files/locations/http.py
+++ b/python-sdk/src/astro/files/locations/http.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 
-import requests
+from urllib.request import urlopen
 
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
@@ -21,8 +21,8 @@ class HTTPLocation(BaseFileLocation):
     @property
     def size(self) -> int:
         """Return file size for HTTP location"""
-        response = requests.head(self.path, allow_redirects=True)
-        return int(response.headers.get("content-length", -1))
+        file = urlopen(self.path)
+        return file.length
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/src/astro/files/locations/http.py
+++ b/python-sdk/src/astro/files/locations/http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import urllib
 from urllib.parse import urlparse
 
 from urllib.request import urlopen
@@ -21,8 +22,8 @@ class HTTPLocation(BaseFileLocation):
     @property
     def size(self) -> int:
         """Return file size for HTTP location"""
-        file = urlopen(self.path)
-        return file.length
+        file = urllib.request.urlopen(self.path)
+        return int(file.length)
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/src/astro/files/locations/http.py
+++ b/python-sdk/src/astro/files/locations/http.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import urllib
-from urllib.parse import urlparse
-
 from urllib.request import urlopen
+from urllib.parse import urlparse
 
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
@@ -22,7 +20,7 @@ class HTTPLocation(BaseFileLocation):
     @property
     def size(self) -> int:
         """Return file size for HTTP location"""
-        file = urllib.request.urlopen(self.path)
+        file = urlopen(self.path)   # skipcq BAN-B310
         return int(file.length)
 
     @property

--- a/python-sdk/src/astro/files/locations/http.py
+++ b/python-sdk/src/astro/files/locations/http.py
@@ -19,9 +19,8 @@ class HTTPLocation(BaseFileLocation):
 
     @property
     def size(self) -> int:
-        print("self.pathself.pathself.pathself.path", self.path)
+        """Return file size for HTTP location"""
         response = requests.head(self.path, allow_redirects=True)
-
         return int(response.headers.get('content-length', -1))
 
     @property

--- a/python-sdk/src/astro/files/locations/http.py
+++ b/python-sdk/src/astro/files/locations/http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from urllib.parse import urlparse
+
 import requests
 
 from astro.constants import FileLocation
@@ -21,7 +22,7 @@ class HTTPLocation(BaseFileLocation):
     def size(self) -> int:
         """Return file size for HTTP location"""
         response = requests.head(self.path, allow_redirects=True)
-        return int(response.headers.get('content-length', -1))
+        return int(response.headers.get("content-length", -1))
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/src/astro/files/locations/http.py
+++ b/python-sdk/src/astro/files/locations/http.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from urllib.request import urlopen
 from urllib.parse import urlparse
+from urllib.request import urlopen
 
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
@@ -20,7 +20,7 @@ class HTTPLocation(BaseFileLocation):
     @property
     def size(self) -> int:
         """Return file size for HTTP location"""
-        file = urlopen(self.path)   # skipcq BAN-B310
+        file = urlopen(self.path)  # skipcq BAN-B310
         return int(file.length)
 
     @property

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -32,7 +32,7 @@ INPUT_STATS = [
                 files=[
                     InputFileFacet(
                         filepath="gs://astro-sdk/workspace/sample_pattern.csv",
-                        file_size=-1,
+                        file_size=65,
                         file_type=FileType.CSV,
                     )
                 ],

--- a/python-sdk/tests/files/locations/test_gcs.py
+++ b/python-sdk/tests/files/locations/test_gcs.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 from google.cloud.storage import Client
@@ -25,5 +26,6 @@ def test_remote_object_store_prefix(remote_file):
 
 def test_size():
     """Test get_size() of for local file."""
-    location = create_file_location("gs://tmp/house1.csv")
-    assert location.size == -1
+    path = "gs://astro-sdk/workspace/sample_pattern.csv"
+    location = create_file_location(path)
+    assert location.size > 0

--- a/python-sdk/tests/files/locations/test_gcs.py
+++ b/python-sdk/tests/files/locations/test_gcs.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+
 import pytest
 from google.cloud.storage import Client
 

--- a/python-sdk/tests/files/locations/test_gcs.py
+++ b/python-sdk/tests/files/locations/test_gcs.py
@@ -26,7 +26,7 @@ def test_remote_object_store_prefix(remote_file):
 
 @pytest.mark.integration
 def test_size():
-    """Test get_size() of for local file."""
+    """Test get_size() of for GCS file."""
     path = "gs://astro-sdk/workspace/sample_pattern.csv"
     location = create_file_location(path)
     assert location.size > 0

--- a/python-sdk/tests/files/locations/test_gcs.py
+++ b/python-sdk/tests/files/locations/test_gcs.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import patch
 
 from google.cloud.storage import Client

--- a/python-sdk/tests/files/locations/test_gcs.py
+++ b/python-sdk/tests/files/locations/test_gcs.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-
+import pytest
 from google.cloud.storage import Client
 
 from astro.files.locations import create_file_location
@@ -23,6 +23,7 @@ def test_remote_object_store_prefix(remote_file):
     assert sorted(location.paths) == sorted(["gs://tmp/house1.csv", "gs://tmp/house2.csv"])
 
 
+@pytest.mark.integration
 def test_size():
     """Test get_size() of for local file."""
     path = "gs://astro-sdk/workspace/sample_pattern.csv"

--- a/python-sdk/tests/files/locations/test_http.py
+++ b/python-sdk/tests/files/locations/test_http.py
@@ -48,5 +48,7 @@ def test_describe_get_paths(path):  # skipcq: PYL-W0612, PTC-W0065
 
 def test_size():
     """Test get_size() of for local file."""
-    location = create_file_location("http://tmp/house2.csv")
-    assert location.size == -1
+    location = create_file_location(
+        "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
+    )
+    assert location.size > 0

--- a/python-sdk/tests/files/locations/test_http.py
+++ b/python-sdk/tests/files/locations/test_http.py
@@ -48,7 +48,7 @@ def test_describe_get_paths(path):  # skipcq: PYL-W0612, PTC-W0065
 
 @pytest.mark.integration
 def test_size():
-    """Test get_size() of for local file."""
+    """Test get_size() of for HTTP file."""
     location = create_file_location(
         "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb_v2.csv"
     )

--- a/python-sdk/tests/files/locations/test_http.py
+++ b/python-sdk/tests/files/locations/test_http.py
@@ -46,6 +46,7 @@ def test_describe_get_paths(path):  # skipcq: PYL-W0612, PTC-W0065
     assert location.paths == [path]
 
 
+@pytest.mark.integration
 def test_size():
     """Test get_size() of for local file."""
     location = create_file_location(

--- a/python-sdk/tests/files/locations/test_s3.py
+++ b/python-sdk/tests/files/locations/test_s3.py
@@ -28,7 +28,7 @@ def test_remote_object_store_prefix(remote_file):
 
 @pytest.mark.integration
 def test_size():
-    """Test get_size() of for s3 file."""
+    """Test get_size() of for S3 file."""
     location = S3Location(path="s3://astro-sdk/imdb.csv", conn_id="aws_conn")
     assert location.size > 0
 

--- a/python-sdk/tests/files/locations/test_s3.py
+++ b/python-sdk/tests/files/locations/test_s3.py
@@ -29,7 +29,7 @@ def test_remote_object_store_prefix(remote_file):
 @pytest.mark.integration
 def test_size():
     """Test get_size() of for s3 file."""
-    location = S3Location(path="s3://tmp/house2.csv", conn_id="aws_conn")
+    location = S3Location(path="s3://astro-sdk/imdb.csv", conn_id="aws_conn")
     assert location.size > 0
 
 

--- a/python-sdk/tests/files/locations/test_s3.py
+++ b/python-sdk/tests/files/locations/test_s3.py
@@ -28,7 +28,7 @@ def test_remote_object_store_prefix(remote_file):
 def test_size():
     """Test get_size() of for local file."""
     location = create_file_location("s3://tmp/house2.csv")
-    assert location.size == -1
+    assert location.size > 0
 
 
 @patch.dict(

--- a/python-sdk/tests/files/locations/test_s3.py
+++ b/python-sdk/tests/files/locations/test_s3.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from unittest.mock import patch
 
 from botocore.client import BaseClient
@@ -25,9 +26,10 @@ def test_remote_object_store_prefix(remote_file):
     assert sorted(location.paths) == sorted(["s3://tmp/house1.csv", "s3://tmp/house2.csv"])
 
 
+@pytest.mark.integration
 def test_size():
-    """Test get_size() of for local file."""
-    location = create_file_location("s3://tmp/house2.csv")
+    """Test get_size() of for s3 file."""
+    location = S3Location(path="s3://tmp/house2.csv", conn_id="aws_conn")
     assert location.size > 0
 
 

--- a/python-sdk/tests/files/locations/test_s3.py
+++ b/python-sdk/tests/files/locations/test_s3.py
@@ -1,7 +1,7 @@
 import os
-import pytest
 from unittest.mock import patch
 
+import pytest
 from botocore.client import BaseClient
 
 from astro.files.locations import create_file_location


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/1080
Fixed `size` property on location objects.

## What is the current behavior?
The `size` property on location objects return -1 except for the local location type


## What is the new behavior?
Now, the `size` property on location objects will return the actual file size


## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
