### PR TITLE
Transform op - database is not picked from metadata

### DIFF
--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -36,6 +36,17 @@ connections:
       role: "AIRFLOW_TEST_USER"
       warehouse: ROBOTS
       database: SANDBOX
+  - conn_id: snowflake_conn_1
+    conn_type: snowflake
+    host: https://gp21411.us-east-1.snowflakecomputing.com
+    port: 443
+    login: $SNOWFLAKE_ACCOUNT_NAME
+    password: $SNOWFLAKE_PASSWORD
+    extra:
+      account: "gp21411"
+      region: "us-east-1"
+      role: "AIRFLOW_TEST_USER"
+      warehouse: ROBOTS
   - conn_id: bigquery
     conn_type: bigquery
     description: null

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -37,6 +37,7 @@ env:
   POSTGRES_HOST: postgres
   POSTGRES_PORT: 5432
   AIRFLOW__ASTRO_SDK__SQL_SCHEMA: astroflow_ci
+  AIRFLOW__ASTRO_SDK__POSTGRES_DEFAULT_SCHEMA: postres
   REDSHIFT_DATABASE: dev
   REDSHIFT_HOST: utkarsh-cluster.cdru7mxqmtyx.us-east-2.redshift.amazonaws.com
   SNOWFLAKE_SCHEMA: ASTROFLOW_CI

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -37,7 +37,7 @@ env:
   POSTGRES_HOST: postgres
   POSTGRES_PORT: 5432
   AIRFLOW__ASTRO_SDK__SQL_SCHEMA: astroflow_ci
-  AIRFLOW__ASTRO_SDK__POSTGRES_DEFAULT_SCHEMA: postres
+  AIRFLOW__ASTRO_SDK__POSTGRES_DEFAULT_SCHEMA: postgres
   REDSHIFT_DATABASE: dev
   REDSHIFT_HOST: utkarsh-cluster.cdru7mxqmtyx.us-east-2.redshift.amazonaws.com
   SNOWFLAKE_SCHEMA: ASTROFLOW_CI

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -37,7 +37,6 @@ env:
   POSTGRES_HOST: postgres
   POSTGRES_PORT: 5432
   AIRFLOW__ASTRO_SDK__SQL_SCHEMA: astroflow_ci
-  AIRFLOW__ASTRO_SDK__POSTGRES_DEFAULT_SCHEMA: postgres
   REDSHIFT_DATABASE: dev
   REDSHIFT_HOST: utkarsh-cluster.cdru7mxqmtyx.us-east-2.redshift.amazonaws.com
   SNOWFLAKE_SCHEMA: ASTROFLOW_CI

--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -72,7 +72,6 @@ def sample_dag():
 def create_unique_table_name(length: int = MAX_TABLE_NAME_LENGTH) -> str:
     """
     Create a unique table name of the requested size, which is compatible with all supported databases.
-
     :return: Unique table name
     :rtype: str
     """
@@ -98,7 +97,6 @@ def schemas_fixture(request, database_table_fixture):
     """
     Given request.param in the format:
         "someschema"  # name of the schema to be created
-
     If the schema exists, it is deleted during the tests setup and tear down.
     """
     schema_name = request.param
@@ -124,7 +122,6 @@ def database_table_fixture(request):
         (database, table)
     Example:
         (astro.databases.sqlite.SqliteDatabase(), Table())
-
     If the table exists, it is deleted during the tests setup and tear down.
     The table will only be created during setup if request.param contains the `file` parameter.
     """
@@ -183,7 +180,6 @@ def multiple_tables_fixture(request, database_table_fixture):
         ]
     }
     If the table key is missing, the fixture creates a table using the database.conn_id.
-
     For each table in the list, if the table exists, it is deleted during the tests setup and tear down.
     The table will only be created during setup if the item contains the "file" to be loaded to the table.
     """
@@ -216,7 +212,6 @@ def remote_files_fixture(request):
     Return a list of remote object filenames.
     By default, this fixture also creates objects using sample.<filetype>, unless
     the user uses file_create=false.
-
     Given request.param in the format:
         {
             "provider": "google",  # mandatory, may be "google" or "amazon"
@@ -231,7 +226,6 @@ def remote_files_fixture(request):
             "gs://some-bucket/test/8df8aea0-9b2e-4671-b84e-2d48f42a182f0.csv",
             "gs://some-bucket/test/8df8aea0-9b2e-4671-b84e-2d48f42a182f1.csv"
         ]
-
     If the objects exist, they are deleted during the tests setup and tear down.
     """
     params = request.param

--- a/python-sdk/src/astro/databases/__init__.py
+++ b/python-sdk/src/astro/databases/__init__.py
@@ -8,6 +8,7 @@ from astro.utils.path import get_class_name, get_dict_with_module_names_to_dot_n
 
 if TYPE_CHECKING:
     from astro.databases.base import BaseDatabase
+    from astro.table import BaseTable
 
 DEFAULT_CONN_TYPE_TO_MODULE_PATH = get_dict_with_module_names_to_dot_notations(Path(__file__))
 CUSTOM_CONN_TYPE_TO_MODULE_PATH = {
@@ -21,7 +22,7 @@ CONN_TYPE_TO_MODULE_PATH = {
 SUPPORTED_DATABASES = set(DEFAULT_CONN_TYPE_TO_MODULE_PATH.keys())
 
 
-def create_database(conn_id: str, table: object | None = None, ) -> "BaseDatabase":
+def create_database(conn_id: str, table: BaseTable | None = None, ) -> "BaseDatabase":
     """
     Given a conn_id, return the associated Database class.
 

