### PR TITLE
Upgrade snowflake-sqlalchemy package

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -59,7 +59,7 @@ google = [
 ]
 snowflake = [
     "apache-airflow-providers-snowflake",
-    "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
+    "snowflake-sqlalchemy>=1.4.3,<1.5.0",
     "snowflake-connector-python[pandas]",
 ]
 postgres = [

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -79,7 +79,7 @@ all = [
     "apache-airflow-providers-snowflake",
     "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]",
-    "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
+    "snowflake-sqlalchemy>=1.4.3,<1.5.0",
     "sqlalchemy-bigquery>=1.3.0",
     "s3fs",
     "protobuf<=3.20", # Google bigquery client require protobuf <= 3.20.0. We can remove the limitation when this limitation is removed

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     "smart-open",
     "SQLAlchemy>=1.3.18,<1.4.42" # Pinning it to <1.4.42 because sqlalchemy 1.4.42
     # has renamed all of the rfc 1738 stuff so imports like `from sqlalchemy.engine.url import _rfc_1738_quote` fails.
-    # which is breaking in snowflake-sqlalchemy.
+    # which is breaking in snowflake-sqlalchemy and we cannot change the version of snowflake-sqlalchemy to anything
+    # other than 1.2.4 because airflow 2.2.5 has a constraint.
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow", "elt", "etl", "dag"]

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
     "pyarrow",
     "python-frontmatter",
     "smart-open",
-    "SQLAlchemy>=1.3.18,<1.4.42"
+    "SQLAlchemy>=1.3.18,<1.4.42" # Pinning it to <1.4.42 because sqlalchemy 1.4.42
+    # has renamed all of the rfc 1738 stuff so imports like `from sqlalchemy.engine.url import _rfc_1738_quote` fails.
+    # which is breaking in snowflake-sqlalchemy.
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow", "elt", "etl", "dag"]

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -79,7 +79,7 @@ all = [
     "apache-airflow-providers-snowflake",
     "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]",
-    "snowflake-sqlalchemy>=1.4.3,<1.5.0",
+    "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
     "sqlalchemy-bigquery>=1.3.0",
     "s3fs",
     "protobuf<=3.20", # Google bigquery client require protobuf <= 3.20.0. We can remove the limitation when this limitation is removed

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyarrow",
     "python-frontmatter",
     "smart-open",
-    "SQLAlchemy>=1.3.18"
+    "SQLAlchemy>=1.3.18,<1.4.42"
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow", "elt", "etl", "dag"]
@@ -59,7 +59,7 @@ google = [
 ]
 snowflake = [
     "apache-airflow-providers-snowflake",
-    "snowflake-sqlalchemy>=1.4.3,<1.5.0",
+    "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
     "snowflake-connector-python[pandas]",
 ]
 postgres = [


### PR DESCRIPTION
# Description
## What is the current behavior?
Due to [changes](https://github.com/snowflakedb/snowflake-sqlalchemy/issues/350) in `sqlalchemy==1.4.42` our CI is failing, since snowflake-sqlalchemy's rfc imports are failing and we cannot change the version of snowflake-sqlalchemy to anything other than 1.2.4 because airflow 2.2.5 has a constraint.
## What is the new behavior?
Upgraded the package to 1.4.3 where the fix is added.

## Does this introduce a breaking change?
Nope
