### PR TITLE
Add config to emit tmp table event in lineage

### DIFF
--- a/python-sdk/docs/configurations.rst
+++ b/python-sdk/docs/configurations.rst
@@ -123,3 +123,23 @@ or by updating Airflow's configuration
 
    [astro_sdk]
    auto_add_inlets_outlets = True
+
+
+Configuring to emit temp table event in openlineage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Astro SDK has ability to create temporary tables see: :ref:`table`.
+
+By default, we emit the temporary tables in openlienage.
+
+This might be not that useful for some users who do not want to emit such event in openlienage. Such users can set the following config to ``False`` to disable auto addition it.
+
+.. code-block:::: shell
+
+   AIRFLOW__ASTRO_SDK__OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = True
+
+or by updating Airflow's configuration
+
+.. code-block:::: ini
+
+   [astro_sdk]
+   openlineage_emit_temp_table_event = True

--- a/python-sdk/docs/configurations.rst
+++ b/python-sdk/docs/configurations.rst
@@ -129,9 +129,9 @@ Configuring to emit temp table event in openlineage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Astro SDK has ability to create temporary tables see: :ref:`table`.
 
-By default, we emit the temporary tables in openlienage.
+By default, we emit the temporary tables event in openlienage.
 
-This might be not that useful for some users who do not want to emit such event in openlienage. Such users can set the following config to ``False`` to disable auto addition it.
+This might be not that useful for some users who do not want to emit such event in openlienage. Such users can set the following config to ``False`` to disable it.
 
 .. code-block:::: shell
 

--- a/python-sdk/docs/configurations.rst
+++ b/python-sdk/docs/configurations.rst
@@ -133,13 +133,13 @@ By default, we emit the temporary tables event in openlienage.
 
 This might be not that useful for some users who do not want to emit such event in openlienage. Such users can set the following config to ``False`` to disable it.
 
-.. code-block:::: shell
+.. code-block:: shell
 
    AIRFLOW__ASTRO_SDK__OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = True
 
 or by updating Airflow's configuration
 
