### PR TITLE
Implement Google Drive file location

### DIFF
--- a/python-sdk/src/astro/constants.py
+++ b/python-sdk/src/astro/constants.py
@@ -20,6 +20,7 @@ class FileLocation(Enum):
     HTTP = "http"
     HTTPS = "https"
     GS = "gs"  # Google Cloud Storage
+    GOOGLE_DRIVE = "gdrive"
     S3 = "s3"  # Amazon S3
     # [END filelocation]
 

--- a/python-sdk/src/astro/files/locations/base.py
+++ b/python-sdk/src/astro/files/locations/base.py
@@ -14,6 +14,9 @@ from astro.constants import FileLocation
 class BaseFileLocation(ABC):
     """Base Location abstract class"""
 
+    location_type: FileLocation
+    """Property to identify location type"""
+
     template_fields = ("path", "conn_id")
 
     def __init__(self, path: str, conn_id: str | None = None):
@@ -28,12 +31,6 @@ class BaseFileLocation(ABC):
 
     @property
     def hook(self):
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def location_type(self):
-        """Property to identify location type"""
         raise NotImplementedError
 
     @property

--- a/python-sdk/src/astro/files/locations/google/gdrive.py
+++ b/python-sdk/src/astro/files/locations/google/gdrive.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import pathlib
+import urllib.parse
+from typing import Any, Iterator, Sequence
+
+from airflow.providers.google.suite.hooks.drive import GoogleDriveHook
+
+from astro.constants import FileLocation
+from astro.files.locations.base import BaseFileLocation
+
+
+def _quote(s: str) -> str:
+    s = s.replace("'", "\\'")  # Escape single quote characters.
+    return f"'{s}'"  # Quote.
+
+
+def _find_item_id(path_parts: Sequence[str], *, conn: Any) -> str:
+    """Drill down the directory hierarchy to find the ID of an item.
+
+    Google Drive does not have a very good random access API by path, so we
+    must look at each directory, level by level, to find the item we want.
+    """
+    folder_id = "root"
+    for part in path_parts:
+        command = conn.files().list(
+            q=f"parents in {_quote(folder_id)} and name = {_quote(part)}",
+            fields="id",
+            pageSize="1",
+        )
+        response = command.execute()
+        try:
+            found = response["files"][0]
+        except IndexError:
+            raise FileNotFoundError
+        folder_id = found["id"]
+    return folder_id
+
+
+def _find_contains(folder_id: str, pattern: str, *, conn: Any) -> Iterator[str]:
+    """Find files in a directory matching given pattern.
+
+    This uses *contains* to search. See Google Drive documentation to
+    understand the implications:
+    https://developers.google.com/drive/api/guides/ref-search-terms
+    """
+    page_token = None
+    while True:
+        command = conn.files().list(
+            q=f"parents in {_quote(folder_id)} and name contains {_quote(pattern)}",
+            fields="nextPageToken, files(name)",
+            pageToken=page_token,
+        )
+        response = command.execute()
+        yield from (f["name"] for f in response["files"])
+        page_token = response["nextPageToken"]
+        if page_token is None:
+            return
+
+
+class GdriveLocation(BaseFileLocation):
+    """Handler for Google Drive operators."""
+
+    location_type = FileLocation.GOOGLE_DRIVE
+
+    @property
+    def hook(self) -> GoogleDriveHook:
+        if self.conn_id:
+            return GoogleDriveHook(gcp_conn_id=self.conn_id)
+        return GoogleDriveHook()
+
+    @property
+    def transport_params(self) -> dict:
+        """Get Google Drive client."""
+        return {"client": self.hook.get_conn()}
+
+    @property
+    def openlineage_dataset_namespace(self) -> str:
+        """
+        Returns the open lineage dataset namespace as per
+        https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
+        """
+        return pathlib.PurePosixPath(urllib.parse.urlsplit(self.path).path).name
+
+    @property
+    def openlineage_dataset_name(self) -> str:
+        """
+        Returns the open lineage dataset name as per
+        https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
+        """
+        return urllib.parse.urlsplit(self.path).path
+
+    def _get_rel_path_parts(self) -> Sequence[str]:
+        p = urllib.parse.urlsplit(self.path).path.lstrip("/")
+        return pathlib.PurePosixPath(p).parts
+
+    def _get_conn(self) -> Any:
+        return self.hook.get_conn()
+
+    @property
+    def paths(self) -> list[str]:
+        path_parts = self._get_rel_path_parts()
+        if not path_parts:
+            return []
+
+        conn = self._get_conn()
+        url = urllib.parse.urlsplit(self.path)
+        parent_path = pathlib.PurePosixPath(*path_parts[:-1])
+        try:
+            folder_id = _find_item_id(path_parts[:-1], conn=conn)
+        except FileNotFoundError:
+            filename = urllib.parse.urlunsplit(url._replace(path=parent_path.as_posix()))
+            raise FileNotFoundError(filename) from None
+        return [
+            urllib.parse.urlunsplit(url._replace(path=parent_path.joinpath(name).as_posix()))
+            for name in _find_contains(folder_id, path_parts[-1], conn=conn)
+        ]
+
+    @property
+    def size(self) -> int:
+        conn = self._get_conn()
+        try:
+            file_id = _find_item_id(self._get_rel_path_parts(), conn=conn)
+        except FileNotFoundError:
+            raise FileNotFoundError(self.path) from None
+        response = conn.files().get(fileId=file_id, fields="size").execute()
+        try:
+            value = response["size"]
+        except KeyError:
+            raise IsADirectoryError(self.path) from None
+        return int(value)

