### PR TITLE
Make flow usage environment aware

### DIFF
--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -94,6 +94,7 @@ jobs:
     env:
       AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
       AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
+      _TYPER_FORCE_DISABLE_TERMINAL: 1
 
 
   Code-Coverage:

--- a/sql-cli/Makefile
+++ b/sql-cli/Makefile
@@ -31,7 +31,7 @@ pre-commit:  # Run pre-commit
 flow:  # Build and run the latest version of flow
 
 test:  # Run tests
-	@PYTHONWARNINGS="ignore" poetry run pytest -s --cov --cov-branch --cov-report=term-missing tests
+	@_TYPER_FORCE_DISABLE_TERMINAL=1 PYTHONWARNINGS="ignore" poetry run pytest -s --cov --cov-branch --cov-report=term-missing tests
 
 release:  # Build a package
 	@echo -e "If this is your first time, please, manually follow these two steps: \n" \

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -16,6 +16,7 @@ app = typer.Typer(
     cls=AstroGroup,
     add_completion=False,
     context_settings={"help_option_names": ["-h", "--help"]},
+    rich_markup_mode="rich",
 )
 
 
@@ -157,30 +158,18 @@ def run(
     help="""
     Initialise a project structure to write workflows using SQL files.
 
-    \b\n
     Examples of usage:
-    \b\n
     $ flow init
-    \b\n
     $ flow init .
-    \b\n
     $ flow init project_name
 
-
-    \b\n
     By default, the project structure includes:
-
     ├── config: withholds configuration, e.g. database connections, within each environment directory
-    \b\n
     ├── data: directory which contains datasets, including SQLite databases used by the examples
-    \b\n
     └── workflows: directory where SQL workflows are declared, by default has two examples of workflow
 
-    \b\n
     Next steps:
-    \b\n
     * Update the file `config/default/configuration.yaml` to declare database connections.
-    \b\n
     * Create SQL workflows within the `workflows` folder.
     """,
 )

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -6,10 +6,17 @@ from dotenv import load_dotenv
 from rich import print as rprint
 
 import sql_cli
+from sql_cli.astro.command import AstroCommand
+from sql_cli.astro.group import AstroGroup
 from sql_cli.constants import DEFAULT_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER
 
 load_dotenv()
