### PR TITLE
Print custom error message for failed runs caused by Operational errors

### DIFF
--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -26,7 +26,7 @@ def set_logger_level(log_level: int) -> None:
         logging.getLogger(name).setLevel(log_level)
 
 
-set_logger_level(logging.ERROR)
+set_logger_level(logging.CRITICAL)
 
 
 @app.command(help="Print the SQL CLI version.")
@@ -135,12 +135,16 @@ def run(
         dags_directory=project.airflow_dags_folder,
     )
     dag = get_dag(dag_id=workflow_name, subdir=dag_file.parent.as_posix(), include_examples=False)
-    run_dag(
+    rprint(f"\nRunning the workflow [bold blue]{dag.dag_id}[/bold blue] for [bold]{env}[/bold] environment\n")
+    dr = run_dag(
         dag,
         run_conf=project.airflow_config,
         connections={c.conn_id: c for c in project.connections},
         verbose=verbose,
     )
+    rprint(f"Completed running the workflow {dr.dag_id}: [bold yellow][{dr.state.upper()}][/bold yellow]")
+    elapsed_seconds = (dr.end_date - dr.start_date).microseconds / 10**6
+    rprint(f"Total elapsed time: [bold blue]{elapsed_seconds:.2}s[/bold blue]")
 
 
 @app.command(

--- a/sql-cli/sql_cli/run_dag.py
+++ b/sql-cli/sql_cli/run_dag.py
@@ -16,6 +16,7 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State
 from airflow.utils.types import DagRunType
 from rich import print as pprint
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.session import Session
 
 from astro.sql.operators.cleanup import AstroCleanupException
@@ -51,7 +52,7 @@ def run_dag(
     connections: dict[str, Connection] | None = None,
     verbose: bool = False,
     session: Session = NEW_SESSION,
-) -> None:
+) -> DagRun:
     """
     Execute one single DagRun for a given DAG and execution date.
 
@@ -61,8 +62,9 @@ def run_dag(
     :param conn_file_path: file path to a connection file in either yaml or json
     :param variable_file_path: file path to a variable file in either yaml or json
     :param session: database connection (optional)
-    """
 
+    :return: the dag run object
+    """
     execution_date = execution_date or timezone.utcnow()
     dag.log.debug("Clearing existing task instances for execution date %s", execution_date)
     dag.clear(
@@ -104,12 +106,10 @@ def run_dag(
                 add_logger_if_needed(dag, ti)
             ti.task = tasks[ti.task_id]
             _run_task(ti, session=session)
-    pprint(f"Completed running the workflow {dr.dag_id}: [bold yellow][{dr.state.upper()}][/bold yellow]")
-    elapsed_seconds = (dr.end_date - dr.start_date).microseconds / 10**6
-    pprint(f"Total elapsed time: [bold blue]{elapsed_seconds:.2}s[/bold blue]")
     if conn_file_path or variable_file_path or connections:
         # Remove the local variables we have added to the secrets_backend_list
         secrets_backend_list.pop(0)  # noqa
+    return dr
 
 
 def add_logger_if_needed(dag: DAG, ti: TaskInstance) -> None:
@@ -117,8 +117,8 @@ def add_logger_if_needed(dag: DAG, ti: TaskInstance) -> None:
     Add a formatted logger to the taskinstance so all logs are surfaced to the command line instead
     of into a task file. Since this is a local test run, it is much better for the user to see logs
     in the command line, rather than needing to search for a log file.
-    :param ti: The taskinstance that will receive a logger
 
+    :param ti: The taskinstance that will receive a logger
     """
     logging_format = logging.Formatter("[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s")
     handler = logging.StreamHandler(sys.stdout)
@@ -149,6 +149,10 @@ def _run_task(ti: TaskInstance, session: Session) -> None:
         session.flush()
         session.commit()
         pprint("[bold green]SUCCESS[/bold green]")
+    except OperationalError as operational_exception:
+        pprint("[bold red]FAILED[/bold red]")
+        original_message = operational_exception.orig.args[0]
+        pprint(f"  Error [red]{original_message}[/red] using connection [bold]{ti.task.conn_id}[/bold].")
     except AstroCleanupException:
         pprint("aql.cleanup async, continuing")
 
@@ -164,12 +168,14 @@ def _get_or_create_dagrun(
     """
     Create a DAGRun, but only after clearing the previous instance of said dagrun to prevent collisions.
     This function is only meant for the `dag.test` function as a helper function.
+
     :param dag: Dag to be used to find dagrun
     :param conf: configuration to pass to newly created dagrun
     :param start_date: start date of new dagrun, defaults to execution_date
     :param execution_date: execution_date for finding the dagrun
     :param run_id: run_id to pass to new dagrun
     :param session: sqlalchemy session
+
     :return: the Dagrun object needed to run tasks.
     """
     log.info("dagrun id: %s", dag.dag_id)
@@ -189,5 +195,4 @@ def _get_or_create_dagrun(
         session=session,
         conf=conf,  # type: ignore
     )
-    pprint(f"\nRunning the workflow [bold blue]{dag.dag_id}[/bold blue]\n")
     return dr

--- a/sql-cli/tests/test_run_dag.py
+++ b/sql-cli/tests/test_run_dag.py
@@ -1,9 +1,11 @@
 import pathlib
+import sqlite3
 from unittest import mock
 
 from airflow.decorators import task
 from airflow.utils.cli import get_dag
 from airflow.utils.trigger_rule import TriggerRule
+from sqlalchemy.exc import OperationalError
 
 from astro import sql as aql
 from sql_cli.run_dag import _run_task, run_dag
@@ -20,6 +22,27 @@ def test_run_task_successfully(mock_session, mock_task_instance, capsys):
     mock_session.flush.assert_called_once()
     captured = capsys.readouterr()
     assert "SUCCESS" in captured.out
+
+
+@mock.patch("airflow.models.taskinstance.TaskInstance")
+@mock.patch("airflow.settings.SASession")
+def test_run_task_failed(mock_session, mock_task_instance, capsys):
+    mock_task_instance.task.conn_id = "sqlite_conn"
+    mock_task_instance._run_raw_task.side_effect = OperationalError(
+        statement=mock.ANY,
+        params=mock.ANY,
+        orig=sqlite3.OperationalError("no such table: orders"),
+    )
+    mock_task_instance.map_index = 0
+    _run_task(mock_task_instance, mock_session)
+    mock_task_instance._run_raw_task.assert_called_once()
+    mock_session.flush.assert_not_called()
+    captured = capsys.readouterr()
+    assert "FAILED" in captured.out
+    assert (
+        f"  Error {mock_task_instance._run_raw_task.side_effect.orig.args[0]}"
+        f" using connection {mock_task_instance.task.conn_id}." in captured.out
+    )
 
 
 def test_run_task_cleanup_log(sample_dag, capsys):


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we don't capture Operational database errors. For more details see the issue below.

closes: #1107

## What is the new behavior?

We print a custom error message for failed runs caused by Operational errors.

- change logger level to CRITICAL
- move workflow print statements to cli
- use tempdir instead of /tmp
- add more tests for failed runs

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
