### PR TITLE
Add CodeOwners for root

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,6 @@
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+*               @pankajastro @feluelle @tatiana @kaxil
 python-sdk/     @dimberman @tatiana @utkarsharma2 @sunank200 @pankajastro @pankajkoti @feluelle
 sql-cli/        @dimberman @tatiana @pankajastro @pankajkoti @feluelle

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-*               @pankajastro @feluelle @tatiana @kaxil
+*               @pankajastro @feluelle @tatiana @kaxil @utkarsharma2
 python-sdk/     @dimberman @tatiana @utkarsharma2 @sunank200 @pankajastro @pankajkoti @feluelle
 sql-cli/        @dimberman @tatiana @pankajastro @pankajkoti @feluelle


### PR DESCRIPTION
The root contains pre-commit hooks, isort configs etc.

I am just adding a few folks I know would be interested in reviewing those files, we can add others if they are interested in it.

The last matching pattern takes the most precedence
