### PR TITLE
Use correct path in example LoadFile 

### DIFF
--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -166,7 +166,7 @@ with dag:
     # [START load_file_example_14]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern*",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -142,7 +142,7 @@ with dag:
     # [START load_file_example_12]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern*",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -142,7 +142,7 @@ with dag:
     # [START load_file_example_12]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern*",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -166,7 +166,7 @@ with dag:
     # [START load_file_example_14]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern*",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -200,7 +200,7 @@ with dag:
     # [START load_file_example_17]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern*",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -142,7 +142,7 @@ with dag:
     # [START load_file_example_12]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),
@@ -166,7 +166,7 @@ with dag:
     # [START load_file_example_14]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),
@@ -200,7 +200,7 @@ with dag:
     # [START load_file_example_17]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -200,7 +200,7 @@ with dag:
     # [START load_file_example_17]
     aql.load_file(
         input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern*",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),


### PR DESCRIPTION
# Description
closes #1163 
## What is the current behavior?
Example Loadfile uses a resource which does not exist.

Since the file does not exist load_file_to_table_natively is failing and it falls for the pandas path. In the pandas path the resolve_file_path_pattern converting path pattern to gs://astro-sdk/workspace/sample_pattern.csv and luckily we do have this file in GCS.


## What is the new behavior?
changes the resource path

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
