### PR TITLE
Bump sql-cli version to 0.1.1a0

### DIFF
--- a/sql-cli/Makefile
+++ b/sql-cli/Makefile
@@ -6,7 +6,7 @@ SYSTEM_PIP := pip
 
 clean:  ## Remove temporary files
 	@echo "Removing cached and temporary files from current directory"
-	@rm -rf logs
+	@rm -rf logs dist
 	@find . -name "*.pyc" -delete
 	@find . -type d -name "__pycache__" -exec rm -rf {} +
 	@find . -name "*.sw[a-z]" -delete

--- a/sql-cli/pyproject.toml
+++ b/sql-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astro-sql-cli"
-version = "0.1.0"
+version = "0.1.1a0"
 description = "Empower analysts to build workflows to transform data using SQL"
 authors = [
     "Astronomer <humans@astronomer.io>",


### PR DESCRIPTION
# Description

To test changes in the upcoming 0.1.1 release we release a 0.1.1a0 version for the sql-cli.

- remove dist folder on "make clean"

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