--- a/python-sdk/tests/files/locations/test_google_drive.py
+++ b/python-sdk/tests/files/locations/test_google_drive.py
@@ -1,0 +1,87 @@
+from unittest import mock
+
+import pytest
+
+from astro.files.locations import create_file_location
+
+
+class MockCommand:
+    def __init__(self, result):
+        self.result = result
+
+    def execute(self):
+        return self.result
+
+
+class MockFiles:
+    def __init__(self, mock_get, mock_list):
+        self.mock_get = mock_get
+        self.mock_list = mock_list
+
+    def list(self, **kwargs):  # noqa: A003
+        return MockCommand(self.mock_list(**kwargs))
+
+    def get(self, **kwargs):
+        return MockCommand(self.mock_get(**kwargs))
+
+
+class MockConn:
+    def __init__(self, *, get, list):
+        self.mock_get = get
+        self.mock_list = list
+
+    def files(self):
+        return MockFiles(self.mock_get, self.mock_list)
+
+
+def test_size_not_found(monkeypatch):
+    location = create_file_location("gdrive:///does-not-exist")
+
+    mock_list = mock.MagicMock()
+    mock_get = mock.MagicMock()
+
+    monkeypatch.setattr(location, "_get_conn", lambda: MockConn(list=mock_list, get=mock_get))
+    mock_list.side_effect = [{"files": []}]
+
+    with pytest.raises(FileNotFoundError) as ctx:
+        location.size
+    assert str(ctx.value) == location.path
+    assert mock_list.mock_calls == [
+        mock.call(q="parents in 'root' and name = 'does-not-exist'", fields="id", pageSize="1"),
+    ]
+    assert mock_get.mock_calls == []
+
+
+def test_size_in_root(monkeypatch):
+    location = create_file_location("gdrive:///something-in-root")
+
+    mock_list = mock.MagicMock()
+    mock_get = mock.MagicMock()
+
+    monkeypatch.setattr(location, "_get_conn", lambda: MockConn(list=mock_list, get=mock_get))
+    mock_list.side_effect = [{"files": [{"id": "fake_id"}]}]
+    mock_get.side_effect = [{"size": "123"}]
+
+    assert location.size == 123
+    assert mock_list.mock_calls == [
+        mock.call(q="parents in 'root' and name = 'something-in-root'", fields="id", pageSize="1"),
+    ]
+    assert mock_get.mock_calls == [mock.call(fileId="fake_id", fields="size")]
+
+
+def test_size_in_subdir(monkeypatch):
+    location = create_file_location("gdrive:///folder/my-file")
+
+    mock_list = mock.MagicMock()
+    mock_get = mock.MagicMock()
+
+    monkeypatch.setattr(location, "_get_conn", lambda: MockConn(list=mock_list, get=mock_get))
+    mock_list.side_effect = [{"files": [{"id": "folder_id"}]}, {"files": [{"id": "file_id"}]}]
+    mock_get.side_effect = [{"size": "456"}]
+
+    assert location.size == 456
+    assert mock_list.mock_calls == [
+        mock.call(q="parents in 'root' and name = 'folder'", fields="id", pageSize="1"),
+        mock.call(q="parents in 'folder_id' and name = 'my-file'", fields="id", pageSize="1"),
+    ]
+    assert mock_get.mock_calls == [mock.call(fileId="file_id", fields="size")]


### PR DESCRIPTION
Close #1044 (eventually?)

This mostly just uses the Google API client. Direct documentation on the client is sparse, but you can find the general HTTP API documentation (which backs the Python API).

Two endpoints are used:

* [`files().list()`](https://developers.google.com/drive/api/v3/reference/files/list) to find files.
* [`files().get()`](https://developers.google.com/drive/api/v3/reference/files/get) to retrieve file metadata.

To use those file APIs you need to kind of visualise traversing the folders in a GUI. To get a file by path, you need to see what items are available in a folder, and select the one with the name you want. If the item is a folder, you need to run list against it again to see what items are in it. Not very efficient, but there are not many choices.

I added some simple tests for `size`.

## Does this introduce a breaking change?

No.


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
