### PR TITLE
Update the test queries

### DIFF
--- a/python-sdk/tests/sql/operators/transform/test_postgres_transform.py
+++ b/python-sdk/tests/sql/operators/transform/test_postgres_transform.py
@@ -86,11 +86,11 @@ def pg_query_result(request):
         return "SELECT * FROM {{input_table}} WHERE last_name LIKE {{last_name}}", {"last_name": "G%%"}
     if query_name == "with_jinja":
         return (
-            "SELECT * FROM {{input_table}} WHERE last_update > '{{execution_date}}' AND last_name LIKE 'G%%'"
+            "SELECT * FROM {{input_table}} WHERE last_update < '{{execution_date}}' AND last_name LIKE 'G%%'"
         )
     if query_name == "with_jinja_template_params":
         return (
-            "SELECT * FROM {{input_table}} WHERE last_update > {{r_date}} AND last_name LIKE 'G%%'",
+            "SELECT * FROM {{input_table}} WHERE last_update < {{r_date}} AND last_name LIKE 'G%%'",
             {"r_date": "{{ execution_date }}"},
         )
 


### PR DESCRIPTION
# Description
Fix Group 12 CI test cases.

Updated the test queries, since the data in the table `actor` is from the year 2016 and the query we were running passes the `execution_date` of dag

SELECT * FROM {{input_table}} WHERE last_update < '{{execution_date}}' AND last_name LIKE 'G%%'

Earlier this was fixed to 1/1/2016. Which was changed to the current date in PR - https://github.com/astronomer/astro-sdk/pull/1174/files#diff-8bf1e910bdc4eb59ed152b04aae0bfb8636309dc0bb5fbd6897c4d6b4c2ecb58

Now we are running the below query, which naturally doesn't result in any data being returned.
"SELECT * FROM public.actor WHERE last_update < '2022-11-02T11:35:55.448319+00:00' AND last_name LIKE 'G%%'"

Actor Table in Postgres DB:
<img width="1728" alt="Screenshot 2022-11-02 at 5 04 27 PM" src="https://user-images.githubusercontent.com/13021213/199481852-5c7d70ee-b2ee-4b07-b94b-fbe76d5aaeae.png">
