### PR TITLE
Use Github action checkout v3

### DIFF
--- a/.github/workflows/ci-benchmark.yaml
+++ b/.github/workflows/ci-benchmark.yaml
@@ -50,7 +50,7 @@ jobs:
       FORCE_COLOR: "true"
       ASTRO_PUBLISH_BENCHMARK_DATA: True
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: rm -f python-sdk/test-connections.yaml
       - run: ls -la
       - run: ( echo "cat <<EOF >python-sdk/test-connections.yaml"; cat .github/ci-test-connections.yaml; ) >python-sdk/test-connections.yaml && . python-sdk/test-connections.yaml


### PR DESCRIPTION
# Description
Fix: benchmark job show below warning 
```
[Run-Benchmark](https://github.com/astronomer/astro-sdk/actions/runs/3301213542/jobs/5446435233)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
```


## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
