### PR TITLE
Change the namespace for open lineage

### DIFF
--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from sqlalchemy import MetaData as SqlaMetaData, create_engine
 from sqlalchemy.engine.base import Engine
@@ -139,9 +140,8 @@ class SqliteDatabase(BaseDatabase):
 
     def openlineage_dataset_namespace(self) -> str:
         """
-        Returns the open lineage dataset name as per
+        Returns the open lineage dataset namespace as per
         https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
-        Example: /tmp/local.db
+        Example: sqlite://127.0.0.1
         """
-        conn = self.hook.get_connection(self.conn_id)
-        return f"{self.sql_type}://{conn.host}"
+        return f"{self.sql_type}://{socket.gethostbyname(socket.gethostname())}"

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import socket
+
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from sqlalchemy import MetaData as SqlaMetaData, create_engine
 from sqlalchemy.engine.base import Engine

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -1,9 +1,9 @@
 import pickle
+import socket
 from datetime import datetime
 from unittest import mock
 
 import pytest
-import socket
 from airflow.models import DAG, Connection
 
 from astro.sql import get_value_list

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
+import socket
 from airflow.models import DAG, Connection
 
 from astro.sql import get_value_list
@@ -212,7 +213,7 @@ def test_if_table_object_can_be_pickled():
         (
             Connection(conn_id="test_conn", conn_type="sqlite", host="tmp/sqlite.db"),
             "tmp/sqlite.db.test_tb",
-            "sqlite://tmp/sqlite.db",
+            f"sqlite://{socket.gethostbyname(socket.gethostname())}",
         ),
     ],
 )


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Fix the comments made on https://github.com/astronomer/astro-sdk/pull/1142

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1179 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fix the namespace for sqlite  as per comment on #1142 

> Two comments here:
> 
> - The namespace should not repeat the dataset name ("tmp/sqlite.db.test_tb").
>- The tricky aspect of those local datasets that are private to the machine they are running on is we want the dataset ns+name to be unique. Otherwise if you run this on two different machines the lineage graph will assume that you are writing and reading the same dataset, which is not true. You need to make the namespace more unique by (for example) adding the machine name/IP in it.
- Fix the test for this


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
