### PR TITLE
Add global debug option and more verbose options to sql-cli

### DIFF
--- a/python-sdk/tests/benchmark/analyse.py
+++ b/python-sdk/tests/benchmark/analyse.py
@@ -8,10 +8,10 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import pandas as pd
-import settings as benchmark_settings
 from google.cloud import storage
 from sqlalchemy import text
 
+import settings as benchmark_settings
 from astro.databases import create_database
 from astro.table import Metadata, Table
 

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -6,10 +6,10 @@ from datetime import datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
-import settings as benchmark_settings
 from airflow import DAG
 from run import export_profile_data_to_bq
 
+import settings as benchmark_settings
 from astro import sql as aql
 from astro.constants import DEFAULT_CHUNK_SIZE, FileType
 from astro.files import File

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -9,12 +9,12 @@ from urllib.parse import urlparse
 import airflow
 import pandas as pd
 import psutil
-import settings as benchmark_settings
 from airflow.executors.debug_executor import DebugExecutor
 from airflow.models import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
 
+import settings as benchmark_settings
 from astro.databases import create_database
 from astro.table import Metadata, Table
 

--- a/sql-cli/Makefile
+++ b/sql-cli/Makefile
@@ -3,7 +3,6 @@
 SHELL := /bin/bash
 SYSTEM_PIP := pip
 
-
 clean:  ## Remove temporary files
 	@echo "Removing cached and temporary files from current directory"
 	@rm -rf logs dist

--- a/sql-cli/Makefile
+++ b/sql-cli/Makefile
@@ -3,6 +3,7 @@
 SHELL := /bin/bash
 SYSTEM_PIP := pip
 
+
 clean:  ## Remove temporary files
 	@echo "Removing cached and temporary files from current directory"
 	@rm -rf logs dist

--- a/sql-cli/conftest.py
+++ b/sql-cli/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import shutil
 import string
@@ -186,11 +187,10 @@ def initialised_project_with_test_config(initialised_project: Project):
 
 
 @pytest.fixture()
-def initialised_project_with_sqlite_non_existent_host_path_config(initialised_project: Project):
-    sqlite_non_existent_host_path = "sqlite_non_existent_host_path"
+def initialised_project_with_invalid_config(initialised_project: Project):
     shutil.copytree(
-        src=CWD / "tests" / "config" / sqlite_non_existent_host_path,
-        dst=initialised_project.directory / "config" / sqlite_non_existent_host_path,
+        src=CWD / "tests" / "config" / "invalid",
+        dst=initialised_project.directory / "config" / "invalid",
     )
     return initialised_project
 
@@ -210,3 +210,13 @@ def initialised_project_with_tests_workflows(initialised_project: Project):
         dirs_exist_ok=True,
     )
     return initialised_project
+
+
+@pytest.fixture()
+def logger():
+    return logging.getLogger("sql_cli")
+
+
+@pytest.fixture()
+def ext_loggers():
+    return [logging.getLogger(logger_name) for logger_name in ["airflow", "botocore", "snowflake"]]

--- a/sql-cli/conftest.py
+++ b/sql-cli/conftest.py
@@ -10,6 +10,7 @@ from airflow.utils import timezone
 from airflow.utils.session import create_session
 
 from astro.table import MAX_TABLE_NAME_LENGTH
+from sql_cli.constants import EXT_LOGGER_NAMES, LOGGER_NAME
 from sql_cli.dag_generator import Workflow
 from sql_cli.project import Project
 from sql_cli.workflow_directory_parser import SqlFile, WorkflowFile
@@ -214,9 +215,9 @@ def initialised_project_with_tests_workflows(initialised_project: Project):
 
 @pytest.fixture()
 def logger():
-    return logging.getLogger("sql_cli")
+    return logging.getLogger(LOGGER_NAME)
 
 
 @pytest.fixture()
 def ext_loggers():
