### PR TITLE
Openlineage support - Add Extractor for `ExportFileOperator`

### DIFF
--- a/python-sdk/src/astro/lineage/extractor.py
+++ b/python-sdk/src/astro/lineage/extractor.py
@@ -34,10 +34,10 @@ class PythonSDKExtractor(BaseExtractor):
         return [
             "AppendOperator",
             "BaseSQLDecoratedOperator",
+            "ExportFileOperator",
             "LoadFileOperator",
             "MergeOperator",
             "TransformOperator",
-            "ExportFileOperator",
         ]
 
     def extract(self) -> TaskMetadata:

--- a/python-sdk/src/astro/lineage/extractor.py
+++ b/python-sdk/src/astro/lineage/extractor.py
@@ -37,6 +37,7 @@ class PythonSDKExtractor(BaseExtractor):
             "LoadFileOperator",
             "MergeOperator",
             "TransformOperator",
+            "ExportFileOperator",
         ]
 
     def extract(self) -> TaskMetadata:

--- a/python-sdk/src/astro/lineage/facets.py
+++ b/python-sdk/src/astro/lineage/facets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import attr
 from openlineage.client.facet import BaseFacet
 
-from astro.constants import FileType, MergeConflictStrategy
+from astro.constants import ExportExistsStrategy, FileType, MergeConflictStrategy
 from astro.table import Column, Metadata
 
 
@@ -20,6 +20,24 @@ class InputFileFacet(BaseFacet):
     filepath: str
     file_size: int | None
     file_type: FileType
+    description: str | None = None
+
+
+@attr.define
+class ExportFileFacet(BaseFacet):
+    """
+    Facet that represents output file for export file
+
+    :param filepath: path of each file.
+    :param file_size: size of the file.
+    :param file_type: type of the file.
+    :param if_exists: Overwrite file if exists.
+    """
+
+    filepath: str
+    file_size: int | None
+    file_type: FileType
+    if_exists: ExportExistsStrategy
     description: str | None = None
 
 

--- a/python-sdk/src/astro/lineage/facets.py
+++ b/python-sdk/src/astro/lineage/facets.py
@@ -38,7 +38,6 @@ class ExportFileFacet(BaseFacet):
     file_size: int | None
     file_type: FileType
     if_exists: ExportExistsStrategy
