### PR TITLE
Fix open lineage namespace for Sqlite as per OL team request

### DIFF
--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -144,4 +144,4 @@ class SqliteDatabase(BaseDatabase):
         Example: /tmp/local.db
         """
         conn = self.hook.get_connection(self.conn_id)
-        return f"{conn.host}"
+        return f"{self.sql_type}://{conn.host}"

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -9,13 +9,31 @@ from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.files import File
 from astro.settings import SCHEMA
-from astro.table import Metadata, Table
+from astro.table import BaseTable, Metadata, Table
 
 CWD = pathlib.Path(__file__).parent
 
 
 class DatabaseSubclass(BaseDatabase):
     pass
+
+
+def test_openlineage_database_dataset_namespace():
+    """
+    Test the open lineage dataset namespace for base class
+    """
+    db = DatabaseSubclass(conn_id="fake_conn_id")
+    with pytest.raises(NotImplementedError):
+        db.openlineage_dataset_namespace()
+
+
+def test_openlineage_database_dataset_name():
+    """
+    Test the open lineage dataset names for the base class
+    """
+    db = DatabaseSubclass(conn_id="fake_conn_id")
+    with pytest.raises(NotImplementedError):
+        db.openlineage_dataset_name(table=BaseTable)
 
 
 def test_subclass_missing_not_implemented_methods_raise_exception():

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -211,8 +211,8 @@ def test_if_table_object_can_be_pickled():
         ),
         (
             Connection(conn_id="test_conn", conn_type="sqlite", host="/tmp/sqlite.db"),
-            "/tmp/sqlite.db.test_tb",
-            "/tmp/sqlite.db",
+            "tmp/sqlite.db.test_tb",
+            "sqlite://tmp/sqlite.db",
         ),
     ],
 )

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -210,7 +210,7 @@ def test_if_table_object_can_be_pickled():
             "snowflake://astro-sdk",
         ),
         (
-            Connection(conn_id="test_conn", conn_type="sqlite", host="/tmp/sqlite.db"),
+            Connection(conn_id="test_conn", conn_type="sqlite", host="tmp/sqlite.db"),
             "tmp/sqlite.db.test_tb",
             "sqlite://tmp/sqlite.db",
         ),


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The sqlite namespace is missing in [OpenLineage naming convention](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md). So we created the namespace by default. OL team has requested to change this namespace.
The Namespaces extracted from AstroSDK do not conform to the [OpenLineage naming convention](https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md) for sqlite. For example, /tmp/sqlite_default.db instead of e.g. sqllite://


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1141

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix the namespace for sqlite
- Fix the test for this


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