-    return [logging.getLogger(logger_name) for logger_name in ["airflow", "botocore", "snowflake"]]
+    return [logging.getLogger(logger_name) for logger_name in EXT_LOGGER_NAMES]

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -68,8 +68,8 @@ def type_check(session: nox.Session) -> None:
     """Run MyPy checks."""
     session.install("poetry")
     session.run("poetry", "install", "--with", "type_check")
-    session.run("mypy", "--version")
-    session.run("mypy")
+    session.run("poetry", "run", "mypy", "--version")
+    session.run("poetry", "run", "mypy")
 
 
 @nox.session()

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import typer
 from dotenv import load_dotenv
-from rich.logging import RichHandler
 
 import sql_cli
 from sql_cli.astro.command import AstroCommand
@@ -15,7 +14,7 @@ from sql_cli.cli import config as cli_config
 from sql_cli.cli.utils import resolve_project_dir
 from sql_cli.constants import DEFAULT_BASE_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR
 from sql_cli.exceptions import ConnectionFailed, DagCycle, EmptyDag, WorkflowFilesDirectoryNotFound
-from sql_cli.utils.rich import rprint
+from sql_cli.utils.rich import RichHandler, rprint
 
 if TYPE_CHECKING:
     from sql_cli.project import Project  # pragma: no cover

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import typer
 from dotenv import load_dotenv
-from typer import Exit
+from rich.logging import RichHandler
 
 import sql_cli
 from sql_cli.astro.command import AstroCommand
@@ -29,16 +29,36 @@ app = typer.Typer(
     rich_markup_mode="rich",
 )
 app.add_typer(cli_config.app, name="config", hidden=True)
+log = logging.getLogger("sql_cli")
 
-airflow_logger = logging.getLogger("airflow")
-airflow_logger.setLevel(logging.CRITICAL)
-airflow_logger.propagate = False
 
-boto_logger = logging.getLogger("botocore")
-boto_logger.setLevel(logging.CRITICAL)
+def set_verbose_mode(verbose: bool) -> None:
+    """
+    Sets the logging level for the sql-cli to be more verbose.
 
-snowflake_logger = logging.getLogger("snowflake")
-snowflake_logger.setLevel(logging.CRITICAL)
+    :param verbose: Whether verbose logs should be enabled.
+    """
+    log.propagate = False
+    log.addHandler(RichHandler(markup=True))
+    if verbose:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.CRITICAL)
+
+
+def set_debug_mode(debug: bool) -> None:
+    """
+    Sets the logging level for all external dependencies.
+
+    :param debug: Whether debug logs should be enabled.
+    """
+    for logger_name in ["airflow", "botocore", "snowflake"]:
+        logger = logging.getLogger(logger_name)
+        logger.propagate = debug
+        if debug:
+            logger.setLevel(logging.DEBUG)
+        else:
+            logger.setLevel(logging.CRITICAL)
 
 
 @app.command(
@@ -79,9 +99,11 @@ def generate(
         help="whether to explicitly generate the tasks in your SQL CLI DAG",
         show_default=True,
     ),
+    verbose: bool = typer.Option(False, help="Whether to show verbose output", show_default=True),
 ) -> None:
     from sql_cli.project import Project
 
+    set_verbose_mode(verbose)
     project_dir_absolute = resolve_project_dir(project_dir)
     project = Project(project_dir_absolute)
     project.load_config(env)
@@ -112,13 +134,19 @@ def validate(
         default=None,
         help="(Optional) Identifier of the connection to be validated. By default checks all the env connections.",
     ),
+    verbose: bool = typer.Option(False, help="Whether to show verbose output", show_default=True),
 ) -> None:
     from sql_cli.connections import validate_connections
     from sql_cli.project import Project
 
+    set_verbose_mode(verbose)
     project_dir_absolute = resolve_project_dir(project_dir)
     project = Project(project_dir_absolute)
-    project.load_config(environment=env)
+    try:
+        project.load_config(environment=env)
+    except FileNotFoundError as file_not_found_error:
+        log.exception(file_not_found_error.args[0])
+        rprint(f"[bold red]{file_not_found_error}[/bold red]")
 
     rprint(f"Validating connection(s) for environment '{env}'")
     validate_connections(connections=project.connections, connection_id=connection)
