### PR TITLE
Reduce command run times for SQL CLI

### DIFF
--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -6,28 +6,13 @@ from dotenv import load_dotenv
 from rich import print as rprint
 
 import sql_cli
-from sql_cli.connections import validate_connections
 from sql_cli.constants import DEFAULT_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER
-from sql_cli.dag_generator import generate_dag
-from sql_cli.exceptions import EmptyDag, SqlFilesDirectoryNotFound
-from sql_cli.project import Project
-from sql_cli.run_dag import run_dag
-from sql_cli.utils.airflow import (
-    get_dag,
-    retrieve_airflow_database_conn_from_config,
-    set_airflow_database_conn,
-)
 
 load_dotenv()
 app = typer.Typer(add_completion=False, context_settings={"help_option_names": ["-h", "--help"]})
 
 
-def set_logger_level(log_level: int) -> None:
-    for name in logging.root.manager.loggerDict:
-        logging.getLogger(name).setLevel(log_level)
-
-
-set_logger_level(logging.CRITICAL)
+logging.getLogger("airflow").setLevel(logging.CRITICAL)
 
 
 @app.command(help="Print the SQL CLI version.")
@@ -55,6 +40,10 @@ def generate(
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
 ) -> None:
+    from sql_cli.dag_generator import generate_dag
+    from sql_cli.project import Project
+    from sql_cli.exceptions import EmptyDag, SqlFilesDirectoryNotFound
+
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute)
     project.load_config(env)
@@ -91,6 +80,10 @@ def validate(
         help="(Optional) Identifier of the connection to be validated. By default checks all the env connections.",
     ),
 ) -> None:
+    from sql_cli.connections import validate_connections
+    from sql_cli.project import Project
+    from sql_cli.utils.airflow import retrieve_airflow_database_conn_from_config, set_airflow_database_conn
+
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute)
     project.load_config(environment=env)
@@ -127,6 +120,16 @@ def run(
     ),
     verbose: bool = typer.Option(False, help="Whether to show airflow logs", show_default=True),
 ) -> None:
+    from sql_cli.dag_generator import generate_dag
+    from sql_cli.project import Project
+    from sql_cli.run_dag import run_dag
+    from sql_cli.utils.airflow import (
+        get_dag,
+        retrieve_airflow_database_conn_from_config,
+        set_airflow_database_conn,
+    )
+    from sql_cli.exceptions import EmptyDag, SqlFilesDirectoryNotFound
+
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute)
     project.update_config(environment=env)
@@ -210,6 +213,8 @@ def init(
         show_default=False,
     ),
 ) -> None:
+    from sql_cli.project import Project
+
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute, airflow_home, airflow_dags_folder)
     project.initialise()

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -41,8 +41,8 @@ def generate(
     ),
 ) -> None:
     from sql_cli.dag_generator import generate_dag
-    from sql_cli.project import Project
     from sql_cli.exceptions import EmptyDag, SqlFilesDirectoryNotFound
+    from sql_cli.project import Project
 
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute)
@@ -121,6 +121,7 @@ def run(
     verbose: bool = typer.Option(False, help="Whether to show airflow logs", show_default=True),
 ) -> None:
     from sql_cli.dag_generator import generate_dag
+    from sql_cli.exceptions import EmptyDag, SqlFilesDirectoryNotFound
     from sql_cli.project import Project
     from sql_cli.run_dag import run_dag
     from sql_cli.utils.airflow import (
@@ -128,7 +129,6 @@ def run(
         retrieve_airflow_database_conn_from_config,
         set_airflow_database_conn,
     )
-    from sql_cli.exceptions import EmptyDag, SqlFilesDirectoryNotFound
 
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute)

--- a/sql-cli/sql_cli/configuration.py
+++ b/sql-cli/sql_cli/configuration.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from airflow.api_connexion.schemas.connection_schema import connection_schema
 from airflow.models.connection import Connection
 
 from sql_cli.constants import CONFIG_DIR, CONFIG_FILENAME
@@ -19,6 +18,8 @@ def convert_to_connection(conn: dict[str, Any]) -> Connection:
     :param conn: SQL CLI connection dictionary
     :returns: Connection object
     """
+    from airflow.api_connexion.schemas.connection_schema import connection_schema
+
     c = conn.copy()
     c["connection_id"] = c["conn_id"]
     c.pop("conn_id")

--- a/sql-cli/sql_cli/run_dag.py
+++ b/sql-cli/sql_cli/run_dag.py
@@ -178,7 +178,7 @@ def _get_or_create_dagrun(
 
     :return: the Dagrun object needed to run tasks.
     """
-    log.info("dagrun id: %s", dag.dag_id)
+    log.debug("dagrun id: %s", dag.dag_id)
     dr: DagRun = (
         session.query(DagRun)
         .filter(DagRun.dag_id == dag.dag_id, DagRun.execution_date == execution_date)

--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
-from airflow.utils.cli import AirflowException, process_subdir, settings
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +77,8 @@ def _search_for_dag_file(val: str) -> str:
     And if the paths are different between worker and dag processor / scheduler, then we won't find
     the dag at the given location.
     """
+    from airflow import settings
+
     if val and Path(val).suffix in (".zip", ".py"):
         matches = list(Path(settings.DAGS_FOLDER).rglob(Path(val).name))
         if len(matches) == 1:
@@ -97,7 +98,10 @@ def get_dag(subdir: str, dag_id: str, include_examples: bool = False) -> DAG:
     find the correct path (assuming it's a file) and failing that, use the configured
     dags folder.
     """
+    from airflow import settings
+    from airflow.exceptions import AirflowException
     from airflow.models import DagBag
+    from airflow.utils.cli import process_subdir
 
     first_path = process_subdir(subdir)
     dagbag = DagBag(first_path, include_examples=include_examples)


### PR DESCRIPTION
This PR moves the import lines to the functions that use them to delay imports. It also changes the "logging" code that sets loggers to critical. Previously since "airflow" was loaded from imports, it sets the level for it as Critical, now we explicitly set the level just for Airflow

**`flow version`**:

Before: 2.156s
Now: 0.175s

<img width="1414" alt="image" src="https://user-images.githubusercontent.com/8811558/197059679-f6c156b3-3171-4dcc-a7cf-a37c4ebad8a3.png">
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/8811558/197059703-d8409591-75dd-4fe2-83cc-c525ba471fd9.png">


**`flow init`**:
Before: 2.108s
Now: 0.409s

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/8811558/197059748-d8e7f734-b208-4aea-bcb4-848bebb8b570.png">
<img width="1415" alt="image" src="https://user-images.githubusercontent.com/8811558/197059771-799318fd-a24c-463f-9f38-bc3349f95ad6.png">


**`flow validate`**:
Before: 2.342s
Now: 1.121s

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/8811558/197059813-5b491361-9a42-4b35-845c-4cbe931bdd7d.png">
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/8811558/197059832-80e69d07-8471-4a98-bb32-ae9acd7000be.png">


**`flow run`**:
No improvement here as it needs most of the libraries

Before: 1.953s
Now: 2.036s
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/8811558/197059891-ed6d1c7f-00ad-4978-88a5-14e484c461c3.png">
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/8811558/197059909-29841483-5d46-4a38-ac82-bdac0a3184d6.png">

