### PR TITLE
Add role and permission docs link

### DIFF
--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -170,21 +170,27 @@ Supported native transfers
    * - File Location
      - Database
      - native_support_kwargs params
+     - Permission
    * - S3
      - Bigquery
      - https://cloud.google.com/bigquery-transfer/docs/s3-transfer#bq
+     - https://cloud.google.com/bigquery/docs/s3-transfer#required_permissions and ``bigquery.jobs.create``
    * - GCS
      - Bigquery
      - https://cloud.google.com/bigquery-transfer/docs/cloud-storage-transfer#bq
+     - https://cloud.google.com/bigquery/docs/cloud-storage-transfer#required_permissions and ``bigquery.jobs.create``
    * - S3
      - Snowflake
      - https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html
+     - https://docs.snowflake.com/en/user-guide/data-load-s3.html
    * - GCS
      - Snowflake
      - https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html
+     - https://docs.snowflake.com/en/user-guide/data-load-gcs-config.html
    * - S3
      - Redshift
      - https://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html
+     - https://docs.aws.amazon.com/redshift/latest/dg/c-getting-started-using-spectrum-create-role.html
 
 .. note::
    For loading from S3 to Redshift database, although Redshift allows the below two options for authorization, **we


### PR DESCRIPTION
# Description
closes: #896 

## What is the current behavior?
docs for permission and role were missing

## What is the new behavior?
Add docs links in our docs for permission and role 

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