@@ -150,7 +178,7 @@ def run(
         help="whether to explicitly generate the tasks in your SQL CLI DAG",
         show_default=True,
     ),
-    verbose: bool = typer.Option(False, help="Whether to show airflow logs", show_default=True),
+    verbose: bool = typer.Option(False, help="Whether to show verbose output", show_default=True),
 ) -> None:
     from airflow.utils.state import State
 
@@ -158,11 +186,16 @@ def run(
     from sql_cli.project import Project
     from sql_cli.utils.airflow import get_dag
 
+    set_verbose_mode(verbose)
     project_dir_absolute = resolve_project_dir(project_dir)
     project = Project(project_dir_absolute)
     project.load_config(env)
 
+    # TODO: Validate all DAG connections before running
+
+    # Generate DAG before running
     dag_file = _generate_dag(project=project, workflow_name=workflow_name, generate_tasks=generate_tasks)
+
     dag = get_dag(dag_id=workflow_name, subdir=dag_file.parent.as_posix(), include_examples=False)
 
     rprint(f"\nRunning the workflow [bold blue]{dag.dag_id}[/bold blue] for [bold]{env}[/bold] environment\n")
@@ -174,13 +207,15 @@ def run(
             verbose=verbose,
         )
     except ConnectionFailed as connection_failed:
+        log.exception(connection_failed.args[0])
         rprint(
             f"  [bold red]{connection_failed}[/bold red] using connection [bold]{connection_failed.conn_id}[/bold]"
         )
-        raise Exit(code=1)
+        raise typer.Exit(code=1)
     except Exception as exception:
+        log.exception(exception.args[0])
         rprint(f"  [bold red]{exception}[/bold red]")
-        raise Exit(code=1)
+        raise typer.Exit(code=1)
     final_state = dr.state
     if dr.state == State.SUCCESS:
         final_state = "[bold green]SUCCESS 🚀[/bold green]"
@@ -261,21 +296,35 @@ def _generate_dag(project: Project, workflow_name: str, generate_tasks: bool) ->
             dags_directory=project.airflow_dags_folder,
             generate_tasks=generate_tasks,
         )
-    except EmptyDag:
+    except EmptyDag as empty_dag:
+        log.exception(empty_dag.args[0])
         rprint(f"[bold red]The workflow {workflow_name} does not have any SQL files![/bold red]")
-        raise Exit(code=1)
-    except WorkflowFilesDirectoryNotFound:
+        raise typer.Exit(code=1)
+    except WorkflowFilesDirectoryNotFound as workflow_files_directory_not_found:
+        log.exception(workflow_files_directory_not_found.args[0])
         rprint(f"[bold red]The workflow {workflow_name} does not exist![/bold red]")
-        raise Exit(code=1)
+        raise typer.Exit(code=1)
     except DagCycle as dag_cycle:
+        log.exception(dag_cycle.args[0])
         rprint(f"[bold red]The workflow {workflow_name} contains a cycle! {dag_cycle}[/bold red]")
-        raise Exit(code=1)
+        raise typer.Exit(code=1)
     import_errors = check_for_dag_import_errors(dag_file)
     if import_errors:
+        log.error(import_errors)
         all_errors = "\n\n".join(list(import_errors.values()))
         rprint(f"[bold red]Workflow failed to render[/bold red]\n errors found:\n\n {all_errors}")
-        raise Exit(code=1)
+        raise typer.Exit(code=1)
     return dag_file
+
+
+@app.callback()
+def main(debug: bool = False) -> None:
+    """
+    The main callback being called when option is provided after flow command. E.g. flow --debug run ...
+
+    :params debug: whether to enable debug logs from third parties.
+    """
+    set_debug_mode(debug)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -12,7 +12,7 @@ from sql_cli.astro.command import AstroCommand
 from sql_cli.astro.group import AstroGroup
 from sql_cli.cli import config as cli_config
 from sql_cli.cli.utils import resolve_project_dir
