### PR TITLE
Disable propagation for airflow logs in sql-cli

### DIFF
--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -12,7 +12,9 @@ load_dotenv()
 app = typer.Typer(add_completion=False, context_settings={"help_option_names": ["-h", "--help"]})
 
 
-logging.getLogger("airflow").setLevel(logging.CRITICAL)
+airflow_logger = logging.getLogger("airflow")
+airflow_logger.setLevel(logging.CRITICAL)
+airflow_logger.propagate = False
 
 
 @app.command(help="Print the SQL CLI version.")

--- a/sql-cli/tests/test_run_dag.py
+++ b/sql-cli/tests/test_run_dag.py
@@ -121,7 +121,7 @@ def test_run_dag(capsys, caplog):
     assert not any(record.name == "airflow.task" for record in caplog.records)
 
 
-def test_run_dag_verbose(capsys, caplog):
+def test_run_dag_verbose(capsys):
     dag = get_dag(dag_id="example_dataframe", subdir=f"{CWD}/test_dag")
     run_dag(dag, verbose=True)
     captured = capsys.readouterr()

--- a/sql-cli/tests/test_run_dag.py
+++ b/sql-cli/tests/test_run_dag.py
@@ -113,9 +113,17 @@ def test_run_dag_with_skip(sample_dag, capsys):
     assert "Processing movie_ends... SUCCESS" in captured.out
 
 
-def test_run_dag(capsys):
+def test_run_dag(capsys, caplog):
     dag = get_dag(dag_id="example_dataframe", subdir=f"{CWD}/test_dag")
     run_dag(dag)
+    captured = capsys.readouterr()
+    assert "The worst month was" in captured.out
+    assert not any(record.name == "airflow.task" for record in caplog.records)
+
+
+def test_run_dag_verbose(capsys, caplog):
+    dag = get_dag(dag_id="example_dataframe", subdir=f"{CWD}/test_dag")
+    run_dag(dag, verbose=True)
     captured = capsys.readouterr()
     assert "The worst month was" in captured.out
 


### PR DESCRIPTION
# Description

## What is the current behavior?

In Airflow version `2.4.2` the airflow logs propagation has changed from `False` to `True`.

closes: #1149
related: https://github.com/apache/airflow/issues/27345

## What is the new behavior?

Since we don't want to show any airflow logs to the user by default we explicitly disable it now.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
