### PR TITLE
Add  global config `enable_native_fallback` for load file op

### DIFF
--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -153,7 +153,7 @@ Refer to :ref:`load_file_working` for details on Native Path.
            :end-before: [END load_file_example_8]
 
 
-#. **enable_native_fallback**: When ``use_native_support`` is set to ``True``, ``load_file`` will attempt to use native transfer. If this fails, ``load_file`` will attempt to use the default path to load data and you will see a warning. If you want to change this behavior you can specify ``enable_native_fallback=False``.
+#. **enable_native_fallback**: When ``use_native_support`` is set to ``True``, ``load_file`` will attempt to use native transfer. If this fails, ``load_file`` task will fail unless you :ref:`configure_native_fallback`
 
         .. literalinclude:: ../../../../example_dags/example_load_file.py
            :language: python

--- a/python-sdk/docs/configurations.rst
+++ b/python-sdk/docs/configurations.rst
@@ -143,3 +143,21 @@ or by updating Airflow's configuration
 
    [astro_sdk]
    openlineage_emit_temp_table_event = True
+
+
+Configuring the native fallback mechanism
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Astro SDK ``LoadFileOperator`` have a fallback mechanism to load data in database using dataframe.
+By default, We have disabled this feature. This can override at task level using ``enable_native_fallback`` param.
+This might be inconvenient for some users who do want to leverage it. Such users can set the following config to ``True`` to enable it at global level.
+
+.. code:: ini
+
+   LOAD_FILE_ENABLE_NATIVE_FALLBACK = False
+
+or by updating Airflow's configuration
+
+.. code:: ini
+
+   [astro_sdk]
+   load_file_enable_native_fallback = False

--- a/python-sdk/docs/configurations.rst
+++ b/python-sdk/docs/configurations.rst
@@ -124,6 +124,7 @@ or by updating Airflow's configuration
    [astro_sdk]
    auto_add_inlets_outlets = True
 
+.. _configure_native_fallback:
 
 Configuring to emit temp table event in openlineage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -147,17 +148,19 @@ or by updating Airflow's configuration
 
 Configuring the native fallback mechanism
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Astro SDK ``LoadFileOperator`` have a fallback mechanism to load data in database using dataframe.
-By default, We have disabled this feature. This can override at task level using ``enable_native_fallback`` param.
-This might be inconvenient for some users who do want to leverage it. Such users can set the following config to ``True`` to enable it at global level.
+The ``LoadFileOperator`` has a fallback mechanism when loading data to the database from file storage as explained in :ref:`load_file_working`.
 
-.. code:: ini
+This fallback can be configured at the task level using ``enable_native_fallback`` param.
 
-   LOAD_FILE_ENABLE_NATIVE_FALLBACK = False
+Users can also control this setting and override the default at a global level (for all tasks) by setting the following config. Set it to ``True`` to allow falling back to "pandas" path.
+
+.. code-block:: shell
+
+   AIRFLOW__ASTRO_SDK__LOAD_FILE_ENABLE_NATIVE_FALLBACK = False
 
 or by updating Airflow's configuration
 
-.. code:: ini
+.. code-block:: ini
 
    [astro_sdk]
    load_file_enable_native_fallback = False

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -118,7 +118,6 @@ with dag:
             "allow_jagged_rows": True,
             "skip_leading_rows": "1",
         },
-        enable_native_fallback=False,
     )
     # [END load_file_example_9]
 

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -165,7 +165,7 @@ with dag:
     # [START load_file_example_14]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),
@@ -199,7 +199,7 @@ with dag:
     # [START load_file_example_17]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -141,7 +141,7 @@ with dag:
     # [START load_file_example_12]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),
@@ -165,7 +165,7 @@ with dag:
     # [START load_file_example_14]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),
@@ -199,7 +199,7 @@ with dag:
     # [START load_file_example_17]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -141,7 +141,7 @@ with dag:
     # [START load_file_example_12]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -411,7 +411,7 @@ class BaseDatabase(ABC):
         :param native_support_kwargs: kwargs to be used by method involved in native support flow
         :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
