### PR TITLE
Improve transform test case

### DIFF
--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -111,25 +111,20 @@ def test_raw_sql(database_table_fixture, sample_dag):
     def validate_raw_sql(cur: pd.DataFrame):
         from sqlalchemy.engine.row import LegacyRow
 
-        # Note: It's a broken feature on the main branch that this is return in a list of lists. Problem reported here:
-        # https://github.com/astronomer/astro-sdk/issues/1035
-        for c in cur[0]:
+        for c in cur:
             assert isinstance(c, LegacyRow)
-        print(cur)
 
     with sample_dag:
         homes_file = aql.load_file(
             input_file=File(path=str(cwd) + "/../../../data/homes.csv"),
             output_table=test_table,
         )
-        raw_sql_result = (
-            raw_sql_query(
+        raw_sql_result = raw_sql_query(
                 my_input_table=homes_file,
                 created_table=test_table,
                 num_rows=5,
                 handler=lambda cur: cur.fetchall(),
-            ),
-        )
+            )
         validate_raw_sql(raw_sql_result)
     test_utils.run_dag(sample_dag)
 

--- a/python-sdk/tests/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_transform.py
@@ -120,11 +120,11 @@ def test_raw_sql(database_table_fixture, sample_dag):
             output_table=test_table,
         )
         raw_sql_result = raw_sql_query(
-                my_input_table=homes_file,
-                created_table=test_table,
-                num_rows=5,
-                handler=lambda cur: cur.fetchall(),
-            )
+            my_input_table=homes_file,
+            created_table=test_table,
+            num_rows=5,
+            handler=lambda cur: cur.fetchall(),
+        )
         validate_raw_sql(raw_sql_result)
     test_utils.run_dag(sample_dag)
 


### PR DESCRIPTION
# Description
## What is the current behavior?
There is an unnecessary `()` wrapping over response of `run_raw_sql` which is converting response into tuple of list

closes: https://github.com/astronomer/astro-sdk/issues/1035


## What is the new behavior?
Removed the wrapping

## Does this introduce a breaking change?
No (Test Fix only)

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