-app = typer.Typer(add_completion=False, context_settings={"help_option_names": ["-h", "--help"]})
+app = typer.Typer(
+    name="flow",
+    cls=AstroGroup,
+    add_completion=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 
 
 airflow_logger = logging.getLogger("airflow")
@@ -17,17 +24,26 @@ airflow_logger.setLevel(logging.CRITICAL)
 airflow_logger.propagate = False
 
 
-@app.command(help="Print the SQL CLI version.")
+@app.command(
+    cls=AstroCommand,
+    help="Print the SQL CLI version.",
+)
 def version() -> None:
     rprint("Astro SQL CLI", sql_cli.__version__)
 
 
-@app.command(help="Print additional information about the project.")
+@app.command(
+    cls=AstroCommand,
+    help="Print additional information about the project.",
+)
 def about() -> None:
     rprint("Find out more: https://github.com/astronomer/astro-sdk/sql-cli")
 
 
-@app.command(help="Generate the Airflow DAG from a directory of SQL files.")
+@app.command(
+    cls=AstroCommand,
+    help="Generate the Airflow DAG from a directory of SQL files.",
+)
 def generate(
     workflow_name: str = typer.Argument(
         default=...,
@@ -53,9 +69,10 @@ def generate(
 
 
 @app.command(
+    cls=AstroCommand,
     help="""
     Validate Airflow connection(s) provided in the configuration file for the given environment.
-    """
+    """,
 )
 def validate(
     project_dir: Path = typer.Argument(
@@ -89,10 +106,11 @@ def validate(
 
 
 @app.command(
+    cls=AstroCommand,
     help="""
     Run a workflow locally. This task assumes that there is a local airflow DB (can be a SQLite file), that has been
     initialized with Airflow tables.
-    """
+    """,
 )
 def run(
     workflow_name: str = typer.Argument(
@@ -135,6 +153,7 @@ def run(
 
 
 @app.command(
+    cls=AstroCommand,
     help="""
     Initialise a project structure to write workflows using SQL files.
 
@@ -163,7 +182,7 @@ def run(
     * Update the file `config/default/configuration.yaml` to declare database connections.
     \b\n
     * Create SQL workflows within the `workflows` folder.
-    """
+    """,
 )
 def init(
     project_dir: Path = typer.Argument(

--- a/sql-cli/sql_cli/astro/command.py
+++ b/sql-cli/sql_cli/astro/command.py
@@ -1,8 +1,8 @@
-import os
-
 import click
 import typer
 from typer.core import TyperCommand
+
+from sql_cli.astro.utils import resolve_command_path
 
 
 class AstroCommand(TyperCommand):
@@ -12,7 +12,4 @@ class AstroCommand(TyperCommand):
         This is a low-level method called by :meth:`get_usage`.
         """
         pieces = self.collect_usage_pieces(ctx)
-        command_path = ctx.command_path
-        if os.getenv("ASTRO_CLI"):
-            command_path = " ".join(["astro", ctx.command_path])
-        formatter.write_usage(command_path, " ".join(pieces))
+        formatter.write_usage(resolve_command_path(ctx.command_path), " ".join(pieces))

--- a/sql-cli/sql_cli/astro/command.py
+++ b/sql-cli/sql_cli/astro/command.py
@@ -1,0 +1,18 @@
+import os
+
+import click
+import typer
+from typer.core import TyperCommand
+
+
+class AstroCommand(TyperCommand):
+    def format_usage(self, ctx: typer.Context, formatter: click.HelpFormatter) -> None:
+        """Writes the usage line into the formatter.
+
+        This is a low-level method called by :meth:`get_usage`.
+        """
+        pieces = self.collect_usage_pieces(ctx)
+        command_path = ctx.command_path
+        if os.getenv("ASTRO_CLI"):
+            command_path = " ".join(["astro", ctx.command_path])
+        formatter.write_usage(command_path, " ".join(pieces))

--- a/sql-cli/sql_cli/astro/group.py
+++ b/sql-cli/sql_cli/astro/group.py
@@ -1,0 +1,18 @@
+import os
+
+import click
+import typer
+from typer.core import TyperGroup
+
+
+class AstroGroup(TyperGroup):
+    def format_usage(self, ctx: typer.Context, formatter: click.HelpFormatter) -> None:
+        """Writes the usage line into the formatter.
+
+        This is a low-level method called by :meth:`get_usage`.
+        """
+        pieces = self.collect_usage_pieces(ctx)
+        command_path = ctx.command_path
+        if os.getenv("ASTRO_CLI"):
+            command_path = " ".join(["astro", ctx.command_path])
+        formatter.write_usage(command_path, " ".join(pieces))

--- a/sql-cli/sql_cli/astro/group.py
+++ b/sql-cli/sql_cli/astro/group.py
@@ -1,8 +1,8 @@
-import os
-
 import click
 import typer
 from typer.core import TyperGroup
+
+from sql_cli.astro.utils import resolve_command_path
 
 
 class AstroGroup(TyperGroup):
@@ -12,7 +12,4 @@ class AstroGroup(TyperGroup):
         This is a low-level method called by :meth:`get_usage`.
         """
         pieces = self.collect_usage_pieces(ctx)
-        command_path = ctx.command_path
-        if os.getenv("ASTRO_CLI"):
-            command_path = " ".join(["astro", ctx.command_path])
-        formatter.write_usage(command_path, " ".join(pieces))
+        formatter.write_usage(resolve_command_path(ctx.command_path), " ".join(pieces))

--- a/sql-cli/sql_cli/astro/utils.py
+++ b/sql-cli/sql_cli/astro/utils.py
@@ -1,0 +1,14 @@
+import os
+
+
+def resolve_command_path(command_path: str) -> str:
+    """
+    Resolve the command path using the current environment.
+
+    :param command_path: The command path to resolve.
+
+    :returns: the resolved command path.
+    """
+    if os.getenv("ASTRO_CLI"):  # being set in astro-cli dockerfile for sql-cli
+        return " ".join(["astro", command_path])
+    return command_path

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -25,6 +25,34 @@ def get_stdout(result) -> str:
     return result.stdout.replace("\n", "")
 
 
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--help"],
+        ["version", "--help"],
+    ],
+    ids=[
+        "group",
+        "command",
+    ],
+)
+@pytest.mark.parametrize(
+    "env,usage",
+    [
+        ({}, "Usage: flow"),
+        ({"ASTRO_CLI": "Yes"}, "Usage: astro flow"),
+    ],
+    ids=[
+        "sql-cli",
+        "astro-cli",
+    ],
+)
+def test_usage(env, usage, args):
+    result = runner.invoke(app, args, env=env)
+    assert result.exit_code == 0
+    assert usage in get_stdout(result)
+
+
 def test_about():
     result = runner.invoke(app, ["about"])
     assert result.exit_code == 0


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, when running flow's `--help` commands they always show the following usage:
```
 Usage: flow [OPTIONS] COMMAND [ARGS]...
```

This is incorrect in case the command is called via astro CLI.

closes: #1190 

## What is the new behavior?

We check for the environment the command is running in and based on that format the usage output. The default will still be showing `flow` whereas when it is running in the astro cli it will show `astro flow`.

E.g.
```
Usage: astro flow [OPTIONS] COMMAND [ARGS]...
```

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