-        :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer.
+        :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
         """
         normalize_config = normalize_config or {}
 

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -30,7 +30,7 @@ from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
-from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA, LOAD_FILE_ENABLE_NATIVE_FALLBACK
+from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK, LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.table import BaseTable, Metadata
 
 

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -30,7 +30,7 @@ from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
-from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
+from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA, ENABLE_NATIVE_FALLBACK
 from astro.table import BaseTable, Metadata
 
 
@@ -395,7 +395,6 @@ class BaseDatabase(ABC):
         use_native_support: bool = True,
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
-        enable_native_fallback: bool | None = True,
         **kwargs,
     ):
         """
@@ -411,7 +410,6 @@ class BaseDatabase(ABC):
         :param native_support_kwargs: kwargs to be used by method involved in native support flow
         :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
-        :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
         """
         normalize_config = normalize_config or {}
 
@@ -433,7 +431,7 @@ class BaseDatabase(ABC):
                 if_exists="append",
                 normalize_config=normalize_config,
                 native_support_kwargs=native_support_kwargs,
-                enable_native_fallback=enable_native_fallback,
+                enable_native_fallback=ENABLE_NATIVE_FALLBACK,
                 chunk_size=chunk_size,
             )
         else:
@@ -488,7 +486,6 @@ class BaseDatabase(ABC):
         if_exists: LoadExistStrategy = "replace",
         normalize_config: dict | None = None,
         native_support_kwargs: dict | None = None,
-        enable_native_fallback: bool | None = True,
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         **kwargs,
     ):
@@ -500,7 +497,6 @@ class BaseDatabase(ABC):
         :param if_exists: Overwrite file if exists
         :param chunk_size: Specify the number of records in each batch to be written at a time
         :param native_support_kwargs: kwargs to be used by method involved in native support flow
-        :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer.
         :param normalize_config: pandas json_normalize params config
         """
 
@@ -518,7 +514,7 @@ class BaseDatabase(ABC):
                 "Loading files failed with Native Support. Falling back to Pandas-based load",
                 exc_info=True,
             )
-            if enable_native_fallback:
+            if ENABLE_NATIVE_FALLBACK:
                 self.load_file_to_table_using_pandas(
                     input_file=source_file,
                     output_table=target_table,

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -30,7 +30,7 @@ from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
-from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA, ENABLE_NATIVE_FALLBACK
+from astro.settings import ENABLE_NATIVE_FALLBACK, LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.table import BaseTable, Metadata
 
 

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -30,7 +30,7 @@ from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
-from astro.settings import ENABLE_NATIVE_FALLBACK, LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
+from astro.settings import LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA, LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.table import BaseTable, Metadata
 
 
@@ -395,6 +395,7 @@ class BaseDatabase(ABC):
         use_native_support: bool = True,
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
+        enable_native_fallback: bool | None = LOAD_FILE_ENABLE_NATIVE_FALLBACK,
         **kwargs,
     ):
         """
@@ -410,6 +411,7 @@ class BaseDatabase(ABC):
         :param native_support_kwargs: kwargs to be used by method involved in native support flow
         :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
+        :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer.
         """
         normalize_config = normalize_config or {}
 
@@ -431,7 +433,7 @@ class BaseDatabase(ABC):
                 if_exists="append",
                 normalize_config=normalize_config,
                 native_support_kwargs=native_support_kwargs,
-                enable_native_fallback=ENABLE_NATIVE_FALLBACK,
+                enable_native_fallback=enable_native_fallback,
                 chunk_size=chunk_size,
             )
         else:
@@ -486,6 +488,7 @@ class BaseDatabase(ABC):
         if_exists: LoadExistStrategy = "replace",
         normalize_config: dict | None = None,
         native_support_kwargs: dict | None = None,
+        enable_native_fallback: bool | None = LOAD_FILE_ENABLE_NATIVE_FALLBACK,
         chunk_size: int = DEFAULT_CHUNK_SIZE,
         **kwargs,
     ):
@@ -497,6 +500,7 @@ class BaseDatabase(ABC):
         :param if_exists: Overwrite file if exists
         :param chunk_size: Specify the number of records in each batch to be written at a time
         :param native_support_kwargs: kwargs to be used by method involved in native support flow
