### PR TITLE
Change the default date to utcnow()

### DIFF
--- a/python-sdk/tests/integration_test_dag.py
+++ b/python-sdk/tests/integration_test_dag.py
@@ -131,4 +131,4 @@ def test_full_dag(database_table_fixture, sample_dag):
             if_exists="replace",
         )
         aql.cleanup()
-    test_utils.run_dag(sample_dag, account_for_cleanup_failure=True)
+    test_utils.run_dag(sample_dag)

--- a/python-sdk/tests/sql/operators/utils.py
+++ b/python-sdk/tests/sql/operators/utils.py
@@ -27,7 +27,7 @@ from astro.table import Metadata
 
 log = logging.getLogger(__name__)
 
-DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+DEFAULT_DATE = timezone.utcnow()
 
 SQL_SERVER_HOOK_PARAMETERS = {
     "snowflake": {

--- a/python-sdk/tests/sql/operators/utils.py
+++ b/python-sdk/tests/sql/operators/utils.py
@@ -27,8 +27,6 @@ from astro.table import Metadata
 
 log = logging.getLogger(__name__)
 
-DEFAULT_DATE = timezone.utcnow()
-
 SQL_SERVER_HOOK_PARAMETERS = {
     "snowflake": {
         "snowflake_conn_id": "snowflake_conn",
@@ -64,17 +62,7 @@ def get_table_name(prefix):
 
 
 def run_dag(dag: DAG, account_for_cleanup_failure=False):
-    """
-
-    :param dag: DAG
-    :param account_for_cleanup_failure: Since our cleanup task fails on purpose when running in 'single thread mode'
-    we account for this by running the backfill one more time if the cleanup task is the ONLY failed task. Otherwise
-    we just passthrough the exception.
-    :return:
-    """
-    dag.clear(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, dag_run_state=State.NONE)
-
-    test_dag(dag=dag, execution_date=DEFAULT_DATE)
+    test_dag(dag=dag)
 
 
 def load_to_dataframe(filepath, file_type):

--- a/python-sdk/tests/test_example_dags.py
+++ b/python-sdk/tests/test_example_dags.py
@@ -6,13 +6,12 @@ import airflow
 import pytest
 from airflow.models import DAG
 from airflow.models.dagbag import DagBag
-from airflow.utils import timezone
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session
 from packaging.version import Version
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from tests.sql.operators import utils as test_utils
+from .sql.operators import utils as test_utils
 
 RETRY_ON_EXCEPTIONS = []
 try:
@@ -24,16 +23,13 @@ except ModuleNotFoundError:
     pass
 
 
-DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-
-
 @retry(
     stop=stop_after_attempt(3),
     retry=retry_if_exception_type(tuple(RETRY_ON_EXCEPTIONS)),
     wait=wait_exponential(multiplier=10, min=10, max=60),  # values in seconds
 )
 def wrapper_run_dag(dag):
-    test_utils.run_dag(dag, account_for_cleanup_failure=True)
+    test_utils.run_dag(dag)
 
 
 @provide_session


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently the DEFAULT_DATE is set to `timezone.datetime(2016, 1, 1)` in `python-sdk/tests/sql/operators/utils.py` So all the DAGs in example DAGs have datetime set to after 2016 are not running and they are marked as success.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1173 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Change to DEFAULT_DATE = timezone.utcnow()

Note: We should merge this change to main ASAP as other tests are not affected.

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