-from sql_cli.constants import DEFAULT_BASE_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR
+from sql_cli.constants import DEFAULT_BASE_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR, STATE
 from sql_cli.exceptions import ConnectionFailed, DagCycle, EmptyDag, WorkflowFilesDirectoryNotFound
 from sql_cli.utils.rich import RichHandler, rprint
 
@@ -51,6 +51,8 @@ def set_debug_mode(debug: bool) -> None:
 
     :param debug: Whether debug logs should be enabled.
     """
+    STATE["debug"] = debug
+
     for logger_name in ["airflow", "botocore", "snowflake"]:
         logger = logging.getLogger(logger_name)
         logger.propagate = debug

--- a/sql-cli/sql_cli/connections.py
+++ b/sql-cli/sql_cli/connections.py
@@ -7,11 +7,12 @@ from typing import Any
 
 from airflow.models import Connection
 
+from sql_cli.constants import LOGGER_NAME
 from sql_cli.utils.rich import rprint
 
 CONNECTION_ID_OUTPUT_STRING_WIDTH = 25
 
-log = logging.getLogger("sql_cli")
+log = logging.getLogger(LOGGER_NAME)
 
 
 def convert_to_connection(conn: dict[str, Any], data_dir: Path) -> Connection:

--- a/sql-cli/sql_cli/connections.py
+++ b/sql-cli/sql_cli/connections.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -9,6 +10,8 @@ from airflow.models import Connection
 from sql_cli.utils.rich import rprint
 
 CONNECTION_ID_OUTPUT_STRING_WIDTH = 25
+
+log = logging.getLogger("sql_cli")
 
 
 def convert_to_connection(conn: dict[str, Any], data_dir: Path) -> Connection:
@@ -49,17 +52,19 @@ def validate_connections(connections: list[Connection], connection_id: str | Non
     for connection in connections:
         if not connection_id or connection_id and connection.conn_id == connection_id:
             os.environ[f"AIRFLOW_CONN_{connection.conn_id.upper()}"] = connection.get_uri()
-            status = (
-                "[bold green]PASSED[/bold green]" if _is_valid(connection) else "[bold red]FAILED[/bold red]"
-            )
+            success_status, message = _is_valid(connection)
+            status = "[bold green]PASSED[/bold green]" if success_status else "[bold red]FAILED[/bold red]"
             rprint(f"Validating connection {connection.conn_id:{CONNECTION_ID_OUTPUT_STRING_WIDTH}}", status)
+            formatted_message = (
+                f"[bold green]{message}[/bold green]" if success_status else f"[bold red]{message}[/bold red]"
+            )
+            log.debug("Connection Message: %s", formatted_message)
 
 
-def _is_valid(connection: Connection) -> bool:
+def _is_valid(connection: Connection) -> tuple[bool, str]:
     # Sqlite automatically creates the file if it does not exist,
     # but our users might not expect that. They are referencing a database they expect to exist.
     if connection.conn_type == "sqlite" and not Path(connection.host).is_file():
-        return False
+        return False, "Sqlite db does not exist!"
 
-    success_status, _ = connection.test_connection()
-    return success_status
+    return connection.test_connection()

--- a/sql-cli/sql_cli/constants.py
+++ b/sql-cli/sql_cli/constants.py
@@ -1,5 +1,3 @@
-STATE = {"debug": False}
-
 CONFIG_DIR = "config"
 GLOBAL_CONFIG_FILENAME = "global.yml"
 CONFIG_FILENAME = "configuration.yml"
@@ -13,3 +11,6 @@ GENERATED_WORKFLOW_INCLUDE_DIRECTORY = "include"
 
 # Connection types
 SQLITE_CONN_TYPE = "sqlite"
+
+LOGGER_NAME = "sql_cli"
+EXT_LOGGER_NAMES = ["airflow", "botocore", "snowflake"]

--- a/sql-cli/sql_cli/constants.py
+++ b/sql-cli/sql_cli/constants.py
@@ -1,3 +1,5 @@
+STATE = {"debug": False}
+
 CONFIG_DIR = "config"
 GLOBAL_CONFIG_FILENAME = "global.yml"
 CONFIG_FILENAME = "configuration.yml"

--- a/sql-cli/sql_cli/dag_runner.py
+++ b/sql-cli/sql_cli/dag_runner.py
@@ -15,13 +15,12 @@ from airflow.utils import timezone
 from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState, State
 from airflow.utils.types import DagRunType
-from rich.logging import RichHandler
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.session import Session
 
 from astro.sql.operators.cleanup import AstroCleanupException
 from sql_cli.exceptions import ConnectionFailed
-from sql_cli.utils.rich import rprint
+from sql_cli.utils.rich import RichHandler, rprint
 
 log = logging.getLogger("sql_cli")
 

--- a/sql-cli/sql_cli/dag_runner.py
+++ b/sql-cli/sql_cli/dag_runner.py
@@ -19,10 +19,11 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.session import Session
 
 from astro.sql.operators.cleanup import AstroCleanupException
+from sql_cli.constants import LOGGER_NAME
 from sql_cli.exceptions import ConnectionFailed
 from sql_cli.utils.rich import RichHandler, rprint
 
-log = logging.getLogger("sql_cli")
+log = logging.getLogger(LOGGER_NAME)
 
 # This was added to airflow.utils.session as part of Airflow 2.2.4, we're copying it here for backwwards
 # compatibility (currently we support Airflow 2.1 onwards)

--- a/sql-cli/sql_cli/settings.py
+++ b/sql-cli/sql_cli/settings.py
@@ -1,0 +1,1 @@
+STATE = {"debug": False}

--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -10,12 +10,13 @@ from typing import TYPE_CHECKING
 
 from packaging.version import Version
 
-from sql_cli.constants import STATE
+from sql_cli.constants import LOGGER_NAME
+from sql_cli.settings import STATE
 
 if TYPE_CHECKING:
     from airflow.models.dag import DAG  # pragma: no cover
 
-log = logging.getLogger("sql_cli")
+log = logging.getLogger(LOGGER_NAME)
 airflow_logger = logging.getLogger("airflow")
 
 
@@ -35,7 +36,7 @@ def initialise(airflow_home: Path, airflow_dags_folder: Path) -> None:
     :params airflow_home: The airflow home to set
     :params airflow_dags_folder: The airflow dags folder to set
     """
