### PR TITLE
Make non-Temp tables unique across test runs

### DIFF
--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -133,7 +133,7 @@ def database_table_fixture(request):
     database = create_database(conn_id)
     table = params.get("table", Table(conn_id=database.conn_id, metadata=database.default_metadata))
     if not isinstance(table, TempTable):
-        # We add a unique suffix to the table name to make the name unique across runs
+        # We create a unique table name to make the name unique across runs
         table.name = create_unique_table_name(UNIQUE_HASH_SIZE)
     file = params.get("file")
 
@@ -196,7 +196,7 @@ def multiple_tables_fixture(request, database_table_fixture):
     for item in items:
         table = item.get("table", Table(conn_id=database.conn_id))
         if not isinstance(table, TempTable):
-            # We add a unique suffix to the table name to make the name unique across runs
+            # We create a unique table name to make the name unique across runs
             table.name = create_unique_table_name(UNIQUE_HASH_SIZE)
         file = item.get("file")
 

--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -132,6 +132,9 @@ def database_table_fixture(request):
     conn_id = DATABASE_NAME_TO_CONN_ID[database_name]
     database = create_database(conn_id)
     table = params.get("table", Table(conn_id=database.conn_id, metadata=database.default_metadata))
+    if not isinstance(table, TempTable):
+        # We add a unique suffix to the table name to make the name unique across runs
+        table.name += create_unique_table_name(UNIQUE_HASH_SIZE)
     file = params.get("file")
 
     database.populate_table_metadata(table)
@@ -192,6 +195,9 @@ def multiple_tables_fixture(request, database_table_fixture):
 
     for item in items:
         table = item.get("table", Table(conn_id=database.conn_id))
+        if not isinstance(table, TempTable):
+            # We add a unique suffix to the table name to make the name unique across runs
+            table.name += create_unique_table_name(UNIQUE_HASH_SIZE)
         file = item.get("file")
 
         database.populate_table_metadata(table)

--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -134,7 +134,7 @@ def database_table_fixture(request):
     table = params.get("table", Table(conn_id=database.conn_id, metadata=database.default_metadata))
     if not isinstance(table, TempTable):
         # We add a unique suffix to the table name to make the name unique across runs
-        table.name += create_unique_table_name(UNIQUE_HASH_SIZE)
+        table.name = create_unique_table_name(UNIQUE_HASH_SIZE)
     file = params.get("file")
 
     database.populate_table_metadata(table)
@@ -197,7 +197,7 @@ def multiple_tables_fixture(request, database_table_fixture):
         table = item.get("table", Table(conn_id=database.conn_id))
         if not isinstance(table, TempTable):
             # We add a unique suffix to the table name to make the name unique across runs
-            table.name += create_unique_table_name(UNIQUE_HASH_SIZE)
+            table.name = create_unique_table_name(UNIQUE_HASH_SIZE)
         file = item.get("file")
 
         database.populate_table_metadata(table)


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, the `multiple_tables_fixture` and `database_table_fixture` are not working across runs as they are using the table names as passed by the user.

closes: https://github.com/astronomer/astro-sdk/issues/1204

## What is the new behavior?

With the proposed change, we always add a unique suffix to non-Temp tables.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