-.. code-block:::: ini
+.. code-block:: ini
 
    [astro_sdk]
    openlineage_emit_temp_table_event = True

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -13,7 +13,7 @@ REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHE
 DATAFRAME_STORAGE_CONN_ID = conf.get("astro_sdk", "xcom_storage_conn_id", fallback=None)
 DATAFRAME_STORAGE_URL = conf.get("astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir())
 STORE_DATA_LOCAL_DEV = conf.get("astro_sdk", "store_data_local_dev", fallback=False)
-OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.get("astro_sdk", "openlineage_emit_temp_table_event", fallback=False)
+OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.get("astro_sdk", "openlineage_emit_temp_table_event", fallback=True)
 XCOM_BACKEND = conf.get("core", "xcom_backend")
 IS_CUSTOM_XCOM_BACKEND = XCOM_BACKEND not in [
     "airflow.models.xcom.BaseXCom",

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -13,6 +13,7 @@ REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHE
 DATAFRAME_STORAGE_CONN_ID = conf.get("astro_sdk", "xcom_storage_conn_id", fallback=None)
 DATAFRAME_STORAGE_URL = conf.get("astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir())
 STORE_DATA_LOCAL_DEV = conf.get("astro_sdk", "store_data_local_dev", fallback=False)
+OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.get("astro_sdk", "openlineage_emit_temp_table_event", fallback=False)
 XCOM_BACKEND = conf.get("core", "xcom_backend")
 IS_CUSTOM_XCOM_BACKEND = XCOM_BACKEND not in [
     "airflow.models.xcom.BaseXCom",

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -13,7 +13,9 @@ REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHE
 DATAFRAME_STORAGE_CONN_ID = conf.get("astro_sdk", "xcom_storage_conn_id", fallback=None)
 DATAFRAME_STORAGE_URL = conf.get("astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir())
 STORE_DATA_LOCAL_DEV = conf.get("astro_sdk", "store_data_local_dev", fallback=False)
-OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.getboolean("astro_sdk", "openlineage_emit_temp_table_event", fallback=True)
+OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.getboolean(
+    "astro_sdk", "openlineage_emit_temp_table_event", fallback=True
+)
 XCOM_BACKEND = conf.get("core", "xcom_backend")
 IS_CUSTOM_XCOM_BACKEND = XCOM_BACKEND not in [
     "airflow.models.xcom.BaseXCom",

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -13,7 +13,7 @@ REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHE
 DATAFRAME_STORAGE_CONN_ID = conf.get("astro_sdk", "xcom_storage_conn_id", fallback=None)
 DATAFRAME_STORAGE_URL = conf.get("astro_sdk", "xcom_storage_url", fallback=tempfile.gettempdir())
 STORE_DATA_LOCAL_DEV = conf.get("astro_sdk", "store_data_local_dev", fallback=False)
-OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.get("astro_sdk", "openlineage_emit_temp_table_event", fallback=True)
+OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.getboolean("astro_sdk", "openlineage_emit_temp_table_event", fallback=True)
 XCOM_BACKEND = conf.get("core", "xcom_backend")
 IS_CUSTOM_XCOM_BACKEND = XCOM_BACKEND not in [
     "airflow.models.xcom.BaseXCom",

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -19,8 +19,9 @@ from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
 from astro.lineage.extractor import OpenLineageFacets
 from astro.lineage.facets import TableDatasetFacet
+from astro.settings import OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.table import BaseTable
+from astro.table import BaseTable, TempTable
 from astro.utils.typing_compat import Context
 
 
@@ -79,62 +80,72 @@ class AppendOperator(AstroSQLBaseOperator):
         """
         append_query = task_instance.xcom_pull(task_ids=task_instance.task_id, key="append_query")
         source_table_rows = self.source_table.row_count
-        input_uri = (
-            f"{self.source_table.openlineage_dataset_namespace()}"
-            f"://{self.source_table.openlineage_dataset_name()}"
-        )
-        input_dataset: list[OpenlineageDataset] = [
-            OpenlineageDataset(
-                namespace=self.source_table.openlineage_dataset_namespace(),
-                name=self.source_table.openlineage_dataset_name(),
-                facets={
-                    "input_table_facet": TableDatasetFacet(
-                        table_name=self.source_table.name,
-                        source_table_rows=source_table_rows,
-                        columns=self.columns,
-                        metadata=self.source_table.metadata,
-                    ),
-                    "schema": SchemaDatasetFacet(
-                        fields=[
-                            SchemaField(
-                                name=self.source_table.metadata.schema,
-                                type=self.source_table.metadata.database,
-                            )
-                        ]
-                    ),
-                    "dataSource": DataSourceDatasetFacet(name=self.source_table.name, uri=input_uri),
-                    "dataQualityMetrics": DataQualityMetricsInputDatasetFacet(
-                        rowCount=self.source_table.row_count, columnMetrics={}
-                    ),
-                },
+        input_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
+        output_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
+        if (
+                (not isinstance(self.source_table, TempTable))
+                or (isinstance(self.source_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
+        ):
+            input_uri = (
+                f"{self.source_table.openlineage_dataset_namespace()}"
+                f"://{self.source_table.openlineage_dataset_name()}"
             )
-        ]
+            input_dataset = [
+                OpenlineageDataset(
+                    namespace=self.source_table.openlineage_dataset_namespace(),
+                    name=self.source_table.openlineage_dataset_name(),
+                    facets={
+                        "input_table_facet": TableDatasetFacet(
+                            table_name=self.source_table.name,
+                            source_table_rows=source_table_rows,
+                            columns=self.columns,
+                            metadata=self.source_table.metadata,
+                        ),
+                        "schema": SchemaDatasetFacet(
+                            fields=[
+                                SchemaField(
+                                    name=self.source_table.metadata.schema,
+                                    type=self.source_table.metadata.database,
+                                )
+                            ]
+                        ),
+                        "dataSource": DataSourceDatasetFacet(name=self.source_table.name, uri=input_uri),
+                        "dataQualityMetrics": DataQualityMetricsInputDatasetFacet(
+                            rowCount=self.source_table.row_count, columnMetrics={}
+                        ),
+                    },
+                )
+            ]
 
-        output_uri = (
-            f"{self.target_table.openlineage_dataset_namespace()}"
-            f"://{self.target_table.openlineage_dataset_name()}"
-        )
-        output_dataset: list[OpenlineageDataset] = [
-            OpenlineageDataset(
-                namespace=self.target_table.openlineage_dataset_namespace(),
-                name=self.target_table.openlineage_dataset_name(),
-                facets={
-                    "output_table_facet": TableDatasetFacet(
-                        table_name=self.target_table.name,
-                        columns=self.columns,
-                        source_table_rows=source_table_rows,
-                        metadata=self.target_table.metadata,
-                    ),
-                    "outputStatistics": OutputStatisticsOutputDatasetFacet(
-                        rowCount=self.target_table.row_count
-                    ),
-                    "dataSource": DataSourceDatasetFacet(name=self.target_table.name, uri=output_uri),
-                    "dataQualityMetrics": DataQualityMetricsInputDatasetFacet(
-                        rowCount=self.target_table.row_count, columnMetrics={}
-                    ),
-                },
+        if (
+                (not isinstance(self.source_table, TempTable))
+                or (isinstance(self.source_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
+        ):
+            output_uri = (
+                f"{self.target_table.openlineage_dataset_namespace()}"
+                f"://{self.target_table.openlineage_dataset_name()}"
             )
-        ]
+            output_dataset = [
+                OpenlineageDataset(
+                    namespace=self.target_table.openlineage_dataset_namespace(),
+                    name=self.target_table.openlineage_dataset_name(),
+                    facets={
+                        "output_table_facet": TableDatasetFacet(
+                            table_name=self.target_table.name,
+                            columns=self.columns,
+                            source_table_rows=source_table_rows,
+                            metadata=self.target_table.metadata,
+                        ),
+                        "outputStatistics": OutputStatisticsOutputDatasetFacet(
+                            rowCount=self.target_table.row_count
+                        ),
+                        "dataSource": DataSourceDatasetFacet(name=self.target_table.name, uri=output_uri),
+                        "dataQualityMetrics": DataQualityMetricsInputDatasetFacet(
+                            rowCount=self.target_table.row_count, columnMetrics={}
+                        ),
+                    },
+                )
+            ]
 
         run_facets: dict[str, BaseFacet] = {}
         job_facets: dict[str, BaseFacet] = {"sql": SqlJobFacet(query=str(append_query))}

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -82,10 +82,7 @@ class AppendOperator(AstroSQLBaseOperator):
         source_table_rows = self.source_table.row_count
         input_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
         output_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
-        if (
-                (not isinstance(self.source_table, TempTable))
-                or (isinstance(self.source_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
-        ):
+        if self.source_table.openlineage_emit_temp_table_event():
             input_uri = (
                 f"{self.source_table.openlineage_dataset_namespace()}"
                 f"://{self.source_table.openlineage_dataset_name()}"
@@ -117,10 +114,7 @@ class AppendOperator(AstroSQLBaseOperator):
                 )
             ]
 
-        if (
-                (not isinstance(self.source_table, TempTable))
-                or (isinstance(self.source_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
-        ):
+        if self.source_table.openlineage_emit_temp_table_event():
             output_uri = (
                 f"{self.target_table.openlineage_dataset_namespace()}"
                 f"://{self.target_table.openlineage_dataset_name()}"

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -19,9 +19,8 @@ from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
 from astro.lineage.extractor import OpenLineageFacets
 from astro.lineage.facets import TableDatasetFacet
-from astro.settings import OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.table import BaseTable, TempTable
+from astro.table import BaseTable
 from astro.utils.typing_compat import Context
 
 

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -211,7 +211,9 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
                     namespace=self.output_table.openlineage_dataset_namespace(),
                     name=self.output_table.openlineage_dataset_name(),
                     facets={
-                        "schema": SchemaDatasetFacet(fields=[SchemaField(name=self.schema, type=self.database)]),
+                        "schema": SchemaDatasetFacet(
+                            fields=[SchemaField(name=self.schema, type=self.database)]
+                        ),
                         "dataSource": DataSourceDatasetFacet(name=self.output_table.name, uri=input_uri),
                     },
                 )

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -202,10 +202,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         """
         input_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
         output_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
-        if (
-                (not isinstance(self.output_table, TempTable))
-                or (isinstance(self.output_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
-        ):
+        if self.output_table.openlineage_emit_temp_table_event():
             input_uri = (
                 f"{self.output_table.openlineage_dataset_namespace()}"
                 f"://{self.output_table.openlineage_dataset_name()}"
@@ -220,11 +217,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
                     },
                 )
             ]
-
-        if (
-                (not isinstance(self.output_table, TempTable))
-                or (isinstance(self.output_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
-        ):
+        if self.output_table.openlineage_emit_temp_table_event():
             output_uri = (
                 f"{self.output_table.openlineage_dataset_namespace()}"
                 f"://{self.output_table.openlineage_dataset_name()}"

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -22,9 +22,8 @@ from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.lineage.extractor import OpenLineageFacets
-from astro.settings import OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
 from astro.sql.operators.upstream_task_mixin import UpstreamTaskMixin
-from astro.table import BaseTable, Table, TempTable
+from astro.table import BaseTable, Table
 from astro.utils.table import find_first_table
 from astro.utils.typing_compat import Context
 

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from typing import Any
 
 import pandas as pd
@@ -184,6 +185,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
 
         return normalize_config
 
+    @typing.no_type_check
     def get_openlineage_facets(self, task_instance) -> OpenLineageFacets:  # skipcq: PYL-W0613
         """
         Returns the lineage data

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -226,10 +226,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         ]
 
         output_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
-        if (
-                (not isinstance(self.output_table, TempTable))
-                or (isinstance(self.output_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
-        ):
+        if self.output_table.openlineage_emit_temp_table_event():
             output_uri = (
                 f"{self.output_table.openlineage_dataset_namespace()}"
                 f"://{self.output_table.openlineage_dataset_name()}"

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -15,8 +15,9 @@ from astro.databases.base import BaseDatabase
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.lineage.extractor import OpenLineageFacets
 from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
+from astro.settings import OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.table import BaseTable
+from astro.table import BaseTable, TempTable
 from astro.utils.dataframe import convert_dataframe_to_file
 from astro.utils.typing_compat import Context
 
@@ -225,7 +226,10 @@ class LoadFileOperator(AstroSQLBaseOperator):
         ]
 
         output_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
-        if self.output_table:
+        if (
+                (not isinstance(self.output_table, TempTable))
+                or (isinstance(self.output_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
+        ):
             output_uri = (
                 f"{self.output_table.openlineage_dataset_namespace()}"
                 f"://{self.output_table.openlineage_dataset_name()}"

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -15,9 +15,8 @@ from astro.databases.base import BaseDatabase
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.lineage.extractor import OpenLineageFacets
 from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
-from astro.settings import OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.table import BaseTable, TempTable
+from astro.table import BaseTable
 from astro.utils.dataframe import convert_dataframe_to_file
 from astro.utils.typing_compat import Context
 

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing
 from typing import Any
 
 import pandas as pd
@@ -185,7 +184,6 @@ class LoadFileOperator(AstroSQLBaseOperator):
 
         return normalize_config
 
-    @typing.no_type_check
     def get_openlineage_facets(self, task_instance) -> OpenLineageFacets:  # skipcq: PYL-W0613
         """
         Returns the lineage data
@@ -227,7 +225,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         ]
 
         output_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
-        if self.output_table.openlineage_emit_temp_table_event():
+        if self.output_table is not None and self.output_table.openlineage_emit_temp_table_event():
             output_uri = (
                 f"{self.output_table.openlineage_dataset_namespace()}"
                 f"://{self.output_table.openlineage_dataset_name()}"

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -95,10 +95,7 @@ class MergeOperator(AstroSQLBaseOperator):
         """
         input_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
         output_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]
-        if (
-                (not isinstance(self.source_table, TempTable))
-                or (isinstance(self.source_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
-        ):
+        if self.source_table.openlineage_emit_temp_table_event():
             input_uri = (
                 f"{self.source_table.openlineage_dataset_namespace()}"
                 f"://{self.source_table.openlineage_dataset_name()}"
@@ -131,10 +128,7 @@ class MergeOperator(AstroSQLBaseOperator):
                 )
             ]
 
-        if (
-                (not isinstance(self.target_table, TempTable))
-                or (isinstance(self.target_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT)
-        ):
+        if self.target_table.openlineage_emit_temp_table_event():
             output_uri = (
                 f"{self.target_table.openlineage_dataset_namespace()}"
                 f"://{self.target_table.openlineage_dataset_name()}"

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -20,9 +20,8 @@ from astro.constants import MergeConflictStrategy
 from astro.databases import create_database
 from astro.lineage.extractor import OpenLineageFacets
 from astro.lineage.facets import SourceTableMergeDatasetFacet, TargetTableMergeDatasetFacet
-from astro.settings import OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.table import BaseTable, TempTable
+from astro.table import BaseTable
 from astro.utils.typing_compat import Context
 
 

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -176,8 +176,8 @@ class BaseTable:
         return database.openlineage_dataset_namespace()
 
     def openlineage_emit_temp_table_event(self):
-        return (not isinstance(self.source_table, TempTable)) or (
-                isinstance(self.source_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
+        return (not isinstance(self, TempTable)) or (
+                isinstance(self, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
         )
 
 

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -177,7 +177,7 @@ class BaseTable:
 
     def openlineage_emit_temp_table_event(self):
         return (not isinstance(self, TempTable)) or (
-                isinstance(self, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
+            isinstance(self, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
         )
 
 

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -176,6 +176,10 @@ class BaseTable:
         return database.openlineage_dataset_namespace()
 
     def openlineage_emit_temp_table_event(self):
+        """
+        Based on airflow config ```OPENLINEAGE_EMIT_TEMP_TABLE_EVENT``` value and table type
+        check whether to emit temp table event in openlineage or not
+        """
         return (not isinstance(self, TempTable)) or (
             isinstance(self, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
         )

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -9,6 +9,7 @@ from sqlalchemy import Column, MetaData
 
 from astro.airflow.datasets import Dataset
 from astro.databases import create_database
+from astro.settings import OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
 
 MAX_TABLE_NAME_LENGTH = 62
 TEMP_PREFIX = "_tmp_"
@@ -173,6 +174,11 @@ class BaseTable:
         """
         database = create_database(self.conn_id)
         return database.openlineage_dataset_namespace()
+
+    def openlineage_emit_temp_table_event(self):
+        return (not isinstance(self.source_table, TempTable)) or (
+                isinstance(self.source_table, TempTable) and OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
+        )
 
 
 @define(slots=False)

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -228,3 +228,15 @@ def test_openlineage_dataset(mock_get_connection, gcp_cred, connection, name, na
 
     assert tb.openlineage_dataset_name() == name
     assert tb.openlineage_dataset_namespace() == namespace
+
+
+def test_openlineage_emit_temp_table_event():
+    tb = TempTable(name="_tmp_xyz")
+    assert tb.openlineage_emit_temp_table_event() is True
+
+    tb = Table(name="test")
+    assert tb.openlineage_emit_temp_table_event() is True
+
+    with mock.patch("astro.settings.OPENLINEAGE_EMIT_TEMP_TABLE_EVENT", new=False):
+        tb = TempTable(name="_tmp_xyz")
+        assert tb.openlineage_emit_temp_table_event() is False

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -231,12 +231,16 @@ def test_openlineage_dataset(mock_get_connection, gcp_cred, connection, name, na
 
 
 def test_openlineage_emit_temp_table_event():
+    """
+    Based on airflow config ```OPENLINEAGE_EMIT_TEMP_TABLE_EVENT``` value and table type
+    check whether to emit temp table event in openlineage or not
+    """
     tb = TempTable(name="_tmp_xyz")
     assert tb.openlineage_emit_temp_table_event() is True
 
     tb = Table(name="test")
     assert tb.openlineage_emit_temp_table_event() is True
 
-    with mock.patch("astro.settings.OPENLINEAGE_EMIT_TEMP_TABLE_EVENT", new=False):
-        tb = TempTable(name="_tmp_xyz")
-        assert tb.openlineage_emit_temp_table_event() is False
+    # with mock.patch("astro.settings.OPENLINEAGE_EMIT_TEMP_TABLE_EVENT", new=False):
+    #     tb = TempTable(name="_tmp_xyz")
+    #     assert tb.openlineage_emit_temp_table_event() is False

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -241,6 +241,6 @@ def test_openlineage_emit_temp_table_event():
     tb = Table(name="test")
     assert tb.openlineage_emit_temp_table_event() is True
 
-    # with mock.patch("astro.settings.OPENLINEAGE_EMIT_TEMP_TABLE_EVENT", new=False):
-    #     tb = TempTable(name="_tmp_xyz")
-    #     assert tb.openlineage_emit_temp_table_event() is False
+    with mock.patch("astro.table.OPENLINEAGE_EMIT_TEMP_TABLE_EVENT", new=False):
+        tb = TempTable(name="_tmp_xyz")
+        assert tb.openlineage_emit_temp_table_event() is False


### PR DESCRIPTION
# Description
closes: #1121 
Make emit temp table event in open lineage configurable 

## What is the current behavior?
We emit events for both temp and not temp in OL

## What is the new behavior?
- Always emit for non-temp table
- if a table is a temp then emit if `OPENLINEAGE_EMIT_TEMP_TABLE_EVENT`  is true

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