-    description: str | None = None
 
 
 @attr.define

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -75,7 +75,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
 
     def get_openlineage_facets(self, task_instance) -> OpenLineageFacets:  # skipcq: PYL-W0613
         """
-        Returns the lineage data
+        Collect the input, output, job and run facets for export file operator
         """
         input_dataset: list[OpenlineageDataset] = [
             OpenlineageDataset(

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -77,13 +77,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
         """
         Collect the input, output, job and run facets for export file operator
         """
-        input_dataset: list[OpenlineageDataset] = [
-            OpenlineageDataset(
-                namespace=None,
-                name=None,
-                facets={},
-            )
-        ]
+        input_dataset: list[OpenlineageDataset] = []
         if isinstance(self.input_data, BaseTable):
             input_uri = (
                 f"{self.input_data.openlineage_dataset_namespace()}"

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -85,8 +85,10 @@ class ExportFileOperator(AstroSQLBaseOperator):
             )
         ]
         if isinstance(self.input_data, BaseTable):
-            input_uri = f"{self.input_data.openlineage_dataset_namespace()}"
-            f"://{self.input_data.openlineage_dataset_name()}"
+            input_uri = (
+                f"{self.input_data.openlineage_dataset_namespace()}"
+                f"://{self.input_data.openlineage_dataset_name()}"
+            )
             input_dataset = [
                 OpenlineageDataset(
                     namespace=self.input_data.openlineage_dataset_namespace(),
@@ -177,6 +179,7 @@ def export_file(
     """
 
     task_id = task_id or get_unique_task_id("export_file")
+
     return ExportFileOperator(
         task_id=task_id,
         output_file=output_file,

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -5,11 +5,22 @@ from typing import Any
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
+from openlineage.client.facet import (
+    BaseFacet,
+    DataQualityMetricsInputDatasetFacet,
+    DataSourceDatasetFacet,
+    OutputStatisticsOutputDatasetFacet,
+    SchemaDatasetFacet,
+    SchemaField,
+)
+from openlineage.client.run import Dataset as OpenlineageDataset
 
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import ExportExistsStrategy
 from astro.databases import create_database
 from astro.files import File
+from astro.lineage.extractor import OpenLineageFacets
+from astro.lineage.facets import ExportFileFacet
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.table import BaseTable, Table
 from astro.utils.typing_compat import Context
@@ -62,6 +73,75 @@ class ExportFileOperator(AstroSQLBaseOperator):
         else:
             raise FileExistsError(f"{self.output_file.path} file already exists.")
 
+    def get_openlineage_facets(self, task_instance) -> OpenLineageFacets:  # skipcq: PYL-W0613
+        """
+        Returns the lineage data
+        """
+        input_dataset: list[OpenlineageDataset] = [
+            OpenlineageDataset(
+                namespace=None,
+                name=None,
+                facets={},
+            )
+        ]
+        if isinstance(self.input_data, BaseTable):
+            input_uri = f"{self.input_data.openlineage_dataset_namespace()}"
+            f"://{self.input_data.openlineage_dataset_name()}"
+            input_dataset = [
+                OpenlineageDataset(
+                    namespace=self.input_data.openlineage_dataset_namespace(),
+                    name=self.input_data.openlineage_dataset_name(),
+                    facets={
+                        "dataSource": DataSourceDatasetFacet(
+                            name=self.input_data.openlineage_dataset_name(), uri=input_uri
+                        ),
+                        "schema": SchemaDatasetFacet(
+                            fields=[
+                                SchemaField(
+                                    name=self.input_data.metadata.schema,
+                                    type=self.input_data.metadata.database,
+                                )
+                            ]
+                        ),
+                        "dataQualityMetrics": DataQualityMetricsInputDatasetFacet(
+                            rowCount=self.input_data.row_count, columnMetrics={}
+                        ),
+                    },
+                )
+            ]
+        output_uri = (
+            f"{self.output_file.openlineage_dataset_namespace}"
+            f"://{self.output_file.openlineage_dataset_name}"
+        )
+        output_dataset = [
+            OpenlineageDataset(
+                namespace=self.output_file.openlineage_dataset_namespace,
+                name=self.output_file.openlineage_dataset_name,
+                facets={
+                    "output_file_facet": ExportFileFacet(
+                        filepath=self.output_file.path,
+                        file_size=self.output_file.size,
+                        file_type=self.output_file.type.name,
+                        if_exists=self.if_exists,
+                    ),
+                    "dataSource": DataSourceDatasetFacet(name=self.output_file.path, uri=output_uri),
+                    "outputStatistics": OutputStatisticsOutputDatasetFacet(
+                        rowCount=self.input_data.row_count
+                        if isinstance(self.input_data, BaseTable)
+                        else len(self.input_data),
+                        size=self.output_file.size,
+                    ),
+                },
+            )
+        ]
+
+        run_facets: dict[str, BaseFacet] = {}
+        job_facets: dict[str, BaseFacet] = {}
+
+        return OpenLineageFacets(
+            inputs=input_dataset, outputs=output_dataset, run_facets=run_facets, job_facets=job_facets
+        )
+
 
 def export_file(
     input_data: BaseTable | pd.DataFrame,
@@ -97,7 +177,6 @@ def export_file(
     """
 
     task_id = task_id or get_unique_task_id("export_file")
-
     return ExportFileOperator(
         task_id=task_id,
         output_file=output_file,

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -140,7 +140,7 @@ def test_python_sdk_export_file_extract_on_complete():
         task_id=task_id,
         input_data=Table(conn_id="sqlite_conn", name="test_extractor"),
         output_file=File(
-            path="gs://astro-sdk/workspace/sample_pattern.csv",
+            path="gs://astro-sdk/workspace/openlineage_export_file.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -38,7 +38,7 @@ OUTPUT_STATS_FOR_EXPORT_FILE = [
         namespace=TEST_OUTPUT_DATASET_NAMESPACE,
         name=TEST_OUTPUT_DATASET_NAME,
         facets={
-            "outputStatistics": OutputStatisticsOutputDatasetFacet(rowCount=117, size=None),
+            "outputStatistics": OutputStatisticsOutputDatasetFacet(rowCount=117, size=65),
         },
     )
 ]

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -122,6 +122,11 @@ def test_python_sdk_load_file_extract_on_complete():
 
 @pytest.mark.integration
 def test_python_sdk_export_file_extract_on_complete():
+    """
+    Tests that  the custom PythonSDKExtractor is able to process the
+    operator's metadata that needs to be extracted as per OpenLineage
+    for ExportFileOperator.
+    """
     LoadFileOperator(
         task_id="load_file",
         input_file=File(


### PR DESCRIPTION
**Please describe the feature you'd like to see**
We should be able to extract open lineage info from the ExportFileOperator.

**Describe the solution you'd like**

- Add a method get_openlineage_facets on the Operator (based on [this doc](https://docs.google.com/document/d/1vPsvHejQ24xTbzpz_LYSf0_ixk9oUuBiEUHVEaF9J2U/edit?usp=sharing))
- The "PythonSDKExtractor" built-in [#898](https://github.com/astronomer/astro-sdk/issues/898) should be able to work with ExportFileOperator.get_openlineage_facets. Test it to make sure it works

**Acceptance Criteria**

- [x] Post the screenshot of how it looks in the Openlineage/Marquez UI
- [x]  All checks and tests in the CI should pass
- [x]  Unit tests (90% code coverage or more, [once available](https://github.com/astronomer/astro-sdk/issues/191))
- [x]  Integration tests (if the feature relates to a new database or external service)
- [x] Docstrings in [reStructuredText](https://peps.python.org/pep-0287/) for each of methods, classes, functions and module-level attributes (including Example DAG on how it should be used)
- [x] Exception handling in case of errors
- [x]  Logging (are we exposing useful information to the user? e.g. source and destination)
- [x]  Improve the documentation (README, Sphinx, and any other relevant)

closes #903 