### PR TITLE
Added missing doc for GCS to Bigquery path

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -116,7 +116,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+https://www.contributor-covenant.org/version/2/0/code_of_conduct/.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).

--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -140,7 +140,7 @@ For a full list of available operators, see the [SDK reference documentation](ht
 
 The documentation is a work in progress--we aim to follow the [Diátaxis](https://diataxis.fr/) system:
 
-- **[Getting Started Tutorial](https://docs.astronomer.io/tutorials/astro-python-sdk)**: A hands-on introduction to the Astro Python SDK
+- **[Getting Started Tutorial](https://docs.astronomer.io/learn/astro-python-sdk)**: A hands-on introduction to the Astro Python SDK
 - **How-to guides**: Simple step-by-step user guides to accomplish specific tasks
 - **[Reference guide](https://astro-sdk-python.readthedocs.io/)**: Commands, modules, classes and methods
 - **Explanation**: Clarification and discussion of key decisions when designing the project

--- a/python-sdk/docs/CHANGELOG.md
+++ b/python-sdk/docs/CHANGELOG.md
@@ -186,7 +186,7 @@
   pre-requirements to work. To disable this mode, use the argument `use_native_support=False` in `aql.load_file`.
   [#557](https://github.com/astronomer/astro-sdk/issues/557), [#481](https://github.com/astronomer/astro-sdk/issues/481)
 * `aql.dataframe` will raise an exception if the default Airflow XCom backend is being used.
-  To solve this, either use an [external XCom backend, such as S3 or GCS](https://www.astronomer.io/guides/custom-xcom-backends)
+  To solve this, either use an [external XCom backend, such as S3 or GCS](https://docs.astronomer.io/learn/custom-xcom-backends)
   or set the configuration `AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE=True`. [#444](https://github.com/astronomer/astro-sdk/issues/444)
 * Change the declaration for the default Astro SDK temporary schema from using `AIRFLOW__ASTRO__SQL_SCHEMA`
   to `AIRFLOW__ASTRO_SDK__SQL_SCHEMA` [#503](https://github.com/astronomer/astro-sdk/issues/503)

--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -228,6 +228,10 @@ Patterns in file path
        :start-after: [START load_file_example_12]
        :end-before: [END load_file_example_12]
 
+#. **GCS to Bigquery** - only applicable when using native support by passing ``use_native_support=True``
+
+    When loading data from ``GCS`` to ``Bigquery``, we by default use the native path, which is faster since the schema detection and pattern are processed directly by ``Bigquery``. We can also process multiple files by passing a pattern; for a valid pattern, check `Bigquery doc <https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload>`_ and look for the sourceUris filed.
+
 
 Inferring file type
 ~~~~~~~~~~~~~~~~~~~

--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -230,7 +230,7 @@ Patterns in file path
 
 #. **GCS to Bigquery** - only applicable when using native path(for details check -:ref:`load_file_working`)
 
-    When loading data from ``GCS`` to ``Bigquery``, we by default use the native path, which is faster since the schema detection and pattern are processed directly by ``Bigquery``. We can also process multiple files by passing a pattern; for a valid pattern, check `Bigquery doc <https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload>`_ and look for the sourceUris filed.
+    When loading data from ``GCS`` to ``Bigquery``, we by default use the native path, which is faster since the schema detection and pattern are processed directly by ``Bigquery``. We can also process multiple files by passing a pattern; for a valid pattern, check `Bigquery doc <https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload>`_ and look for the ``sourceUris`` field.
 
 
 Inferring file type

--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -228,7 +228,7 @@ Patterns in file path
        :start-after: [START load_file_example_12]
        :end-before: [END load_file_example_12]
 
-#. **GCS to Bigquery** - only applicable when using native support by passing ``use_native_support=True``
+#. **GCS to Bigquery** - only applicable when using native path(for details check -:ref:`load_file_working`)
 
     When loading data from ``GCS`` to ``Bigquery``, we by default use the native path, which is faster since the schema detection and pattern are processed directly by ``Bigquery``. We can also process multiple files by passing a pattern; for a valid pattern, check `Bigquery doc <https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload>`_ and look for the sourceUris filed.
 

--- a/python-sdk/docs/getting-started/GETTING_STARTED.md
+++ b/python-sdk/docs/getting-started/GETTING_STARTED.md
@@ -1,3 +1,3 @@
 # Getting Started
 
-See the [tutorial](https://docs.astronomer.io/tutorials/astro-python-sdk) on the Astronomer documentation site to get started with the Astro Python SDK.
+See the [tutorial](https://docs.astronomer.io/learn/astro-python-sdk) on the Astronomer documentation site to get started with the Astro Python SDK.

--- a/python-sdk/src/astro/exceptions.py
+++ b/python-sdk/src/astro/exceptions.py
@@ -8,7 +8,7 @@ class IllegalLoadToDatabaseException(Exception):
             "Failing this task because you do not have a custom xcom backend set up. If you use "
             "the default XCOM backend to store large dataframes, this can significantly degrade "
             "Airflow DB performance. Please set up a custom XCOM backend (info here "
-            "https://www.astronomer.io/guides/custom-xcom-backends) or set the environment "
+            "https://docs.astronomer.io/learn/custom-xcom-backends) or set the environment "
             "variable AIRFLOW__ASTRO_SDK__DATAFRAME_ALLOW_UNSAFE_STORAGE to true if you wish to proceed while "
             "knowing the risks. "
         )


### PR DESCRIPTION
# Description
## What is the current behavior?
We already have a section for pattern resolution - https://astro-sdk-python.readthedocs.io/en/stable/astro/sql/operators/load_file.html#patterns-in-file-path
But we have not covered the scenario when GCS to Bigquery native path is used and the pattern is processed by bigquery and not SDK.

closes: #800


## What is the new behavior?
Added missing GCS to Bigquery when using the native path.

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
