### PR TITLE
Tests: Fix error on retry

### DIFF
--- a/python-sdk/tests/test_example_dags.py
+++ b/python-sdk/tests/test_example_dags.py
@@ -29,7 +29,7 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 @retry(
     stop=stop_after_attempt(3),
-    retry=retry_if_exception_type(RETRY_ON_EXCEPTIONS),
+    retry=retry_if_exception_type(tuple(RETRY_ON_EXCEPTIONS)),
     wait=wait_exponential(multiplier=10, min=10, max=60),  # values in seconds
 )
 def wrapper_run_dag(dag):


### PR DESCRIPTION
Our retry logic (added in https://github.com/astronomer/astro-sdk/pull/641) wasn't working because the `retry_if_exception_type` expected a tuple while we passed a list

Before:

```
============================================================================================== short test summary info ===============================================================================================
FAILED tests/test_example_dags.py::test_example_dag[calculate_popular_movies] - TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
====================================================================================== 1 failed, 1 passed, 4 warnings in 1.30s =======================================================================================

```

After:

```
============================================================================================== short test summary info ===============================================================================================
FAILED tests/test_example_dags.py::test_example_dag[calculate_popular_movies] - requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://raw.githubusercontent.com/astronomer/astro-sdk/main/tes...
====================================================================================== 1 failed, 1 passed, 4 warnings in 1.65s =======================================================================================

```

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
