### PR TITLE
Do not try to create DAG for invalid workflow

### DIFF
--- a/sql-cli/conftest.py
+++ b/sql-cli/conftest.py
@@ -157,3 +157,12 @@ def connections():
     return [
         Connection(conn_id="sqlite_conn", conn_type="sqlite", host="data/imdb.db"),
     ]
+
+
+@pytest.fixture()
+def initialised_project_with_empty_workflow(initialised_project: Project):
+    shutil.copytree(
+        src=CWD / "tests" / "workflows" / "empty",
+        dst=initialised_project.directory / "workflows" / "empty",
+    )
+    return initialised_project

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -9,6 +9,7 @@ import sql_cli
 from sql_cli.connections import validate_connections
 from sql_cli.constants import DEFAULT_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER
 from sql_cli.dag_generator import generate_dag
+from sql_cli.exceptions import EmptyDag, SqlFilesDirectoryNotFound
 from sql_cli.project import Project
 from sql_cli.run_dag import run_dag
 from sql_cli.utils.airflow import (
@@ -58,10 +59,17 @@ def generate(
     project = Project(project_dir_absolute)
     project.load_config(env)
 
-    dag_file = generate_dag(
-        directory=project.directory / project.workflows_directory / workflow_name,
-        dags_directory=project.airflow_dags_folder,
-    )
+    try:
+        dag_file = generate_dag(
+            directory=project.directory / project.workflows_directory / workflow_name,
+            dags_directory=project.airflow_dags_folder,
+        )
+    except EmptyDag:
+        rprint("[bold red]The workflow does not have any SQL files![/bold red]")
+        raise typer.Exit(code=1)
+    except SqlFilesDirectoryNotFound:
+        rprint("[bold red]A workflow with the given name does not exist![/bold red]")
+        raise typer.Exit(code=1)
     rprint("The DAG file", dag_file.resolve(), "has been successfully generated. 🎉")
 
 
@@ -130,10 +138,17 @@ def run(
     airflow_meta_conn = retrieve_airflow_database_conn_from_config(project.directory / project.airflow_home)
     set_airflow_database_conn(airflow_meta_conn)
 
-    dag_file = generate_dag(
-        directory=project.directory / project.workflows_directory / workflow_name,
-        dags_directory=project.airflow_dags_folder,
-    )
+    try:
+        dag_file = generate_dag(
+            directory=project.directory / project.workflows_directory / workflow_name,
+            dags_directory=project.airflow_dags_folder,
+        )
+    except EmptyDag:
+        rprint("[bold red]The workflow does not have any SQL files![/bold red]")
+        raise typer.Exit(code=1)
+    except SqlFilesDirectoryNotFound:
+        rprint("[bold red]A workflow with the given name does not exist![/bold red]")
+        raise typer.Exit(code=1)
     dag = get_dag(dag_id=workflow_name, subdir=dag_file.parent.as_posix(), include_examples=False)
     run_dag(
         dag,

--- a/sql-cli/sql_cli/dag_generator.py
+++ b/sql-cli/sql_cli/dag_generator.py
@@ -25,7 +25,7 @@ class SqlFilesDAG:
     start_date: datetime
     sql_files: list[SqlFile]
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.sql_files:
             raise EmptyDag("Missing SQL files!")
 

--- a/sql-cli/sql_cli/dag_generator.py
+++ b/sql-cli/sql_cli/dag_generator.py
@@ -6,12 +6,12 @@ from pathlib import Path
 
 from networkx import DiGraph, depth_first_search, find_cycle, is_directed_acyclic_graph
 
-from sql_cli.exceptions import DagCycle
+from sql_cli.exceptions import DagCycle, EmptyDag, SqlFilesDirectoryNotFound
 from sql_cli.sql_directory_parser import SqlFile, get_sql_files
 from sql_cli.utils.jinja import render
 
 
-@dataclass
+@dataclass(frozen=True)
 class SqlFilesDAG:
     """
     A DAG of sql files i.e. used for finding the right order to execute the sql files in.
@@ -24,6 +24,10 @@ class SqlFilesDAG:
     dag_id: str
     start_date: datetime
     sql_files: list[SqlFile]
+
+    def __post_init__(self):
+        if not self.sql_files:
+            raise EmptyDag("Missing SQL files!")
 
     def has_sql_file(self, variable_name: str) -> bool:
         """
@@ -89,6 +93,8 @@ def generate_dag(directory: Path, dags_directory: Path) -> Path:
 
     :returns: the path to the DAG file.
     """
+    if not directory.exists():
+        raise SqlFilesDirectoryNotFound("The directory does not exist!")
     sql_files = sorted(get_sql_files(directory, target_directory=dags_directory / "sql"))
     sql_files_dag = SqlFilesDAG(
         dag_id=directory.name,

--- a/sql-cli/sql_cli/exceptions.py
+++ b/sql-cli/sql_cli/exceptions.py
@@ -4,3 +4,11 @@ class DagCycle(Exception):
 
 class InvalidProject(Exception):
     """An exception raised when Project is invalid."""
+
+
+class EmptyDag(Exception):
+    """An exception raised when there are no SQL files within the DAG."""
+
+
+class SqlFilesDirectoryNotFound(Exception):
+    """An exception raised when the sql files directory does not exist."""

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -64,6 +64,28 @@ def test_generate(workflow_name, environment, initialised_project):
 
 
 @pytest.mark.parametrize(
+    "workflow_name,message",
+    [
+        ("empty", "The workflow does not have any SQL files!"),
+        ("foo", "A workflow with the given name does not exist!"),
+    ],
+)
+def test_generate_fails(workflow_name, message, initialised_project_with_empty_workflow):
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            workflow_name,
+            "--project-dir",
+            initialised_project_with_empty_workflow.directory.as_posix(),
+        ],
+    )
+    assert result.exit_code == 1
+    result_stdout = get_stdout(result)
+    assert result_stdout == message
+
+
+@pytest.mark.parametrize(
     "env,connection,status",
     [
         ("default", "sqlite_conn", "PASSED"),
@@ -127,6 +149,28 @@ def test_run(workflow_name, environment, initialised_project):
     assert result.exit_code == 0
     result_stdout = get_stdout(result)
     assert f"Completed running the workflow {workflow_name}: [SUCCESS]" in result_stdout
+
+
+@pytest.mark.parametrize(
+    "workflow_name,message",
+    [
+        ("empty", "The workflow does not have any SQL files!"),
+        ("foo", "A workflow with the given name does not exist!"),
+    ],
+)
+def test_run_fails(workflow_name, message, initialised_project_with_empty_workflow):
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            workflow_name,
+            "--project-dir",
+            initialised_project_with_empty_workflow.directory.as_posix(),
+        ],
+    )
+    assert result.exit_code == 1
+    result_stdout = get_stdout(result)
+    assert result_stdout == message
 
 
 def test_init_with_directory(tmp_path):

--- a/sql-cli/tests/test_dag_generator.py
+++ b/sql-cli/tests/test_dag_generator.py
@@ -1,6 +1,10 @@
-import pytest
+from pathlib import Path
 
-from sql_cli.dag_generator import DagCycle, generate_dag
+import pytest
+from conftest import DEFAULT_DATE
+
+from sql_cli.dag_generator import SqlFilesDAG, generate_dag
+from sql_cli.exceptions import DagCycle, EmptyDag, SqlFilesDirectoryNotFound
 
 
 def test_sql_files_dag(sql_files_dag, sql_files_dag_with_parameters, sql_file, sql_file_with_parameters):
@@ -9,13 +13,25 @@ def test_sql_files_dag(sql_files_dag, sql_files_dag_with_parameters, sql_file, s
     assert sql_files_dag_with_parameters.sorted_sql_files() == [sql_file_with_parameters]
 
 
-def test_sql_files_dag_raises_exception(sql_files_dag_with_cycle):
+def test_sql_files_dag_with_cycle(sql_files_dag_with_cycle):
     """Test that an exception is being raised when it is not a DAG."""
     with pytest.raises(DagCycle):
         assert sql_files_dag_with_cycle.sorted_sql_files()
+
+
+def test_sql_files_dag_without_sql_files():
+    """Test that an exception is being raised when it does not have sql files."""
+    with pytest.raises(EmptyDag):
+        SqlFilesDAG(dag_id="sql_files_dag_without_sql_files", start_date=DEFAULT_DATE, sql_files=[])
 
 
 def test_generate_dag(root_directory, dags_directory):
     """Test that the whole DAG generation process including sql files parsing works."""
     dag_file = generate_dag(directory=root_directory, dags_directory=dags_directory)
     assert dag_file
+
+
+def test_generate_dag_invalid_directory(root_directory, dags_directory):
+    """Test that an exception is being raised when the directory does not exist."""
+    with pytest.raises(SqlFilesDirectoryNotFound):
+        generate_dag(directory=Path("foo"), dags_directory=dags_directory)


### PR DESCRIPTION
# Description

## What is the current behavior?

See issue below.

closes: #1108

## What is the new behavior?

We no longer try to create a DAG from an invalid workflow directory.

- fix dag creation on invalid workflow name
- fix dag creation on empty workflow

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