--- a/python-sdk/src/astro/databases/__init__.py
+++ b/python-sdk/src/astro/databases/__init__.py
@@ -22,7 +22,10 @@ CONN_TYPE_TO_MODULE_PATH = {
 SUPPORTED_DATABASES = set(DEFAULT_CONN_TYPE_TO_MODULE_PATH.keys())
 
 
-def create_database(conn_id: str, table: BaseTable | None = None, ) -> "BaseDatabase":
+def create_database(
+    conn_id: str,
+    table: BaseTable | None = None,
+) -> BaseDatabase:
     """
     Given a conn_id, return the associated Database class.
 
@@ -35,5 +38,5 @@ def create_database(conn_id: str, table: BaseTable | None = None, ) -> "BaseData
     module_path = CONN_TYPE_TO_MODULE_PATH[conn_type]
     module = importlib.import_module(module_path)
     class_name = get_class_name(module_ref=module, suffix="Database")
-    database: "BaseDatabase" = getattr(module, class_name)(conn_id, table)
+    database: BaseDatabase = getattr(module, class_name)(conn_id, table)
     return database

--- a/python-sdk/src/astro/databases/__init__.py
+++ b/python-sdk/src/astro/databases/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from astro.utils.path import get_class_name, get_dict_with_module_names_to_dot_notations
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from astro.databases.base import BaseDatabase
     from astro.table import BaseTable
 

--- a/python-sdk/src/astro/databases/__init__.py
+++ b/python-sdk/src/astro/databases/__init__.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+#from astro.table import BaseTable
 from astro.utils.path import get_class_name, get_dict_with_module_names_to_dot_notations
 
 if TYPE_CHECKING:
@@ -19,11 +22,12 @@ CONN_TYPE_TO_MODULE_PATH = {
 SUPPORTED_DATABASES = set(DEFAULT_CONN_TYPE_TO_MODULE_PATH.keys())
 
 
-def create_database(conn_id: str) -> "BaseDatabase":
+def create_database(conn_id: str, table: object | None = None, ) -> "BaseDatabase":
     """
     Given a conn_id, return the associated Database class.
 
     :param conn_id: Database connection ID in Airflow
+    :param table: (optional) The Table object
     """
     from airflow.hooks.base import BaseHook
 
@@ -31,5 +35,5 @@ def create_database(conn_id: str) -> "BaseDatabase":
     module_path = CONN_TYPE_TO_MODULE_PATH[conn_type]
     module = importlib.import_module(module_path)
     class_name = get_class_name(module_ref=module, suffix="Database")
-    database: "BaseDatabase" = getattr(module, class_name)(conn_id)
+    database: "BaseDatabase" = getattr(module, class_name)(conn_id, table)
     return database

--- a/python-sdk/src/astro/databases/__init__.py
+++ b/python-sdk/src/astro/databases/__init__.py
@@ -4,7 +4,6 @@ import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-#from astro.table import BaseTable
 from astro.utils.path import get_class_name, get_dict_with_module_names_to_dot_notations
 
 if TYPE_CHECKING:

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -88,6 +88,7 @@ class RedshiftDatabase(BaseDatabase):
         kwargs = {}
         _hook = RedshiftSQLHook(redshift_conn_id=self.conn_id, use_legacy_sql=False)
         database = _hook.conn.schema
+        # currently, kwargs might not get used because Airflow hook accept it but does not use it.
         if (database is None) and (self.table and self.table.metadata and self.table.metadata.database):
             kwargs.update({"schema": self.table.metadata.database})
         return RedshiftSQLHook(redshift_conn_id=self.conn_id, use_legacy_sql=False, **kwargs)

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -1,7 +1,7 @@
 """AWS Redshift table implementation."""
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import pandas as pd
 import sqlalchemy

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -84,9 +84,8 @@ class RedshiftDatabase(BaseDatabase):
     def hook(self) -> RedshiftSQLHook:
         """Retrieve Airflow hook to interface with the Redshift database."""
         kwargs = {}
-        if self.table and self.table.metadata:
-            if self.table.metadata.database:
-                kwargs.update({"schema": self.table.metadata.database})
+        if self.table and self.table.metadata and self.table.metadata.database:
+            kwargs.update({"schema": self.table.metadata.database})
         return RedshiftSQLHook(redshift_conn_id=self.conn_id, use_legacy_sql=False)
 
     @property

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -86,9 +86,11 @@ class RedshiftDatabase(BaseDatabase):
     def hook(self) -> RedshiftSQLHook:
         """Retrieve Airflow hook to interface with the Redshift database."""
         kwargs = {}
-        if self.table and self.table.metadata and self.table.metadata.database:
+        _hook = RedshiftSQLHook(redshift_conn_id=self.conn_id, use_legacy_sql=False)
+        database = _hook.conn.schema
+        if (database is None) and (self.table and self.table.metadata and self.table.metadata.database):
             kwargs.update({"schema": self.table.metadata.database})
-        return RedshiftSQLHook(redshift_conn_id=self.conn_id, use_legacy_sql=False)
+        return RedshiftSQLHook(redshift_conn_id=self.conn_id, use_legacy_sql=False, **kwargs)
 
     @property
     def sqlalchemy_engine(self) -> Engine:

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -1,4 +1,6 @@
 """AWS Redshift table implementation."""
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
@@ -71,7 +73,7 @@ class RedshiftDatabase(BaseDatabase):
     illegal_column_name_chars: List[str] = ["."]
     illegal_column_name_chars_replacement: List[str] = ["_"]
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable | None = None):
         super().__init__(conn_id)
         self._create_table_statement: str = "CREATE TABLE {} AS {}"
         self.table = table

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -71,7 +71,7 @@ class RedshiftDatabase(BaseDatabase):
     illegal_column_name_chars: List[str] = ["."]
     illegal_column_name_chars_replacement: List[str] = ["_"]
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
         super().__init__(conn_id)
         self._create_table_statement: str = "CREATE TABLE {} AS {}"
         self.table = table

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -74,6 +74,7 @@ class RedshiftDatabase(BaseDatabase):
     def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
         self._create_table_statement: str = "CREATE TABLE {} AS {}"
+        self.table = table
 
     @property
     def sql_type(self):
@@ -82,6 +83,10 @@ class RedshiftDatabase(BaseDatabase):
     @property
     def hook(self) -> RedshiftSQLHook:
         """Retrieve Airflow hook to interface with the Redshift database."""
+        kwargs = {}
+        if self.table and self.table.metadata:
+            if self.table.metadata.database:
+                kwargs.update({"schema": self.table.metadata.database})
         return RedshiftSQLHook(redshift_conn_id=self.conn_id, use_legacy_sql=False)
 
     @property

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -70,8 +70,8 @@ class RedshiftDatabase(BaseDatabase):
         FileLocation.S3: "load_s3_file_to_table",
     }
 
-    illegal_column_name_chars: List[str] = ["."]
-    illegal_column_name_chars_replacement: List[str] = ["_"]
+    illegal_column_name_chars: list[str] = ["."]
+    illegal_column_name_chars_replacement: list[str] = ["_"]
 
     def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable | None = None):
         super().__init__(conn_id)
@@ -158,12 +158,12 @@ class RedshiftDatabase(BaseDatabase):
         if_conflicts: MergeConflictStrategy,
         stage_table_name: str,
         source_table_name: str,
-        source_to_target_map_source_columns: List[str],
-        source_to_target_map_target_columns: List[str],
+        source_to_target_map_source_columns: list[str],
+        source_to_target_map_target_columns: list[str],
         source_table_all_columns_string: str,
         target_table_all_columns_string: str,
-        target_conflict_columns: List[str],
-    ) -> Optional[List[str]]:
+        target_conflict_columns: list[str],
+    ) -> list[str] | None:
         """
         Builds conflict SQL statement to be applied while merging.
 
@@ -217,8 +217,8 @@ class RedshiftDatabase(BaseDatabase):
         self,
         source_table: BaseTable,
         target_table: BaseTable,
-        source_to_target_columns_map: Dict[str, str],
-        target_conflict_columns: List[str],
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
         if_conflicts: MergeConflictStrategy = "exception",
     ) -> None:
         """
@@ -260,7 +260,7 @@ class RedshiftDatabase(BaseDatabase):
             f"INSERT INTO {stage_table_name}({target_table_all_columns_string}) "
             f"SELECT {target_table_all_columns_string} FROM {target_table_name}"
         )
-        conflict_statements: Optional[List[str]] = self._get_conflict_statements(
+        conflict_statements: list[str] | None = self._get_conflict_statements(
             if_conflicts,
             stage_table_name,
             source_table_name,
@@ -307,7 +307,7 @@ class RedshiftDatabase(BaseDatabase):
         source_file: File,
         target_table: BaseTable,
         if_exists: LoadExistStrategy = "replace",
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         """
@@ -339,7 +339,7 @@ class RedshiftDatabase(BaseDatabase):
         self,
         source_file: File,
         target_table: BaseTable,