-    # Set airflow environment variables prior to database initialization
+    log.debug("Set airflow environment variables prior to database initialization")
     os.environ["AIRFLOW_HOME"] = airflow_home.as_posix()
     os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = airflow_dags_folder.as_posix()
     if version() >= Version("2.3"):
@@ -43,18 +44,20 @@ def initialise(airflow_home: Path, airflow_dags_folder: Path) -> None:
     else:
         os.environ.pop("AIRFLOW__CORE__SQL_ALCHEMY_CONN", None)
 
-    # Reload airflow configuration after setting environment variables
+    log.debug("Reload airflow configuration after setting environment variables")
     from airflow import configuration
 
     importlib.reload(configuration)
 
     if STATE["debug"]:
-        # Initialise the airflow database
+        log.debug("Initialise the airflow database")
         exit_code = os.system("airflow db init")  # skipcq: BAN-B605,BAN-B607
         airflow_logger.debug("Airflow DB Initialization exited with %s", exit_code)
     else:
-        # Initialise the airflow database & hide all logs
+        log.debug("Initialise the airflow database & hide all logs")
         os.system("airflow db init > /dev/null 2>&1")  # skipcq: BAN-B605,BAN-B607
+
+    log.debug("Initialised Airflow successfully. Airflow env vars are: %s", _get_airflow_env_vars())
 
 
 def reload(airflow_home: Path) -> None:
