### PR TITLE
Use Intersphinx to avoid direct link to Airflow docs

### DIFF
--- a/python-sdk/docs/astro/files/operators/get_file_list.rst
+++ b/python-sdk/docs/astro/files/operators/get_file_list.rst
@@ -23,5 +23,5 @@ The following example retrieves a file list from the GCS bucket and dynamically 
 Related references
 ~~~~~~~~~~~~~~~~~~
 
-- `Dynamic task mapping - Apache Airflow <https://airflow.apache.org/docs/apache-airflow/2.3.0/concepts/dynamic-task-mapping.html>`_
+- :external+airflow:doc:`Dynamic task mapping - Apache Airflow <concepts/dynamic-task-mapping>`
 - `Dynamic tasks - Astronomer <https://www.astronomer.io/guides/dynamic-tasks/>`_

--- a/python-sdk/docs/astro/sql/operators/get_value_list.rst
+++ b/python-sdk/docs/astro/sql/operators/get_value_list.rst
@@ -20,5 +20,5 @@ We can use ``get_value_list`` when you want to execute a SQL query on a database
 Related references
 ~~~~~~~~~~~~~~~~~~
 
-- `Dynamic task mapping - Apache Airflow <https://airflow.apache.org/docs/apache-airflow/2.3.0/concepts/dynamic-task-mapping.html>`_
+- :external+airflow:doc:`Dynamic task mapping - Apache Airflow <concepts/dynamic-task-mapping>`
 - `Dynamic tasks - Astronomer <https://www.astronomer.io/guides/dynamic-tasks/>`_

--- a/python-sdk/docs/concepts.rst
+++ b/python-sdk/docs/concepts.rst
@@ -94,7 +94,7 @@ The parameter list passed to the decorated function is also added to the context
        :start-after: [START transform_example_3]
        :end-before: [END transform_example_3]
 
-More details can be found at `airflow templates reference <https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html>`_
+More details can be found at Airflow's :external+airflow:doc:`templates-ref`.
 
 .. _file_pattern:
 
@@ -174,7 +174,7 @@ Following is a view of dag dependencies on datasets
 
 .. image:: ./images/dag-dependencies-on-datasets.png
 
-More details can be found at `airflow datasets concept <https://airflow.apache.org/docs/apache-airflow/stable/concepts/datasets.html>`_
+More details can be found at Airflow's :external+airflow:doc:`concepts/dynamic-task-mapping`.
 
 .. Note::
     The concept of Datasets in astro-sdk is supported only from the **1.1.0** release ( and requires Airflow version **2.4.0** and above).

--- a/python-sdk/docs/conf.py
+++ b/python-sdk/docs/conf.py
@@ -37,7 +37,7 @@ release = __version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "autoapi.extension", "myst_parser"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "autoapi.extension", "myst_parser"]
 autodoc_typehints = "description"
 
 myst_all_links_external = True
@@ -62,6 +62,12 @@ templates_path = ["_autoapi_templates"]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "*.txt"]
+
+# Mapping to inter-sphinx linking.
+intersphinx_mapping = {
+    "airflow": ("https://airflow.apache.org/docs/apache-airflow/stable", None),
+    "airflow-postgres": ("https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable", None),
+}
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -42,15 +42,16 @@ class PostgresDatabase(BaseDatabase):
 
     @property
     def default_metadata(self) -> Metadata:
-        """
-        Fill in default metadata values for table objects addressing Postgres databases.
+        """Fill in default metadata values for table objects addressing Postgres databases.
 
-        Currently, Schema is not being fetched from airflow connection for Postgres because, in Postgres, databases and
-        schema are different concepts: https://www.postgresql.org/docs/current/ddl-schemas.html
+        Currently, Schema is not being fetched from airflow connection for Postgres because, in Postgres,
+        databases and schema are different concepts: https://www.postgresql.org/docs/current/ddl-schemas.html
+
         The PostgresHook only exposes schema:
-        https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/_api/airflow/providers/postgres/hooks/postgres/index.html
-        However, implementation-wise, it seems that if the PostgresHook receives a schema during initialization,
-        but it uses it as a database in the connection to Postgres:
+        :external+airflow-postgres:py:class:`airflow.providers.postgres.hooks.postgres.PostgresHook`
+
+        However, implementation-wise, it seems that if the PostgresHook receives a schema during
+        initialization, but it uses it as a database in the connection to Postgres:
         https://github.com/apache/airflow/blob/main/airflow/providers/postgres/hooks/postgres.py#L96
         """
         # TODO: Change airflow PostgresHook to fetch database and schema separately


### PR DESCRIPTION
Currently the documentation links to Airflow documentation pages directly; this uses [Intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) instead as a more robust way to manage the references.

There are probably other links that can be converted; they can be converted incrementally when encountered—I only changed the most obvious ones.