-        native_support_kwargs: Optional[Dict] = None,
+        native_support_kwargs: dict | None = None,
         **kwargs,
     ):
         """

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -71,7 +71,7 @@ class RedshiftDatabase(BaseDatabase):
     illegal_column_name_chars: List[str] = ["."]
     illegal_column_name_chars_replacement: List[str] = ["_"]
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
         self._create_table_statement: str = "CREATE TABLE {} AS {}"
 

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, Optional
 
 import pandas as pd
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
@@ -102,7 +102,7 @@ class BigqueryDatabase(BaseDatabase):
         DatabaseCustomError,
     )
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
         super().__init__(conn_id)
         self.table = table
 

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Mapping
 
 import pandas as pd
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -104,6 +104,7 @@ class BigqueryDatabase(BaseDatabase):
 
     def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
+        self.table = table
 
     @property
     def sql_type(self) -> str:

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -102,7 +102,7 @@ class BigqueryDatabase(BaseDatabase):
         DatabaseCustomError,
     )
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable | None = None):
         super().__init__(conn_id)
         self.table = table
 

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -102,7 +102,7 @@ class BigqueryDatabase(BaseDatabase):
         DatabaseCustomError,
     )
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
 
     @property

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 from contextlib import closing
+from typing import Optional
 
 import pandas as pd
 import sqlalchemy
@@ -28,7 +29,7 @@ class PostgresDatabase(BaseDatabase):
     illegal_column_name_chars: list[str] = ["."]
     illegal_column_name_chars_replacement: list[str] = ["_"]
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
         super().__init__(conn_id)
         self.table = table
 

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -39,9 +39,9 @@ class PostgresDatabase(BaseDatabase):
     @property
     def hook(self) -> PostgresHook:
         """Retrieve Airflow hook to interface with the Postgres database."""
-        _hook = PostgresHook(postgres_conn_id=self.conn_id).get_connection(self.conn_id)
+        conn = PostgresHook(postgres_conn_id=self.conn_id).get_connection(self.conn_id)
         kwargs = {}
-        if (_hook.schema is None) and (self.table and self.table.metadata and self.table.metadata.schema):
+        if (conn.schema is None) and (self.table and self.table.metadata and self.table.metadata.schema):
             kwargs.update({"schema": self.table.metadata.schema})
         return PostgresHook(postgres_conn_id=self.conn_id, **kwargs)
 

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -28,7 +28,7 @@ class PostgresDatabase(BaseDatabase):
     illegal_column_name_chars: list[str] = ["."]
     illegal_column_name_chars_replacement: list[str] = ["_"]
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
 
     @property

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -29,7 +29,7 @@ class PostgresDatabase(BaseDatabase):
     illegal_column_name_chars: list[str] = ["."]
     illegal_column_name_chars_replacement: list[str] = ["_"]
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable | None = None):
         super().__init__(conn_id)
         self.table = table
 

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -40,9 +40,8 @@ class PostgresDatabase(BaseDatabase):
     def hook(self) -> PostgresHook:
         """Retrieve Airflow hook to interface with the Postgres database."""
         kwargs = {}
-        if self.table and self.table.metadata:
-            if self.table.metadata.schema:
-                kwargs.update({"schema": self.table.metadata.schema})
+        if self.table and self.table.metadata and self.table.metadata.schema:
+            kwargs.update({"schema": self.table.metadata.schema})
         return PostgresHook(postgres_conn_id=self.conn_id, **kwargs)
 
     @property

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import io
 from contextlib import closing
-from typing import Optional
 
 import pandas as pd
 import sqlalchemy

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -39,8 +39,9 @@ class PostgresDatabase(BaseDatabase):
     @property
     def hook(self) -> PostgresHook:
         """Retrieve Airflow hook to interface with the Postgres database."""
+        _hook = PostgresHook(postgres_conn_id=self.conn_id).get_connection(self.conn_id)
         kwargs = {}
-        if self.table and self.table.metadata and self.table.metadata.schema:
+        if (_hook.schema is None) and (self.table and self.table.metadata and self.table.metadata.schema):
             kwargs.update({"schema": self.table.metadata.schema})
         return PostgresHook(postgres_conn_id=self.conn_id, **kwargs)
 

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -42,7 +42,7 @@ class PostgresDatabase(BaseDatabase):
         conn = PostgresHook(postgres_conn_id=self.conn_id).get_connection(self.conn_id)
         kwargs = {}
         if (conn.schema is None) and (self.table and self.table.metadata and self.table.metadata.schema):
-            kwargs.update({"schema": self.table.metadata.schema})
+            kwargs.update({"database": self.table.metadata.schema})
         return PostgresHook(postgres_conn_id=self.conn_id, **kwargs)
 
     @property

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -30,6 +30,7 @@ class PostgresDatabase(BaseDatabase):
 
     def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
+        self.table = table
 
     @property
     def sql_type(self) -> str:
@@ -38,7 +39,11 @@ class PostgresDatabase(BaseDatabase):
     @property
     def hook(self) -> PostgresHook:
         """Retrieve Airflow hook to interface with the Postgres database."""
-        return PostgresHook(postgres_conn_id=self.conn_id)
+        kwargs = {}
+        if self.table and self.table.metadata:
+            if self.table.metadata.schema:
+                kwargs.update({"schema": self.table.metadata.schema})
+        return PostgresHook(postgres_conn_id=self.conn_id, **kwargs)
 
     @property
     def default_metadata(self) -> Metadata:

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -263,7 +263,7 @@ class SnowflakeDatabase(BaseDatabase):
             if _hook.database is None and self.table.metadata.database:
                 kwargs.update({"database": self.table.metadata.database})
             if _hook.schema is None and self.table.metadata.schema:
-                kwargs = {"schema": self.table.metadata.schema}
+                kwargs.update({"schema": self.table.metadata.schema})
         return SnowflakeHook(snowflake_conn_id=self.conn_id, **kwargs)
 
     @property

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -259,7 +259,10 @@ class SnowflakeDatabase(BaseDatabase):
         """Retrieve Airflow hook to interface with the snowflake database."""
         kwargs = {}
         if self.table and self.table.metadata:
-            kwargs = {"schema": self.table.metadata.schema, "database": self.table.metadata.database}
+            if self.table.metadata.database:
+                kwargs.update({"database": self.table.metadata.database})
+            if self.table.metadata.schema:
+                kwargs = {"schema": self.table.metadata.schema}
         return SnowflakeHook(snowflake_conn_id=self.conn_id, **kwargs)
 
     @property

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -259,10 +259,7 @@ class SnowflakeDatabase(BaseDatabase):
         """Retrieve Airflow hook to interface with the snowflake database."""
         kwargs = {}
         if self.table and self.table.metadata:
-            kwargs = {
-                "schema": self.table.metadata.schema,
-                "database": self.table.metadata.database
-            }
+            kwargs = {"schema": self.table.metadata.schema, "database": self.table.metadata.database}
         return SnowflakeHook(snowflake_conn_id=self.conn_id, **kwargs)
 
     @property

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -100,9 +100,9 @@ class SnowflakeFileFormat:
         :return: unique file format name
         """
         return (
-                "file_format_"
-                + random.choice(string.ascii_lowercase)
-                + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
+            "file_format_"
+            + random.choice(string.ascii_lowercase)
+            + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
         )
 
     def set_file_type_from_file(self, file: File) -> None:
@@ -171,9 +171,9 @@ class SnowflakeStage:
         :return: unique stage name
         """
         return (
-                "stage_"
-                + random.choice(string.ascii_lowercase)
-                + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
+            "stage_"
+            + random.choice(string.ascii_lowercase)
+            + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
         )
 
     def set_url_from_file(self, file: File) -> None:
@@ -361,10 +361,10 @@ class SnowflakeDatabase(BaseDatabase):
         return auth
 
     def create_stage(
-            self,
-            file: File,
-            storage_integration: str | None = None,
-            metadata: Metadata | None = None,
+        self,
+        file: File,
+        storage_integration: str | None = None,
+        metadata: Metadata | None = None,
     ) -> SnowflakeStage:
         """
         Creates a new named external stage to use for loading data from files into Snowflake
@@ -436,7 +436,7 @@ class SnowflakeDatabase(BaseDatabase):
     # ---------------------------------------------------------
 
     def is_native_autodetect_schema_available(  # skipcq: PYL-R0201
-            self, file: File  # skipcq: PYL-W0613
+        self, file: File  # skipcq: PYL-W0613
     ) -> bool:
         """
         Check if native auto detection of schema is available.
@@ -446,14 +446,14 @@ class SnowflakeDatabase(BaseDatabase):
         """
         is_file_type_supported = file.type.name in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_TYPES
         is_file_location_supported = (
-                file.location.location_type in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_LOCATIONS
+            file.location.location_type in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_LOCATIONS
         )
         return is_file_type_supported and is_file_location_supported
 
     def create_table_using_native_schema_autodetection(
-            self,
-            table: BaseTable,
-            file: File,
+        self,
+        table: BaseTable,
+        file: File,
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file via native database support.
@@ -511,11 +511,11 @@ class SnowflakeDatabase(BaseDatabase):
         return any(col for col in cols if not col.islower() and not col.isupper())
 
     def create_table_using_schema_autodetection(
-            self,
-            table: BaseTable,
-            file: File | None = None,
-            dataframe: pd.DataFrame | None = None,
-            columns_names_capitalization: ColumnCapitalization = "original",
+        self,
+        table: BaseTable,
+        file: File | None = None,
+        dataframe: pd.DataFrame | None = None,
+        columns_names_capitalization: ColumnCapitalization = "original",
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file.
@@ -559,17 +559,17 @@ class SnowflakeDatabase(BaseDatabase):
         """
         is_file_type_supported = source_file.type.name in NATIVE_LOAD_SUPPORTED_FILE_TYPES
         is_file_location_supported = (
-                source_file.location.location_type in NATIVE_LOAD_SUPPORTED_FILE_LOCATIONS
+            source_file.location.location_type in NATIVE_LOAD_SUPPORTED_FILE_LOCATIONS
         )
         return is_file_type_supported and is_file_location_supported
 
     def load_file_to_table_natively(
-            self,
-            source_file: File,
-            target_table: BaseTable,
-            if_exists: LoadExistStrategy = "replace",
-            native_support_kwargs: dict | None = None,
-            **kwargs,
+        self,
+        source_file: File,
+        target_table: BaseTable,
+        if_exists: LoadExistStrategy = "replace",
+        native_support_kwargs: dict | None = None,
+        **kwargs,
     ):
         """
         Load the content of a file to an existing Snowflake table natively by:
@@ -609,11 +609,11 @@ class SnowflakeDatabase(BaseDatabase):
         self.drop_stage(stage)
 
     def load_pandas_dataframe_to_table(
-            self,
-            source_dataframe: pd.DataFrame,
-            target_table: BaseTable,
-            if_exists: LoadExistStrategy = "replace",
-            chunk_size: int = DEFAULT_CHUNK_SIZE,
+        self,
+        source_dataframe: pd.DataFrame,
+        target_table: BaseTable,
+        if_exists: LoadExistStrategy = "replace",
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
         """
         Create a table with the dataframe's contents.
@@ -643,7 +643,7 @@ class SnowflakeDatabase(BaseDatabase):
         )
 
     def get_sqlalchemy_template_table_identifier_and_parameter(
-            self, table: BaseTable, jinja_table_identifier: str
+        self, table: BaseTable, jinja_table_identifier: str
     ) -> tuple[str, str]:
         """
         During the conversion from a Jinja-templated SQL query to a SQLAlchemy query, there is the need to
@@ -710,12 +710,12 @@ class SnowflakeDatabase(BaseDatabase):
         return len(created_schemas) == 1
 
     def merge_table(
-            self,
-            source_table: BaseTable,
-            target_table: BaseTable,
-            source_to_target_columns_map: dict[str, str],
-            target_conflict_columns: list[str],
-            if_conflicts: MergeConflictStrategy = "exception",
+        self,
+        source_table: BaseTable,
+        target_table: BaseTable,
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
+        if_conflicts: MergeConflictStrategy = "exception",
     ) -> None:
         """
         Merge the source table rows into a destination table.
@@ -737,12 +737,12 @@ class SnowflakeDatabase(BaseDatabase):
         self.run_sql(sql=statement, parameters=params)
 
     def _build_merge_sql(
-            self,
-            source_table: BaseTable,
-            target_table: BaseTable,
-            source_to_target_columns_map: dict[str, str],
-            target_conflict_columns: list[str],
-            if_conflicts: MergeConflictStrategy = "exception",
+        self,
+        source_table: BaseTable,
+        target_table: BaseTable,
+        source_to_target_columns_map: dict[str, str],
+        target_conflict_columns: list[str],
+        if_conflicts: MergeConflictStrategy = "exception",
     ):
         """Build the SQL statement for Merge operation"""
         # TODO: Simplify this function
@@ -771,17 +771,17 @@ class SnowflakeDatabase(BaseDatabase):
         ) = self.get_sqlalchemy_template_table_identifier_and_parameter(target_table, "target_table")
 
         statement = (
-                f"merge into {target_table_identifier} using {source_table_identifier} " + "on {merge_clauses}"
+            f"merge into {target_table_identifier} using {source_table_identifier} " + "on {merge_clauses}"
         )
 
         merge_target_dict = {
             f"merge_clause_target_{i}": f"{target_table_name}."
-                                        f"{target_identifier_enclosure}{x}{target_identifier_enclosure}"
+            f"{target_identifier_enclosure}{x}{target_identifier_enclosure}"
             for i, x in enumerate(target_conflict_columns)
         }
         merge_source_dict = {
             f"merge_clause_source_{i}": f"{source_table_name}."
-                                        f"{source_identifier_enclosure}{x}{source_identifier_enclosure}"
+            f"{source_identifier_enclosure}{x}{source_identifier_enclosure}"
             for i, x in enumerate(target_conflict_columns)
         }
         statement = statement.replace(
@@ -834,10 +834,10 @@ class SnowflakeDatabase(BaseDatabase):
         return statement, params
 
     def append_table(
-            self,
-            source_table: BaseTable,
-            target_table: BaseTable,
-            source_to_target_columns_map: dict[str, str],
+        self,
+        source_table: BaseTable,
+        target_table: BaseTable,
+        source_to_target_columns_map: dict[str, str],
     ) -> None:
         """
         Append the source table rows into a destination table.

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -6,7 +6,7 @@ import os
 import random
 import string
 from dataclasses import dataclass, field
-from typing import Any, Optional, Sequence
+from typing import Any, Sequence
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -100,9 +100,9 @@ class SnowflakeFileFormat:
         :return: unique file format name
         """
         return (
-            "file_format_"
-            + random.choice(string.ascii_lowercase)
-            + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
+                "file_format_"
+                + random.choice(string.ascii_lowercase)
+                + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
         )
 
     def set_file_type_from_file(self, file: File) -> None:
@@ -171,9 +171,9 @@ class SnowflakeStage:
         :return: unique stage name
         """
         return (
-            "stage_"
-            + random.choice(string.ascii_lowercase)
-            + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
+                "stage_"
+                + random.choice(string.ascii_lowercase)
+                + "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(7))
         )
 
     def set_url_from_file(self, file: File) -> None:
@@ -258,10 +258,11 @@ class SnowflakeDatabase(BaseDatabase):
     def hook(self) -> SnowflakeHook:
         """Retrieve Airflow hook to interface with the snowflake database."""
         kwargs = {}
+        _hook = SnowflakeHook(snowflake_conn_id=self.conn_id)
         if self.table and self.table.metadata:
-            if self.table.metadata.database:
+            if _hook.database is None and self.table.metadata.database:
                 kwargs.update({"database": self.table.metadata.database})
-            if self.table.metadata.schema:
+            if _hook.schema is None and self.table.metadata.schema:
                 kwargs = {"schema": self.table.metadata.schema}
         return SnowflakeHook(snowflake_conn_id=self.conn_id, **kwargs)
 
@@ -360,10 +361,10 @@ class SnowflakeDatabase(BaseDatabase):
         return auth
 
     def create_stage(
-        self,
-        file: File,
-        storage_integration: str | None = None,
-        metadata: Metadata | None = None,
+            self,
+            file: File,
+            storage_integration: str | None = None,
+            metadata: Metadata | None = None,
     ) -> SnowflakeStage:
         """
         Creates a new named external stage to use for loading data from files into Snowflake
@@ -435,7 +436,7 @@ class SnowflakeDatabase(BaseDatabase):
     # ---------------------------------------------------------
 
     def is_native_autodetect_schema_available(  # skipcq: PYL-R0201
-        self, file: File  # skipcq: PYL-W0613
+            self, file: File  # skipcq: PYL-W0613
     ) -> bool:
         """
         Check if native auto detection of schema is available.
@@ -445,14 +446,14 @@ class SnowflakeDatabase(BaseDatabase):
         """
         is_file_type_supported = file.type.name in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_TYPES
         is_file_location_supported = (
-            file.location.location_type in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_LOCATIONS
+                file.location.location_type in NATIVE_AUTODETECT_SCHEMA_SUPPORTED_FILE_LOCATIONS
         )
         return is_file_type_supported and is_file_location_supported
 
     def create_table_using_native_schema_autodetection(
-        self,
-        table: BaseTable,
-        file: File,
+            self,
+            table: BaseTable,
+            file: File,
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file via native database support.
@@ -510,11 +511,11 @@ class SnowflakeDatabase(BaseDatabase):
         return any(col for col in cols if not col.islower() and not col.isupper())
 
     def create_table_using_schema_autodetection(
-        self,
-        table: BaseTable,
-        file: File | None = None,
-        dataframe: pd.DataFrame | None = None,
-        columns_names_capitalization: ColumnCapitalization = "original",
+            self,
+            table: BaseTable,
+            file: File | None = None,
+            dataframe: pd.DataFrame | None = None,
+            columns_names_capitalization: ColumnCapitalization = "original",
     ) -> None:
         """
         Create a SQL table, automatically inferring the schema using the given file.
@@ -558,17 +559,17 @@ class SnowflakeDatabase(BaseDatabase):
         """
         is_file_type_supported = source_file.type.name in NATIVE_LOAD_SUPPORTED_FILE_TYPES
         is_file_location_supported = (
-            source_file.location.location_type in NATIVE_LOAD_SUPPORTED_FILE_LOCATIONS
+                source_file.location.location_type in NATIVE_LOAD_SUPPORTED_FILE_LOCATIONS
         )
         return is_file_type_supported and is_file_location_supported
 
     def load_file_to_table_natively(
-        self,
-        source_file: File,
-        target_table: BaseTable,
-        if_exists: LoadExistStrategy = "replace",
-        native_support_kwargs: dict | None = None,
-        **kwargs,
+            self,
+            source_file: File,
+            target_table: BaseTable,
+            if_exists: LoadExistStrategy = "replace",
+            native_support_kwargs: dict | None = None,
+            **kwargs,
     ):
         """
         Load the content of a file to an existing Snowflake table natively by:
@@ -608,11 +609,11 @@ class SnowflakeDatabase(BaseDatabase):
         self.drop_stage(stage)
 
     def load_pandas_dataframe_to_table(
-        self,
-        source_dataframe: pd.DataFrame,
-        target_table: BaseTable,
-        if_exists: LoadExistStrategy = "replace",
-        chunk_size: int = DEFAULT_CHUNK_SIZE,
+            self,
+            source_dataframe: pd.DataFrame,
+            target_table: BaseTable,
+            if_exists: LoadExistStrategy = "replace",
+            chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
         """
         Create a table with the dataframe's contents.
@@ -642,7 +643,7 @@ class SnowflakeDatabase(BaseDatabase):
         )
 
     def get_sqlalchemy_template_table_identifier_and_parameter(
-        self, table: BaseTable, jinja_table_identifier: str
+            self, table: BaseTable, jinja_table_identifier: str
     ) -> tuple[str, str]:
         """
         During the conversion from a Jinja-templated SQL query to a SQLAlchemy query, there is the need to
@@ -709,12 +710,12 @@ class SnowflakeDatabase(BaseDatabase):
         return len(created_schemas) == 1
 
     def merge_table(
-        self,
-        source_table: BaseTable,
-        target_table: BaseTable,
-        source_to_target_columns_map: dict[str, str],
-        target_conflict_columns: list[str],
-        if_conflicts: MergeConflictStrategy = "exception",
+            self,
+            source_table: BaseTable,
+            target_table: BaseTable,
+            source_to_target_columns_map: dict[str, str],
+            target_conflict_columns: list[str],
+            if_conflicts: MergeConflictStrategy = "exception",
     ) -> None:
         """
         Merge the source table rows into a destination table.
@@ -736,12 +737,12 @@ class SnowflakeDatabase(BaseDatabase):
         self.run_sql(sql=statement, parameters=params)
 
     def _build_merge_sql(
-        self,
-        source_table: BaseTable,
-        target_table: BaseTable,
-        source_to_target_columns_map: dict[str, str],
-        target_conflict_columns: list[str],
-        if_conflicts: MergeConflictStrategy = "exception",
+            self,
+            source_table: BaseTable,
+            target_table: BaseTable,
+            source_to_target_columns_map: dict[str, str],
+            target_conflict_columns: list[str],
+            if_conflicts: MergeConflictStrategy = "exception",
     ):
         """Build the SQL statement for Merge operation"""
         # TODO: Simplify this function
@@ -770,17 +771,17 @@ class SnowflakeDatabase(BaseDatabase):
         ) = self.get_sqlalchemy_template_table_identifier_and_parameter(target_table, "target_table")
 
         statement = (
-            f"merge into {target_table_identifier} using {source_table_identifier} " + "on {merge_clauses}"
+                f"merge into {target_table_identifier} using {source_table_identifier} " + "on {merge_clauses}"
         )
 
         merge_target_dict = {
             f"merge_clause_target_{i}": f"{target_table_name}."
-            f"{target_identifier_enclosure}{x}{target_identifier_enclosure}"
+                                        f"{target_identifier_enclosure}{x}{target_identifier_enclosure}"
             for i, x in enumerate(target_conflict_columns)
         }
         merge_source_dict = {
             f"merge_clause_source_{i}": f"{source_table_name}."
-            f"{source_identifier_enclosure}{x}{source_identifier_enclosure}"
+                                        f"{source_identifier_enclosure}{x}{source_identifier_enclosure}"
             for i, x in enumerate(target_conflict_columns)
         }
         statement = statement.replace(
@@ -833,10 +834,10 @@ class SnowflakeDatabase(BaseDatabase):
         return statement, params
 
     def append_table(
-        self,
-        source_table: BaseTable,
-        target_table: BaseTable,
-        source_to_target_columns_map: dict[str, str],
+            self,
+            source_table: BaseTable,
+            target_table: BaseTable,
+            source_to_target_columns_map: dict[str, str],
     ) -> None:
         """
         Append the source table rows into a destination table.

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -250,7 +250,7 @@ class SnowflakeDatabase(BaseDatabase):
     )
     DEFAULT_SCHEMA = SNOWFLAKE_SCHEMA
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable | None = None):
         super().__init__(conn_id)
         self.table = table
 

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -6,7 +6,7 @@ import os
 import random
 import string
 from dataclasses import dataclass, field
-from typing import Any, Sequence
+from typing import Any, Optional, Sequence
 
 import pandas as pd
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
@@ -250,7 +250,7 @@ class SnowflakeDatabase(BaseDatabase):
     )
     DEFAULT_SCHEMA = SNOWFLAKE_SCHEMA
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
         super().__init__(conn_id)
         self.table = table
 

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -250,13 +250,20 @@ class SnowflakeDatabase(BaseDatabase):
     )
     DEFAULT_SCHEMA = SNOWFLAKE_SCHEMA
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
+        self.table = table
 
     @property
     def hook(self) -> SnowflakeHook:
         """Retrieve Airflow hook to interface with the snowflake database."""