@@ -64,9 +67,9 @@ def reload(airflow_home: Path) -> None:
 
     :params airflow_home: The airflow home to set
     """
-    # Set airflow environment variables
+    log.debug("Set airflow environment variables")
     os.environ["AIRFLOW_HOME"] = airflow_home.as_posix()
-    # ..from config
+    log.debug("Set airflow environment variables from config")
     parser = ConfigParser()
     parser.read(airflow_home / "airflow.cfg")
     if version() >= Version("2.3"):
@@ -83,6 +86,12 @@ def reload(airflow_home: Path) -> None:
     import airflow
 
     importlib.reload(airflow)
+
+    log.debug("Reloaded Airflow successfully. Airflow env vars are: %s", _get_airflow_env_vars())
+
+
+def _get_airflow_env_vars() -> list[str]:
+    return [f"{item}={value}" for item, value in os.environ.items() if item.startswith("AIRFLOW_")]
 
 
 # The following function was copied from Apache Airflow

--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -10,10 +10,13 @@ from typing import TYPE_CHECKING
 
 from packaging.version import Version
 
+from sql_cli.constants import STATE
+
 if TYPE_CHECKING:
     from airflow.models.dag import DAG  # pragma: no cover
 
 log = logging.getLogger("sql_cli")
+airflow_logger = logging.getLogger("airflow")
 
 
 def version() -> Version:
@@ -45,10 +48,10 @@ def initialise(airflow_home: Path, airflow_dags_folder: Path) -> None:
 
     importlib.reload(configuration)
 
-    if log.level == logging.DEBUG:
+    if STATE["debug"]:
         # Initialise the airflow database
         exit_code = os.system("airflow db init")  # skipcq: BAN-B605,BAN-B607
-        log.debug("Airflow DB Initialization exited with %s", exit_code)
+        airflow_logger.debug("Airflow DB Initialization exited with %s", exit_code)
     else:
         # Initialise the airflow database & hide all logs
         os.system("airflow db init > /dev/null 2>&1")  # skipcq: BAN-B605,BAN-B607

--- a/sql-cli/sql_cli/utils/rich.py
+++ b/sql-cli/sql_cli/utils/rich.py
@@ -2,6 +2,7 @@ from typing import IO, Any, Optional, Union
 
 import click
 from rich.highlighter import ReprHighlighter
+from rich.logging import RichHandler as OriginalRichHandler
 from rich.panel import Panel
 from typer.rich_utils import (
     ALIGN_ERRORS_PANEL,
@@ -71,3 +72,8 @@ def rprint(
 
     write_console = console if file is None else Console(file=file)
     return write_console.print(*objects, sep=sep, end=end)
+
+
+class RichHandler(OriginalRichHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, console=_get_rich_console())

--- a/sql-cli/sql_cli/utils/rich.py
+++ b/sql-cli/sql_cli/utils/rich.py
@@ -75,5 +75,5 @@ def rprint(
 
 
 class RichHandler(OriginalRichHandler):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs, console=_get_rich_console())

--- a/sql-cli/sql_cli/utils/rich.py
+++ b/sql-cli/sql_cli/utils/rich.py
@@ -75,5 +75,5 @@ def rprint(
 
 
 class RichHandler(OriginalRichHandler):
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs, console=_get_rich_console())

--- a/sql-cli/tests/config/invalid/configuration.yml
+++ b/sql-cli/tests/config/invalid/configuration.yml
@@ -1,5 +1,5 @@
 connections:
-  - conn_id: sqlite_conn_invalid
+  - conn_id: sqlite_non_existent_host_path
     conn_type: sqlite
     host: imdb2.db
     login:


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we don't have an option for the user to show verbose output to debug.

closes: #1040

## What is the new behavior?

We add a global `--debug` option and more local `--verbose` flags.

- show airflow and other deps debug logs when debug is set
- show raw exceptions when verbose is set
- add verbose log to validate_connections
- use sql-cli logger instead of new logger in run_dag
- add RichHandler instead of StreamHandler to ti logger
- add test for log level
- set log level for ti.log
- show airflow db init stdout/stderr when debug is set
- catch exception in validate connections to continue validating

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