+        :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
         :param normalize_config: pandas json_normalize params config
         """
 
@@ -514,7 +518,7 @@ class BaseDatabase(ABC):
                 "Loading files failed with Native Support. Falling back to Pandas-based load",
                 exc_info=True,
             )
-            if ENABLE_NATIVE_FALLBACK:
+            if enable_native_fallback:
                 self.load_file_to_table_using_pandas(
                     input_file=source_file,
                     output_table=target_table,

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -10,7 +10,7 @@ BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHE
 SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)
 REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHEMA)
 
-ENABLE_NATIVE_FALLBACK = conf.get("astro_sdk", "enable_native_fallback", False)
+LOAD_FILE_ENABLE_NATIVE_FALLBACK = conf.get("astro_sdk", "load_file_enable_native_fallback", False)
 
 DATAFRAME_STORAGE_CONN_ID = conf.get("astro_sdk", "xcom_storage_conn_id", fallback=None)
 DATAFRAME_STORAGE_URL = conf.get("astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir())

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -10,7 +10,7 @@ BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHE
 SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)
 REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHEMA)
 
-LOAD_FILE_ENABLE_NATIVE_FALLBACK = conf.get("astro_sdk", "load_file_enable_native_fallback", False)
+LOAD_FILE_ENABLE_NATIVE_FALLBACK = conf.get("astro_sdk", "load_file_enable_native_fallback", fallback=False)
 
 DATAFRAME_STORAGE_CONN_ID = conf.get("astro_sdk", "xcom_storage_conn_id", fallback=None)
 DATAFRAME_STORAGE_URL = conf.get("astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir())

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -10,6 +10,8 @@ BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHE
 SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)
 REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHEMA)
 
+ENABLE_NATIVE_FALLBACK = conf.get("astro_sdk", "enable_native_fallback", False)
+
 DATAFRAME_STORAGE_CONN_ID = conf.get("astro_sdk", "xcom_storage_conn_id", fallback=None)
 DATAFRAME_STORAGE_URL = conf.get("astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir())
 STORE_DATA_LOCAL_DEV = conf.get("astro_sdk", "store_data_local_dev", fallback=False)

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any
-import warnings
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
@@ -15,7 +14,7 @@ from astro.databases.base import BaseDatabase
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.lineage.extractor import OpenLineageFacets
 from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
-from astro.settings import ENABLE_NATIVE_FALLBACK
+from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.table import BaseTable
 from astro.utils.dataframe import convert_dataframe_to_file
@@ -52,7 +51,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         use_native_support: bool = True,
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
-        enable_native_fallback: bool | None = ENABLE_NATIVE_FALLBACK,
+        enable_native_fallback: bool | None = LOAD_FILE_ENABLE_NATIVE_FALLBACK,
         **kwargs,
     ) -> None:
         super().__init__(

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -34,7 +34,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
     :param native_support_kwargs: kwargs to be used by method involved in native support flow
     :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
-    :param enable_native_fallback: (deprecated) Use enable_native_fallback=True to fall back to default transfer
+    :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
 
     :return: If ``output_table`` is passed this operator returns a Table object. If not
         passed, returns a dataframe.
@@ -52,6 +52,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         use_native_support: bool = True,
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
+        enable_native_fallback: bool | None = ENABLE_NATIVE_FALLBACK,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -71,16 +72,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         self.use_native_support = use_native_support
         self.native_support_kwargs: dict[str, Any] = native_support_kwargs or {}
         self.columns_names_capitalization = columns_names_capitalization
-        if "enable_native_fallback" in kwargs:
-            warnings.warn(
-                "`enable_native_fallback` as param is deprecated and will be removed in future release"
-                "Please use Airflow config  `AIRFLOW__ASTRO_SDK__ENABLE_NATIVE_FALLBACK` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.enable_native_fallback = kwargs.get("enable_native_fallback")
-        else:
-            self.enable_native_fallback = ENABLE_NATIVE_FALLBACK
+        self.enable_native_fallback = enable_native_fallback
 
     def execute(self, context: Context) -> BaseTable | File:  # skipcq: PYL-W0613
         """