-        return SnowflakeHook(snowflake_conn_id=self.conn_id)
+        kwargs = {}
+        if self.table and self.table.metadata:
+            kwargs = {
+                "schema": self.table.metadata.schema,
+                "database": self.table.metadata.database
+            }
+        return SnowflakeHook(snowflake_conn_id=self.conn_id, **kwargs)
 
     @property
     def sql_type(self) -> str:

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -20,7 +20,7 @@ class SqliteDatabase(BaseDatabase):
     logic in other parts of our code-base.
     """
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable | None = None):
         super().__init__(conn_id)
         self.table = table
 

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from sqlalchemy import MetaData as SqlaMetaData, create_engine
 from sqlalchemy.engine.base import Engine

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -18,7 +18,7 @@ class SqliteDatabase(BaseDatabase):
     logic in other parts of our code-base.
     """
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
 
     @property

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from sqlalchemy import MetaData as SqlaMetaData, create_engine
 from sqlalchemy.engine.base import Engine
@@ -18,7 +20,7 @@ class SqliteDatabase(BaseDatabase):
     logic in other parts of our code-base.
     """
 
-    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
+    def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: Optional[BaseTable] = None):
         super().__init__(conn_id)
         self.table = table
 

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -20,6 +20,7 @@ class SqliteDatabase(BaseDatabase):
 
     def __init__(self, conn_id: str = DEFAULT_CONN_ID, table: BaseTable = None):
         super().__init__(conn_id)
+        self.table = table
 
     @property
     def sql_type(self) -> str:

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -62,7 +62,7 @@ class AppendOperator(AstroSQLBaseOperator):
         )
 
     def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613
-        db = create_database(self.target_table.conn_id)
+        db = create_database(self.target_table.conn_id, self.target_table)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
         db.append_table(

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -62,7 +62,7 @@ class AppendOperator(AstroSQLBaseOperator):
         )
 
     def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613
-        db = create_database(self.target_table.conn_id)
+        db = create_database(self.target_table.conn_id, table=self.source_table)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
         db.append_table(

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -62,7 +62,7 @@ class AppendOperator(AstroSQLBaseOperator):
         )
 
     def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613
-        db = create_database(self.target_table.conn_id, self.target_table)
+        db = create_database(self.target_table.conn_id)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
         db.append_table(

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -85,7 +85,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         else:
             if not self.conn_id:
                 raise ValueError("You need to provide a table or a connection id")
-        self.database_impl = create_database(self.conn_id)
+        self.database_impl = create_database(self.conn_id, self.output_table)
 
         # Find and load dataframes from op_arg and op_kwarg into Table
         self.create_output_table_if_needed()

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -259,7 +259,7 @@ def load_op_arg_dataframes_into_sql(conn_id: str, op_args: tuple, target_table: 
     :return: New op_args, in which dataframes are replaced by tables
     """
     final_args = []
-    database = create_database(conn_id=conn_id)
+    database = create_database(conn_id=conn_id, table=target_table)
     for arg in op_args:
         if isinstance(arg, pd.DataFrame):
             database.load_pandas_dataframe_to_table(source_dataframe=arg, target_table=target_table)
@@ -282,7 +282,7 @@ def load_op_kwarg_dataframes_into_sql(conn_id: str, op_kwargs: dict, target_tabl
     :return: New op_kwargs, in which dataframes are replaced by tables
     """
     final_kwargs = {}
-    database = create_database(conn_id=conn_id)
+    database = create_database(conn_id=conn_id, table=target_table)
     for key, value in op_kwargs.items():
         if isinstance(value, pd.DataFrame):
             df_table = cast(BaseTable, target_table.create_similar_table())

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -85,7 +85,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         else:
             if not self.conn_id:
                 raise ValueError("You need to provide a table or a connection id")
-        self.database_impl = create_database(self.conn_id, self.output_table)
+        self.database_impl = create_database(self.conn_id, first_table)
 
         # Find and load dataframes from op_arg and op_kwarg into Table
         self.create_output_table_if_needed()

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -259,7 +259,7 @@ def load_op_arg_dataframes_into_sql(conn_id: str, op_args: tuple, target_table: 
     :return: New op_args, in which dataframes are replaced by tables
     """
     final_args = []
-    database = create_database(conn_id=conn_id, table=target_table)
+    database = create_database(conn_id=conn_id)
     for arg in op_args:
         if isinstance(arg, pd.DataFrame):
             database.load_pandas_dataframe_to_table(source_dataframe=arg, target_table=target_table)

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -109,7 +109,7 @@ class CleanupOperator(AstroSQLBaseOperator):
             self.drop_table(table)
 
     def drop_table(self, table: BaseTable) -> None:
-        db = create_database(table.conn_id)
+        db = create_database(conn_id=table.conn_id, table=table)
         self.log.info("Dropping table %s", table.name)
         db.drop_table(table)
 

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -109,7 +109,7 @@ class CleanupOperator(AstroSQLBaseOperator):
             self.drop_table(table)
 
     def drop_table(self, table: BaseTable) -> None:
-        db = create_database(table.conn_id, table=table)
+        db = create_database(table.conn_id)
         self.log.info("Dropping table %s", table.name)
         db.drop_table(table)
 

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -109,7 +109,7 @@ class CleanupOperator(AstroSQLBaseOperator):
             self.drop_table(table)
 
     def drop_table(self, table: BaseTable) -> None:
-        db = create_database(table.conn_id)
+        db = create_database(table.conn_id, table=table)
         self.log.info("Dropping table %s", table.name)
         db.drop_table(table)
 

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -31,7 +31,7 @@ def _get_dataframe(
     """
     Exports records from a SQL table and converts it into a pandas dataframe
     """
-    database = create_database(table.conn_id)
+    database = create_database(table.conn_id, table=table)
     df = database.export_table_to_pandas_dataframe(source_table=table)
     df = convert_columns_names_capitalization(
         df=df, columns_names_capitalization=columns_names_capitalization
@@ -180,7 +180,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
                     "function output."
                 )
             self.output_table.conn_id = self.output_table.conn_id or self.conn_id
-            db = create_database(self.output_table.conn_id)
+            db = create_database(self.output_table.conn_id, table=self.output_table)
             self.output_table = db.populate_table_metadata(self.output_table)
             db.load_pandas_dataframe_to_table(
                 source_dataframe=function_output,

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -31,7 +31,7 @@ def _get_dataframe(
     """
     Exports records from a SQL table and converts it into a pandas dataframe
     """
-    database = create_database(table.conn_id, table=table)
+    database = create_database(table.conn_id)
     df = database.export_table_to_pandas_dataframe(source_table=table)
     df = convert_columns_names_capitalization(
         df=df, columns_names_capitalization=columns_names_capitalization
@@ -180,7 +180,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
                     "function output."
                 )
             self.output_table.conn_id = self.output_table.conn_id or self.conn_id
-            db = create_database(self.output_table.conn_id, table=self.output_table)
+            db = create_database(self.output_table.conn_id)
             self.output_table = db.populate_table_metadata(self.output_table)
             db.load_pandas_dataframe_to_table(
                 source_dataframe=function_output,

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -180,7 +180,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
                     "function output."
                 )
             self.output_table.conn_id = self.output_table.conn_id or self.conn_id
-            db = create_database(self.output_table.conn_id)
+            db = create_database(self.output_table.conn_id, table=self.output_table)
             self.output_table = db.populate_table_metadata(self.output_table)
             db.load_pandas_dataframe_to_table(
                 source_dataframe=function_output,

--- a/python-sdk/src/astro/sql/operators/drop.py
+++ b/python-sdk/src/astro/sql/operators/drop.py
@@ -31,7 +31,7 @@ class DropTableOperator(AstroSQLBaseOperator):
 
     def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613
         """Method run when the Airflow runner calls the operator."""
-        database = create_database(self.table.conn_id)
+        database = create_database(self.table.conn_id, self.table)
         self.table = database.populate_table_metadata(self.table)
         database.drop_table(self.table)
         return self.table

--- a/python-sdk/src/astro/sql/operators/drop.py
+++ b/python-sdk/src/astro/sql/operators/drop.py
@@ -31,7 +31,7 @@ class DropTableOperator(AstroSQLBaseOperator):
 
     def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613
         """Method run when the Airflow runner calls the operator."""
-        database = create_database(self.table.conn_id, self.table)
+        database = create_database(self.table.conn_id)
         self.table = database.populate_table_metadata(self.table)
         database.drop_table(self.table)
         return self.table

--- a/python-sdk/src/astro/sql/operators/drop.py
+++ b/python-sdk/src/astro/sql/operators/drop.py
@@ -31,7 +31,7 @@ class DropTableOperator(AstroSQLBaseOperator):
 
     def execute(self, context: Context) -> BaseTable:  # skipcq: PYL-W0613
         """Method run when the Airflow runner calls the operator."""
-        database = create_database(self.table.conn_id)
+        database = create_database(self.table.conn_id, table=self.table)
         self.table = database.populate_table_metadata(self.table)
         database.drop_table(self.table)
         return self.table

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -48,7 +48,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
         """
         # Infer db type from `input_conn_id`.
         if isinstance(self.input_data, BaseTable):
-            database = create_database(self.input_data.conn_id, table=self.input_data)
+            database = create_database(self.input_data.conn_id)
             self.input_data = database.populate_table_metadata(self.input_data)
             df = database.export_table_to_pandas_dataframe(self.input_data)
         elif isinstance(self.input_data, pd.DataFrame):

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -48,7 +48,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
         """
         # Infer db type from `input_conn_id`.
         if isinstance(self.input_data, BaseTable):
-            database = create_database(self.input_data.conn_id)
+            database = create_database(self.input_data.conn_id, table=self.input_data)
             self.input_data = database.populate_table_metadata(self.input_data)
             df = database.export_table_to_pandas_dataframe(self.input_data)
         elif isinstance(self.input_data, pd.DataFrame):

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -98,7 +98,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         """
         if not isinstance(self.output_table, BaseTable):
             raise ValueError("Please pass a valid Table instance in 'output_table' parameter")
-        database = create_database(self.output_table.conn_id)
+        database = create_database(self.output_table.conn_id, self.output_table)
         self.output_table = database.populate_table_metadata(self.output_table)
         normalize_config = self._populate_normalize_config(
             ndjson_normalize_sep=self.ndjson_normalize_sep,

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -98,7 +98,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         """
         if not isinstance(self.output_table, BaseTable):
             raise ValueError("Please pass a valid Table instance in 'output_table' parameter")
-        database = create_database(self.output_table.conn_id, table=self.output_table)
+        database = create_database(self.output_table.conn_id)
         self.output_table = database.populate_table_metadata(self.output_table)
         normalize_config = self._populate_normalize_config(
             ndjson_normalize_sep=self.ndjson_normalize_sep,

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -98,7 +98,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         """
         if not isinstance(self.output_table, BaseTable):
             raise ValueError("Please pass a valid Table instance in 'output_table' parameter")
-        database = create_database(self.output_table.conn_id)
+        database = create_database(self.output_table.conn_id, table=self.output_table)
         self.output_table = database.populate_table_metadata(self.output_table)
         normalize_config = self._populate_normalize_config(
             ndjson_normalize_sep=self.ndjson_normalize_sep,

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -74,7 +74,7 @@ class MergeOperator(AstroSQLBaseOperator):
         )
 
     def execute(self, context: Context) -> BaseTable:
-        db = create_database(self.target_table.conn_id, self.target_table)
+        db = create_database(self.target_table.conn_id)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
 

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -74,7 +74,7 @@ class MergeOperator(AstroSQLBaseOperator):
         )
 
     def execute(self, context: Context) -> BaseTable:
-        db = create_database(self.target_table.conn_id)
+        db = create_database(self.target_table.conn_id, table=self.source_table)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
 

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -74,7 +74,7 @@ class MergeOperator(AstroSQLBaseOperator):
         )
 
     def execute(self, context: Context) -> BaseTable:
-        db = create_database(self.target_table.conn_id)
+        db = create_database(self.target_table.conn_id, self.target_table)
         self.source_table = db.populate_table_metadata(self.source_table)
         self.target_table = db.populate_table_metadata(self.target_table)
 

--- a/python-sdk/tests/databases/test_redshift.py
+++ b/python-sdk/tests/databases/test_redshift.py
@@ -8,8 +8,8 @@ from urllib.parse import urlparse
 import pandas as pd
 import pytest
 import sqlalchemy
-from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
 from airflow.models import Connection
+from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
 
 from astro.constants import Database, FileType
 from astro.databases import create_database

--- a/python-sdk/tests/databases/test_redshift.py
+++ b/python-sdk/tests/databases/test_redshift.py
@@ -2,11 +2,14 @@
 import os
 import pathlib
 import re
+from unittest import mock
 from urllib.parse import urlparse
 
 import pandas as pd
 import pytest
 import sqlalchemy
+from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
+from airflow.models import DAG, Connection
 
 from astro.constants import Database, FileType
 from astro.databases import create_database
@@ -371,3 +374,15 @@ def test_create_table_from_select_statement(database_table_fixture):
     expected = pd.DataFrame([{"id": 1, "name": "First"}]).sort_values(by="id")
     test_utils.assert_dataframes_are_equal(df, expected)
     database.drop_table(target_table)
+
+
+@mock.patch("redshift_connector.connect")
+@mock.patch("airflow.hooks.base.BaseHook.get_connection")
+def test_hook_with_db_from_table(mock_conn, redshift_conn):
+    mock_conn.return_value = Connection(conn_id="test_conn", extra={})
+    table = Table(conn_id="test", metadata=Metadata(database="dev"))
+    db = RedshiftDatabase(conn_id="test", table=table)
+    hook = db.hook
+    assert isinstance(hook, RedshiftSQLHook)
+    # TODO: Remove comment when RedshiftSQLHook in Airflow start using the kwargs
+    # redshift_conn.assert_called_once_with({"database": "dev"})

--- a/python-sdk/tests/databases/test_redshift.py
+++ b/python-sdk/tests/databases/test_redshift.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 import sqlalchemy
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
-from airflow.models import DAG, Connection
+from airflow.models import Connection
 
 from astro.constants import Database, FileType
 from astro.databases import create_database

--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -253,5 +253,5 @@ def test_transform_using_table_metadata(sample_dag):
         def select(input_table: Table):
             return "SELECT * FROM {{input_table}} LIMIT 4;"
 
-        select(input_table=test_table, output_table=Table(conn_id="snowflake_conn_1"))
+        select(input_table=homes_file, output_table=Table(conn_id="snowflake_conn_1"))
     test_utils.run_dag(sample_dag)

--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -253,8 +253,5 @@ def test_transform_using_table_metadata(sample_dag):
         def select(input_table: Table):
             return "SELECT * FROM {{input_table}} LIMIT 4;"
 
-        select(
-            input_table=test_table,
-            output_table=Table(conn_id="snowflake_conn_1")
-        )
+        select(input_table=test_table, output_table=Table(conn_id="snowflake_conn_1"))
     test_utils.run_dag(sample_dag)

--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -9,7 +9,7 @@ from astro import sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
 from astro.files import File
-from astro.table import Table, Metadata
+from astro.table import Metadata, Table
 from tests.sql.operators import utils as test_utils
 
 cwd = pathlib.Path(__file__).parent
@@ -248,7 +248,7 @@ def test_transform_using_table_metadata(sample_dag):
             metadata=Metadata(
                 database=os.environ["SNOWFLAKE_DATABASE"],
                 schema=os.environ["SNOWFLAKE_SCHEMA"],
-            )
+            ),
         )
         homes_file = aql.load_file(
             input_file=File(path=str(cwd) + "/../../../data/homes.csv"),

--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 
 import pandas as pd
@@ -8,7 +9,7 @@ from astro import sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.constants import Database
 from astro.files import File
-from astro.table import Table
+from astro.table import Table, Metadata
 from tests.sql.operators import utils as test_utils
 
 cwd = pathlib.Path(__file__).parent
@@ -242,8 +243,13 @@ def test_transform_using_table_metadata(sample_dag):
     Test that load file and transform when database and schema is available in table metadata instead of conn
     """
     with sample_dag:
-        metadata = {"database": "SANDBOX", "schema": "ASTROFLOW_CI"}
-        test_table = Table(conn_id="snowflake_conn_1", metadata=metadata)
+        test_table = Table(
+            conn_id="snowflake_conn_1",
+            metadata=Metadata(
+                database=os.environ["SNOWFLAKE_DATABASE"],
+                schema=os.environ["SNOWFLAKE_SCHEMA"],
+            )
+        )
         homes_file = aql.load_file(
             input_file=File(path=str(cwd) + "/../../../data/homes.csv"),
             output_table=test_table,


### PR DESCRIPTION
# Description
closes: #1034 
Add table param in ```create_database``` function so that can access and use table metadata while creating a hook

## What is the current behavior?
Currently, we don't use Table metadata param schema and database while creating so if these values is not set in the airflow connection we are getting an error in the case of snowflake


## What is the new behavior?
change 

```
def create_database(conn_id: str) -> BaseDatabase:
    ...
```
to
```
def create_database(
    conn_id: str,
    table: object | None = None,
) -> BaseDatabase: 
    ...
```
and use table metadata if available while creating snowflake hook


## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