@@ -297,7 +289,7 @@ def load_file(
     :param native_support_kwargs: kwargs to be used by method involved in native support flow
     :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
         in the resulting dataframe
-    :param enable_native_fallback: (deprecated) Use enable_native_fallback=True to fall back to default transfer
+    :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
     """
 
     # Note - using path for task id is causing issues as it's a pattern and

--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -234,7 +234,8 @@ def test_load_file_to_table_natively_for_fallback(mock_load_file, database_table
     database, target_table = database_table_fixture
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
     response = database.load_file_to_table_natively_with_fallback(
-        File(filepath), target_table,
+        File(filepath),
+        target_table,
         enable_native_fallback=True,
     )
     assert response is None

--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -263,7 +263,6 @@ def test_load_file_to_table_natively_for_fallback_wrong_file_location_with_enabl
         database.load_file_to_table_natively_with_fallback(
             source_file=File(filepath),
             target_table=target_table,
-            enable_native_fallback=False,
         )
 
 

--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -233,7 +233,10 @@ def test_load_file_to_table_natively_for_fallback(mock_load_file, database_table
     mock_load_file.side_effect = DatabaseCustomError
     database, target_table = database_table_fixture
     filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
-    response = database.load_file_to_table_natively_with_fallback(File(filepath), target_table)
+    response = database.load_file_to_table_natively_with_fallback(
+        File(filepath), target_table,
+        enable_native_fallback=True,
+    )
     assert response is None
 
 

--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -317,7 +317,6 @@ def test_load_file_to_table_natively_for_fallback_raises_exception_if_not_enable
         database.load_file_to_table_natively_with_fallback(
             source_file=File(filepath),
             target_table=target_table,
-            enable_native_fallback=False,
         )
 
 

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -52,7 +52,7 @@ OUTPUT_STATS = [
                 columns=[],
                 schema="astro",
                 used_native_path=False,
-                enabled_native_fallback=True,
+                enabled_native_fallback=False,
                 native_support_arguments={},
                 description=None,
             )

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -10,6 +10,7 @@ from astro.constants import FileType
 from astro.files import File
 from astro.lineage.extractor import PythonSDKExtractor
 from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
+from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.sql import AppendOperator, MergeOperator
 from astro.sql.operators.load_file import LoadFileOperator
 from astro.table import Metadata, Table
@@ -52,7 +53,7 @@ OUTPUT_STATS = [
                 columns=[],
                 schema="astro",
                 used_native_path=False,
-                enabled_native_fallback=False,
+                enabled_native_fallback=LOAD_FILE_ENABLE_NATIVE_FALLBACK,
                 native_support_arguments={},
                 description=None,
             )

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -29,7 +29,7 @@ INPUT_STATS = [
             "input_file_facet": InputFileDatasetFacet(
                 number_of_files=1,
                 description=None,
-                is_pattern=True,
+                is_pattern=False,
                 files=[
                     InputFileFacet(
                         filepath="gs://astro-sdk/workspace/sample_pattern.csv",

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -16,7 +16,7 @@ from astro.sql.operators.load_file import LoadFileOperator
 from astro.table import Metadata, Table
 from tests.utils.airflow import create_context
 
-TEST_FILE_LOCATION = "gs://astro-sdk/workspace/sample_pattern.csv"
+TEST_FILE_LOCATION = "gs://astro-sdk/workspace/sample_pattern"
 TEST_TABLE = "test-table"
 TEST_INPUT_DATASET_NAMESPACE = "gs://astro-sdk"
 TEST_INPUT_DATASET_NAME = "/workspace/sample_pattern"
@@ -30,7 +30,7 @@ INPUT_STATS = [
             "input_file_facet": InputFileDatasetFacet(
                 number_of_files=1,
                 description=None,
-                is_pattern=False,
+                is_pattern=True,
                 files=[
                     InputFileFacet(
                         filepath="gs://astro-sdk/workspace/sample_pattern.csv",
@@ -109,13 +109,13 @@ def test_append_op_extract_on_complete():
 
     src_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn"),
     ).execute({})
 
     target_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn"),
     ).execute({})
 
@@ -149,13 +149,13 @@ def test_merge_op_extract_on_complete():
     task_id = "merge"
     src_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
     ).execute({})
 
     target_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
     ).execute({})
     op = MergeOperator(

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -16,7 +16,7 @@ from astro.sql.operators.load_file import LoadFileOperator
 from astro.table import Metadata, Table
 from tests.utils.airflow import create_context
 
-TEST_FILE_LOCATION = "gs://astro-sdk/workspace/sample_pattern"
+TEST_FILE_LOCATION = "gs://astro-sdk/workspace/sample_pattern.csv"
 TEST_TABLE = "test-table"
 TEST_INPUT_DATASET_NAMESPACE = "gs://astro-sdk"
 TEST_INPUT_DATASET_NAME = "/workspace/sample_pattern"
@@ -30,7 +30,7 @@ INPUT_STATS = [
             "input_file_facet": InputFileDatasetFacet(
                 number_of_files=1,
                 description=None,
-                is_pattern=True,
+                is_pattern=False,
                 files=[
                     InputFileFacet(
                         filepath="gs://astro-sdk/workspace/sample_pattern.csv",
@@ -109,13 +109,13 @@ def test_append_op_extract_on_complete():
 
     src_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn"),
     ).execute({})
 
     target_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn"),
     ).execute({})
 
@@ -149,13 +149,13 @@ def test_merge_op_extract_on_complete():
     task_id = "merge"
     src_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
     ).execute({})
 
     target_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
     ).execute({})
     op = MergeOperator(

--- a/python-sdk/tests/extractors/test_extractor.py
+++ b/python-sdk/tests/extractors/test_extractor.py
@@ -15,7 +15,7 @@ from astro.sql.operators.load_file import LoadFileOperator
 from astro.table import Metadata, Table
 from tests.utils.airflow import create_context
 
-TEST_FILE_LOCATION = "gs://astro-sdk/workspace/sample_pattern"
+TEST_FILE_LOCATION = "gs://astro-sdk/workspace/sample_pattern.csv"
 TEST_TABLE = "test-table"
 TEST_INPUT_DATASET_NAMESPACE = "gs://astro-sdk"
 TEST_INPUT_DATASET_NAME = "/workspace/sample_pattern"
@@ -108,13 +108,13 @@ def test_append_op_extract_on_complete():
 
     src_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn"),
     ).execute({})
 
     target_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn"),
     ).execute({})
 
@@ -148,13 +148,13 @@ def test_merge_op_extract_on_complete():
     task_id = "merge"
     src_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
     ).execute({})
 
     target_table = LoadFileOperator(
         task_id="load_file",
-        input_file=File(path="gs://astro-sdk/workspace/sample_pattern", filetype=FileType.CSV),
+        input_file=File(path="gs://astro-sdk/workspace/sample_pattern.csv", filetype=FileType.CSV),
         output_table=Table(conn_id="gcp_conn", metadata=Metadata(schema="astro")),
     ).execute({})
     op = MergeOperator(

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -1173,7 +1173,6 @@ def test_load_file_col_cap_native_path(sample_dag, database_table_fixture):
                 "snowflake_storage_integration_google": "gcs_int_python_sdk",
                 "storage_integration": "gcs_int_python_sdk",
             },
-            enable_native_fallback=False,
         )
     test_utils.run_dag(sample_dag)
 


### PR DESCRIPTION
# Description
closes: #1089 
Add `LOAD_FILE_ENABLE_NATIVE_FALLBACK` config to globally disable native fallback

## What is the current behavior?
currently, we do not have a way to disable the native fallback globally

## What is the new behavior?
you can set LOAD_FILE_ENABLE_NATIVE_FALLBACK to disable/enable native fallback still local config will overwrite the global config in case it is provided

## Does this introduce a breaking change?
No (But, by default the ENABLE_NATIVE_FALLBACK was true now its false)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
