### PR TITLE
Fix or Skip `Deepsource` warning

### DIFF
--- a/python-sdk/dev/scripts/pre_commit_context_typing_compat.py
+++ b/python-sdk/dev/scripts/pre_commit_context_typing_compat.py
@@ -27,14 +27,16 @@ class ImportCrawler(NodeVisitor):
             return
 
         for alias in node.names:
-            if f"{node.module}.{alias.name}" == "airflow.utils.context.Context":
-                if not self.has_incompatible_context_imports:
-                    self.has_incompatible_context_imports = True
+            if (
+                f"{node.module}.{alias.name}" == "airflow.utils.context.Context"
+                and not self.has_incompatible_context_imports
+            ):
+                self.has_incompatible_context_imports = True
 
 
 def get_all_provider_files() -> list[Path]:
     """Retrieve all eligible provider module files."""
-    provider_files = []
+    _provider_files = []
     for (root, _, file_names) in os.walk(ASTRO_ROOT):
         for file_name in file_names:
             file_path = Path(root, file_name)
@@ -43,9 +45,9 @@ def get_all_provider_files() -> list[Path]:
                 and file_path.name.endswith(".py")
                 and TYPING_COMPAT_PATH not in str(file_path)
             ):
-                provider_files.append(file_path)
+                _provider_files.append(file_path)
 
-    return provider_files
+    return _provider_files
 
 
 def find_incompatible_context_imports(file_paths: list[Path]) -> list[str]:

--- a/python-sdk/docs/conf.py
+++ b/python-sdk/docs/conf.py
@@ -88,6 +88,7 @@ source_suffix = {
 }
 
 
+# TODO: We should consider removing param start _
 def skip_util_classes(_app, _what, _name, obj, skip, _options):
     """This allows us skipping certain objects (including functions & methods) from docs"""
     if ":sphinx-autoapi-skip:" in obj.docstring:

--- a/python-sdk/docs/conf.py
+++ b/python-sdk/docs/conf.py
@@ -88,7 +88,7 @@ source_suffix = {
 }
 
 
-def skip_util_classes(app, what, name, obj, skip, options):
+def skip_util_classes(_app, _what, _name, obj, skip, _options):
     """This allows us skipping certain objects (including functions & methods) from docs"""
     if ":sphinx-autoapi-skip:" in obj.docstring:
         skip = True

--- a/python-sdk/src/astro/custom_backend/serializer.py
+++ b/python-sdk/src/astro/custom_backend/serializer.py
@@ -47,19 +47,16 @@ def serialize(obj: Table | File | Any) -> dict | Any:  # noqa
     elif isinstance(obj, np.ndarray):
         return obj.tolist()
     elif isinstance(obj, SQLAlcRow):
-        keymap = obj._keymap  # skipcq PYL-W021
-        key_style = obj._key_style  # skipcq PYL-W021
+        serialized_obj = {
+            "class": "SQLAlcRow",
+            "key_map": obj._keymap,  # skipcq PYL-W021
+            "key_style": obj._key_style,  # skipcq PYL-W021
+        }
         if airflow.__version__ >= "2.3":
-            return {
-                "class": "SQLAlcRow",
-                "key_map": keymap,
-                "data": obj._data,  # skipcq PYL-W021
-                "key_style": key_style,
-            }
-        else:
-            return {"class": "SQLAlcRow", "key_map": keymap, "key_style": key_style}
+            serialized_obj["data"] = obj._data  # skipcq PYL-W021
+        return serialized_obj
 
-    elif isinstance(obj, str):  # pragma: no cover
+    elif isinstance(obj, str):
         return {"class": "string", "value": obj}
     else:
         return _attempt_to_serialize_unknown_object(obj)

--- a/python-sdk/src/astro/custom_backend/serializer.py
+++ b/python-sdk/src/astro/custom_backend/serializer.py
@@ -47,15 +47,17 @@ def serialize(obj: Table | File | Any) -> dict | Any:  # noqa
     elif isinstance(obj, np.ndarray):
         return obj.tolist()
     elif isinstance(obj, SQLAlcRow):
+        keymap = obj._keymap  # skipcq PYL-W021
+        key_style = obj._key_style  # skipcq PYL-W021
         if airflow.__version__ >= "2.3":
             return {
                 "class": "SQLAlcRow",
-                "key_map": obj._keymap,
-                "data": obj._data,
-                "key_style": obj._key_style,
+                "key_map": keymap,
+                "data": obj._data,  # skipcq PYL-W021
+                "key_style": key_style,
             }
         else:
-            return {"class": "SQLAlcRow", "key_map": obj._keymap, "key_style": obj._key_style}
+            return {"class": "SQLAlcRow", "key_map": keymap, "key_style": key_style}
 
     elif isinstance(obj, str):
         return {"class": "string", "value": obj}

--- a/python-sdk/src/astro/custom_backend/serializer.py
+++ b/python-sdk/src/astro/custom_backend/serializer.py
@@ -59,7 +59,7 @@ def serialize(obj: Table | File | Any) -> dict | Any:  # noqa
         else:
             return {"class": "SQLAlcRow", "key_map": keymap, "key_style": key_style}
 
-    elif isinstance(obj, str):
+    elif isinstance(obj, str):  # pragma: no cover
         return {"class": "string", "value": obj}
     else:
         return _attempt_to_serialize_unknown_object(obj)

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -136,9 +136,6 @@ class RedshiftDatabase(BaseDatabase):
 
         :param table: The table we want to retrieve the qualified name for.
         """
-        # Initially this method belonged to the Table class.
-        # However, in order to have an agnostic table class implementation,
-        # we are keeping all methods which vary depending on the database within the Database class.
         if table.metadata and table.metadata.schema:
             qualified_name = f'"{table.metadata.schema}"."{table.name}"'
         else:

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -251,16 +251,14 @@ class RedshiftDatabase(BaseDatabase):
 
         source_to_target_map_source_columns = list(source_to_target_columns_map.keys())
         source_to_target_map_target_columns = list(source_to_target_columns_map.values())
-        source_table_all_columns = self.hook.run(
-            "select col_name from pg_get_cols('%s') "
-            "cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
-            parameters=(source_table_name,),
+        source_table_all_columns = self.hook.run(  # skipcq BAN-B608
+            f"select col_name from pg_get_cols('{source_table_name}') "
+            f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
             handler=lambda x: [y[0] for y in x.fetchall()],
         )
-        target_table_all_columns = self.hook.run(
-            "select col_name from pg_get_cols('%s') "
-            "cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
-            parameters=(source_table_name,),
+        target_table_all_columns = self.hook.run(  # skipcq BAN-B608
+            f"select col_name from pg_get_cols('{source_table_name}') "
+            f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
             handler=lambda x: [y[0] for y in x.fetchall()],
         )
         target_table_all_columns_string = ",".join(map(str, source_to_target_map_target_columns))

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -238,6 +238,8 @@ class RedshiftDatabase(BaseDatabase):
 
         source_to_target_map_source_columns = list(source_to_target_columns_map.keys())
         source_to_target_map_target_columns = list(source_to_target_columns_map.values())
+        # Need skipcq because string concatenation in query,
+        # We should consider using parameterized if possible
         source_table_all_columns = self.hook.run(  # skipcq BAN-B608
             f"select col_name from pg_get_cols('{source_table_name}') "
             f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -140,9 +140,9 @@ class RedshiftDatabase(BaseDatabase):
         # However, in order to have an agnostic table class implementation,
         # we are keeping all methods which vary depending on the database within the Database class.
         if table.metadata and table.metadata.schema:
-            qualified_name = f"\"{table.metadata.schema}\".\"{table.name}\""
+            qualified_name = f'"{table.metadata.schema}"."{table.name}"'
         else:
-            qualified_name = f"\"{table.name}\""
+            qualified_name = f'"{table.name}"'
         return qualified_name
 
     def load_pandas_dataframe_to_table(

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -140,9 +140,9 @@ class RedshiftDatabase(BaseDatabase):
         # However, in order to have an agnostic table class implementation,
         # we are keeping all methods which vary depending on the database within the Database class.
         if table.metadata and table.metadata.schema:
-            qualified_name = f"'{table.metadata.schema}'.'{table.name}'"
+            qualified_name = f"\"{table.metadata.schema}\".\"{table.name}\""
         else:
-            qualified_name = f"'{table.name}'"
+            qualified_name = f"\"{table.name}\""
         return qualified_name
 
     def load_pandas_dataframe_to_table(

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -246,7 +246,7 @@ class RedshiftDatabase(BaseDatabase):
             handler=lambda x: [y[0] for y in x.fetchall()],
         )
         target_table_all_columns = self.hook.run(  # skipcq BAN-B608
-            f"select col_name from pg_get_cols('{source_table_name}') "
+            f"select col_name from pg_get_cols('{target_table_name}') "
             f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
             handler=lambda x: [y[0] for y in x.fetchall()],
         )

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -238,12 +238,12 @@ class RedshiftDatabase(BaseDatabase):
 
         source_to_target_map_source_columns = list(source_to_target_columns_map.keys())
         source_to_target_map_target_columns = list(source_to_target_columns_map.values())
-        source_table_all_columns = self.hook.run(
+        source_table_all_columns = self.hook.run(  # skipcq BAN-B608
             f"select col_name from pg_get_cols('{source_table_name}') "
             f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
             handler=lambda x: [y[0] for y in x.fetchall()],
         )
-        target_table_all_columns = self.hook.run(
+        target_table_all_columns = self.hook.run(  # skipcq BAN-B608
             f"select col_name from pg_get_cols('{target_table_name}') "
             f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
             handler=lambda x: [y[0] for y in x.fetchall()],
@@ -272,7 +272,7 @@ class RedshiftDatabase(BaseDatabase):
             target_conflict_columns,
         )
         truncate_target_table = f"TRUNCATE {target_table_name}"
-        insert_into_target_table = f"INSERT INTO {target_table_name} SELECT * FROM {stage_table_name}"
+        insert_into_target_table = f"INSERT INTO '{target_table_name}' SELECT * FROM '{stage_table_name}'"
         drop_stage_table = f"DROP TABLE {stage_table_name}"
         end_transaction = "END TRANSACTION"
 
@@ -292,7 +292,9 @@ class RedshiftDatabase(BaseDatabase):
             for statement in statements:
                 cursor.execute(statement)
 
-    def is_native_load_file_available(self, source_file: File, target_table: BaseTable) -> bool:
+    def is_native_load_file_available(
+        self, source_file: File, target_table: BaseTable  # skipcq PYL-W0613
+    ) -> bool:
         """
         Check if there is an optimised path for source to destination.
 
@@ -387,7 +389,7 @@ class RedshiftDatabase(BaseDatabase):
             raise DatabaseCustomError from exe
 
     @staticmethod
-    def get_merge_initialization_query(parameters: tuple) -> str:
+    def get_merge_initialization_query(parameters: tuple) -> str:  # skipcq PYL-W0613
         """
         Handles database-specific logic to handle constraints
         for Redshift.

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -129,19 +129,6 @@ class RedshiftDatabase(BaseDatabase):
         inspector = sqlalchemy.inspect(self.sqlalchemy_engine)
         return bool(inspector.dialect.has_table(self.connection, table.name, schema=table.metadata.schema))
 
-    @staticmethod
-    def get_table_qualified_name(table: BaseTable) -> str:  # skipcq: PYL-R0201
-        """
-        Return table qualified name for redshift.
-
-        :param table: The table we want to retrieve the qualified name for.
-        """
-        if table.metadata and table.metadata.schema:
-            qualified_name = f'"{table.metadata.schema}"."{table.name}"'
-        else:
-            qualified_name = f'"{table.name}"'
-        return qualified_name
-
     def load_pandas_dataframe_to_table(
         self,
         source_dataframe: pd.DataFrame,

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -252,14 +252,14 @@ class RedshiftDatabase(BaseDatabase):
         source_to_target_map_source_columns = list(source_to_target_columns_map.keys())
         source_to_target_map_target_columns = list(source_to_target_columns_map.values())
         source_table_all_columns = self.hook.run(
-            f"select col_name from pg_get_cols('%s') "
-            f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
+            "select col_name from pg_get_cols('%s') "
+            "cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
             parameters=(source_table_name,),
             handler=lambda x: [y[0] for y in x.fetchall()],
         )
         target_table_all_columns = self.hook.run(
-            f"select col_name from pg_get_cols('%s') "
-            f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
+            "select col_name from pg_get_cols('%s') "
+            "cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
             parameters=(source_table_name,),
             handler=lambda x: [y[0] for y in x.fetchall()],
         )

--- a/python-sdk/src/astro/databases/aws/redshift.py
+++ b/python-sdk/src/astro/databases/aws/redshift.py
@@ -251,14 +251,16 @@ class RedshiftDatabase(BaseDatabase):
 
         source_to_target_map_source_columns = list(source_to_target_columns_map.keys())
         source_to_target_map_target_columns = list(source_to_target_columns_map.values())
-        source_table_all_columns = self.hook.run(  # skipcq BAN-B608
-            f"select col_name from pg_get_cols('{source_table_name}') "
+        source_table_all_columns = self.hook.run(
+            f"select col_name from pg_get_cols('%s') "
             f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
+            parameters=(source_table_name,),
             handler=lambda x: [y[0] for y in x.fetchall()],
         )
-        target_table_all_columns = self.hook.run(  # skipcq BAN-B608
-            f"select col_name from pg_get_cols('{target_table_name}') "
+        target_table_all_columns = self.hook.run(
+            f"select col_name from pg_get_cols('%s') "
             f"cols(view_schema name, view_name name, col_name name, col_type varchar, col_num int);",
+            parameters=(source_table_name,),
             handler=lambda x: [y[0] for y in x.fetchall()],
         )
         target_table_all_columns_string = ",".join(map(str, source_to_target_map_target_columns))

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -690,7 +690,7 @@ class BaseDatabase(ABC):
 
     def get_sqlalchemy_template_table_identifier_and_parameter(
         self, table: BaseTable, jinja_table_identifier: str
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str]:  # skipcq PYL-W0613
         """
         During the conversion from a Jinja-templated SQL query to a SQLAlchemy query, there is the need to
         convert a Jinja table identifier to a safe SQLAlchemy-compatible table identifier.

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -253,6 +253,7 @@ class BigqueryDatabase(BaseDatabase):
         supported_config = self.NATIVE_AUTODETECT_SCHEMA_CONFIG.get(file.location.location_type)
         return supported_config["method"](table=table, file=file)  # type: ignore
 
+    # Require skipcq because method overriding we need param target_table
     def is_native_load_file_available(
         self, source_file: File, target_table: BaseTable  # skipcq PYL-W0613
     ) -> bool:

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -169,7 +169,7 @@ class BigqueryDatabase(BaseDatabase):
         :param chunk_size: Specify the number of rows in each batch to be written at a time.
         """
         try:
-            creds = self.hook._get_credentials()
+            creds = self.hook._get_credentials()  # skipcq PYL-W021
         except AttributeError:
             # Details: https://github.com/astronomer/astro-sdk/issues/703
             creds = self.hook.get_credentials()

--- a/python-sdk/src/astro/databases/google/bigquery.py
+++ b/python-sdk/src/astro/databases/google/bigquery.py
@@ -253,7 +253,9 @@ class BigqueryDatabase(BaseDatabase):
         supported_config = self.NATIVE_AUTODETECT_SCHEMA_CONFIG.get(file.location.location_type)
         return supported_config["method"](table=table, file=file)  # type: ignore
 
-    def is_native_load_file_available(self, source_file: File, target_table: BaseTable) -> bool:
+    def is_native_load_file_available(
+        self, source_file: File, target_table: BaseTable  # skipcq PYL-W0613
+    ) -> bool:
         """
         Check if there is an optimised path for source to destination.
 

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -76,6 +76,7 @@ class PostgresDatabase(BaseDatabase):
         )
         return len(schema_result) > 0
 
+    # Require skipcq because method overriding we need param chunk_size
     def load_pandas_dataframe_to_table(
         self,
         source_dataframe: pd.DataFrame,

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -82,7 +82,7 @@ class PostgresDatabase(BaseDatabase):
         target_table: BaseTable,
         if_exists: LoadExistStrategy = "replace",
         chunk_size: int = DEFAULT_CHUNK_SIZE,
-    ) -> None:
+    ) -> None:  # skipcq PYL-W0613
         """
         Create a table with the dataframe's contents.
         If the table already exists, append or replace the content, depending on the value of `if_exists`.

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -553,7 +553,7 @@ class SnowflakeDatabase(BaseDatabase):
         self.truncate_table(table)
 
     def is_native_load_file_available(
-        self, source_file: File, target_table: BaseTable  # skipcq PYL-W0613
+        self, source_file: File, target_table: BaseTable  # skipcq PYL-W0613, PYL-R0201
     ) -> bool:
         """
         Check if there is an optimised path for source to destination.
@@ -665,7 +665,7 @@ class SnowflakeDatabase(BaseDatabase):
 
     def get_sqlalchemy_template_table_identifier_and_parameter(
         self, table: BaseTable, jinja_table_identifier: str
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str]:  # skipcq PYL-R0201
         """
         During the conversion from a Jinja-templated SQL query to a SQLAlchemy query, there is the need to
         convert a Jinja table identifier to a safe SQLAlchemy-compatible table identifier.

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -912,7 +912,7 @@ class SnowflakeDatabase(BaseDatabase):
             identifier_enclosure = '"'
 
         constraints = ",".join([f"{identifier_enclosure}{p}{identifier_enclosure}" for p in parameters])
-        sql = "ALTER TABLE {{table}} ADD CONSTRAINT airflow UNIQUE (%s)" % constraints
+        sql = "ALTER TABLE {{table}} ADD CONSTRAINT airflow UNIQUE (%s)" % constraints  # skipcq PYL-C0209
         return sql
 
     def openlineage_dataset_name(self, table: BaseTable) -> str:

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -518,7 +518,7 @@ class SnowflakeDatabase(BaseDatabase):
         file: File | None = None,
         dataframe: pd.DataFrame | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
-    ) -> None:
+    ) -> None:  # skipcq PYL-W0613
         """
         Create a SQL table, automatically inferring the schema using the given file.
         Overriding default behaviour and not using the `prep_table` since it doesn't allow the adding quotes.
@@ -552,7 +552,9 @@ class SnowflakeDatabase(BaseDatabase):
         # Since this method is used by both native and pandas path we cannot skip this step.
         self.truncate_table(table)
 
-    def is_native_load_file_available(self, source_file: File, target_table: BaseTable) -> bool:
+    def is_native_load_file_available(
+        self, source_file: File, target_table: BaseTable  # skipcq PYL-W0613
+    ) -> bool:
         """
         Check if there is an optimised path for source to destination.
 
@@ -572,7 +574,7 @@ class SnowflakeDatabase(BaseDatabase):
         if_exists: LoadExistStrategy = "replace",
         native_support_kwargs: dict | None = None,
         **kwargs,
-    ):
+    ):  # skipcq PYL-W0613
         """
         Load the content of a file to an existing Snowflake table natively by:
         - Creating a Snowflake external stage

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -71,7 +71,7 @@ class SqliteDatabase(BaseDatabase):
         Since SQLite does not have schemas, we do not need to set a schema here.
         """
 
-    def schema_exists(self, schema: str) -> bool:
+    def schema_exists(self, schema: str) -> bool:  # skipcq PYL-W0613
         """
         Check if a schema exists. We return false for sqlite since sqlite does not have schemas
         """

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -82,7 +82,7 @@ class SqliteDatabase(BaseDatabase):
         """
         Handles database-specific logic to handle index for Sqlite.
         """
-        return "CREATE UNIQUE INDEX merge_index ON {{table}}(%s)" % ",".join(parameters)
+        return "CREATE UNIQUE INDEX merge_index ON {{table}}(%s)" % ",".join(parameters)  # skipcq PYL-C0209
 
     def merge_table(
         self,

--- a/python-sdk/src/astro/databases/sqlite.py
+++ b/python-sdk/src/astro/databases/sqlite.py
@@ -71,7 +71,7 @@ class SqliteDatabase(BaseDatabase):
         Since SQLite does not have schemas, we do not need to set a schema here.
         """
 
-    def schema_exists(self, schema: str) -> bool:  # skipcq PYL-W0613
+    def schema_exists(self, schema: str) -> bool:  # skipcq PYL-W0613,PYL-R0201
         """
         Check if a schema exists. We return false for sqlite since sqlite does not have schemas
         """

--- a/python-sdk/src/astro/files/types/base.py
+++ b/python-sdk/src/astro/files/types/base.py
@@ -46,5 +46,5 @@ class FileType(ABC):
     def __eq__(self, other):
         return self.name == other.name
 
-    def __hash__(self):
+    def __hash__(self):  # pragma: no cover
         return hash(self.name)

--- a/python-sdk/src/astro/files/types/base.py
+++ b/python-sdk/src/astro/files/types/base.py
@@ -46,5 +46,5 @@ class FileType(ABC):
     def __eq__(self, other):
         return self.name == other.name
 
-    def __hash__(self):  # pragma: no cover
+    def __hash__(self):
         return hash(self.name)

--- a/python-sdk/src/astro/files/types/base.py
+++ b/python-sdk/src/astro/files/types/base.py
@@ -45,3 +45,6 @@ class FileType(ABC):
 
     def __eq__(self, other):
         return self.name == other.name
+
+    def __hash__(self):
+        return hash(self.name)

--- a/python-sdk/src/astro/files/types/csv.py
+++ b/python-sdk/src/astro/files/types/csv.py
@@ -12,7 +12,9 @@ from astro.utils.dataframe import convert_columns_names_capitalization
 class CSVFileType(FileType):
     """Concrete implementation to handle CSV file type"""
 
-    def export_to_dataframe(self, stream, columns_names_capitalization="original", **kwargs) -> pd.DataFrame:
+    def export_to_dataframe(
+        self, stream, columns_names_capitalization="original", **kwargs
+    ) -> pd.DataFrame:  # skipcq PYL-R0201
         """read csv file from one of the supported locations and return dataframe
 
         :param stream: file stream object

--- a/python-sdk/src/astro/files/types/csv.py
+++ b/python-sdk/src/astro/files/types/csv.py
@@ -12,6 +12,7 @@ from astro.utils.dataframe import convert_columns_names_capitalization
 class CSVFileType(FileType):
     """Concrete implementation to handle CSV file type"""
 
+    # We need skipcq because it's a method overloading so we don't want to make it a static method
     def export_to_dataframe(
         self, stream, columns_names_capitalization="original", **kwargs
     ) -> pd.DataFrame:  # skipcq PYL-R0201
@@ -27,7 +28,8 @@ class CSVFileType(FileType):
         )
         return df
 
-    def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
+    # We need skipcq because it's a method overloading so we don't want to make it a static method
+    def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:  # skipcq PYL-R0201
         """Write csv file to one of the supported locations
 
         :param df: pandas dataframe

--- a/python-sdk/src/astro/files/types/json.py
+++ b/python-sdk/src/astro/files/types/json.py
@@ -12,6 +12,7 @@ from astro.utils.dataframe import convert_columns_names_capitalization
 class JSONFileType(FileType):
     """Concrete implementation to handle JSON file type"""
 
+    # We need skipcq because it's a method overloading so we don't want to make it a static method
     def export_to_dataframe(
         self,
         stream: io.TextIOWrapper,
@@ -33,6 +34,7 @@ class JSONFileType(FileType):
         )
         return df
 
+    # We need skipcq because it's a method overloading so we don't want to make it a static method
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:  # skipcq PYL-R0201
         """Write json file to one of the supported locations
 

--- a/python-sdk/src/astro/files/types/json.py
+++ b/python-sdk/src/astro/files/types/json.py
@@ -17,7 +17,7 @@ class JSONFileType(FileType):
         stream: io.TextIOWrapper,
         columns_names_capitalization="original",
         **kwargs,
-    ) -> pd.DataFrame:
+    ) -> pd.DataFrame:  # skipcq PYL-R0201
         """read json file from one of the supported locations and return dataframe
 
         :param stream: file stream object
@@ -33,7 +33,7 @@ class JSONFileType(FileType):
         )
         return df
 
-    def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
+    def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:  # skipcq PYL-R0201
         """Write json file to one of the supported locations
 
         :param df: pandas dataframe

--- a/python-sdk/src/astro/files/types/ndjson.py
+++ b/python-sdk/src/astro/files/types/ndjson.py
@@ -26,7 +26,7 @@ class NDJSONFileType(FileType):
         )
         return df
 
-    def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
+    def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:  # skipcq PYL-R0201
         """Write ndjson file to one of the supported locations
 
         :param df: pandas dataframe

--- a/python-sdk/src/astro/files/types/ndjson.py
+++ b/python-sdk/src/astro/files/types/ndjson.py
@@ -26,6 +26,7 @@ class NDJSONFileType(FileType):
         )
         return df
 
+    # We need skipcq because it's a method overloading so we don't want to make it a static method
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:  # skipcq PYL-R0201
         """Write ndjson file to one of the supported locations
 

--- a/python-sdk/src/astro/files/types/parquet.py
+++ b/python-sdk/src/astro/files/types/parquet.py
@@ -46,6 +46,7 @@ class ParquetFileType(FileType):
         remote_obj_buffer.seek(0)
         return remote_obj_buffer
 
+    # We need skipcq because it's a method overloading so we don't want to make it a static method
     def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:  # skipcq PYL-R0201
         """Write parquet file to one of the supported locations
 

--- a/python-sdk/src/astro/files/types/parquet.py
+++ b/python-sdk/src/astro/files/types/parquet.py
@@ -46,7 +46,7 @@ class ParquetFileType(FileType):
         remote_obj_buffer.seek(0)
         return remote_obj_buffer
 
-    def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:
+    def create_from_dataframe(self, df: pd.DataFrame, stream: io.TextIOWrapper) -> None:  # skipcq PYL-R0201
         """Write parquet file to one of the supported locations
 
         :param df: pandas dataframe

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -13,6 +13,29 @@ from astro.sql.operators.raw_sql import RawSQLOperator, run_raw_sql
 from astro.sql.operators.transform import TransformOperator, transform, transform_file
 from astro.table import Metadata, Table
 
+__all__ = [
+    "AppendOperator",
+    "append",
+    "CleanupOperator",
+    "cleanup",
+    "DataframeOperator",
+    "dataframe",
+    "DropTableOperator",
+    "drop_table",
+    "ExportFileOperator",
+    "export_file",
+    "LoadFileOperator",
+    "load_file",
+    "MergeOperator",
+    "merge",
+    "Metadata",
+    "run_raw_sql",
+    "Table",
+    "TransformOperator",
+    "transform_file",
+    "transform",
+]
+
 
 def get_value_list(sql: str, conn_id: str, **kwargs) -> XComArg:
     """

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -52,7 +52,7 @@ class ExportFileOperator(AstroSQLBaseOperator):
             datasets["input_datasets"] = input_data
         super().__init__(**kwargs_with_datasets(kwargs=kwargs, **datasets))
 
-    def execute(self, context: Context) -> File:
+    def execute(self, context: Context) -> File:  # skipcq PYL-W0613
         """Write SQL table to csv/parquet on local/S3/GCS.
 
         Infers SQL database type based on connection.

--- a/python-sdk/src/astro/utils/load.py
+++ b/python-sdk/src/astro/utils/load.py
@@ -34,9 +34,10 @@ def copy_remote_file_to_local(
         tmp_file = tempfile.NamedTemporaryFile(mode=write_mode, delete=False)
         target_filepath = tmp_file.name
 
-    with open(target_filepath, write_mode) as fp_out:
-        with smart_open.open(source_filepath, mode=read_mode, transport_params=transport_params) as fp_in:
-            content = fp_in.read()
-            fp_out.write(content)
+    with open(target_filepath, write_mode) as fp_out, smart_open.open(
+        source_filepath, mode=read_mode, transport_params=transport_params
+    ) as fp_in:
+        content = fp_in.read()
+        fp_out.write(content)
 
     return target_filepath

--- a/python-sdk/src/astro/utils/table.py
+++ b/python-sdk/src/astro/utils/table.py
@@ -101,7 +101,7 @@ def find_first_table(
 
     if op_args:
         first_table = _find_first_table_from_op_args(op_args=op_args, context=context)
-    if not first_table and op_kwargs and python_callable:  # type ignore
+    if not first_table and op_kwargs and python_callable is not None:
         first_table = _find_first_table_from_op_kwargs(
             op_kwargs=op_kwargs,
             python_callable=python_callable,

--- a/python-sdk/src/astro/utils/table.py
+++ b/python-sdk/src/astro/utils/table.py
@@ -101,7 +101,7 @@ def find_first_table(
 
     if op_args:
         first_table = _find_first_table_from_op_args(op_args=op_args, context=context)
-    if not first_table and op_kwargs and python_callable:  # type ignore[truthy-function]
+    if not first_table and op_kwargs and python_callable:  # type ignore
         first_table = _find_first_table_from_op_kwargs(
             op_kwargs=op_kwargs,
             python_callable=python_callable,

--- a/python-sdk/src/astro/utils/table.py
+++ b/python-sdk/src/astro/utils/table.py
@@ -101,7 +101,7 @@ def find_first_table(
 
     if op_args:
         first_table = _find_first_table_from_op_args(op_args=op_args, context=context)
-    if not first_table and op_kwargs and python_callable:
+    if not first_table and op_kwargs and python_callable:  # type ignore[truthy-function]
         first_table = _find_first_table_from_op_kwargs(
             op_kwargs=op_kwargs,
             python_callable=python_callable,

--- a/python-sdk/src/astro/utils/task_id_helper.py
+++ b/python-sdk/src/astro/utils/task_id_helper.py
@@ -9,5 +9,5 @@ def get_task_id(prefix: str, path: str) -> str:
     :param prefix: prefix string
     :param path: file path.
     """
-    task_id = "{}_{}".format(prefix, path.rsplit("/", 1)[-1].replace(".", "_"))
+    task_id = f"{prefix}_{path.rsplit('/', 1)[-1].replace('.', '_')}"
     return cast(str, get_unique_task_id(task_id))

--- a/python-sdk/src/astro/utils/typing_compat.py
+++ b/python-sdk/src/astro/utils/typing_compat.py
@@ -10,7 +10,7 @@ try:
     from airflow.utils.context import Context
 except ModuleNotFoundError:  # pragma: no cover
 
-    class Context(MutableMapping[str, Any]):  # type: ignore[no-redef]
+    class Context(MutableMapping[str, Any]):  # type: ignore[no-redef] # skipcq PYL-W0223
         """Placeholder typing class for ``airflow.utils.context.Context``."""
 
 

--- a/python-sdk/tests/benchmark/analyse.py
+++ b/python-sdk/tests/benchmark/analyse.py
@@ -140,21 +140,31 @@ def analyse_results(df: pd.DataFrame, output_filepath: str = None):
         lambda text: text.split("load_file_")[-1].split("_into")[0]
     )
 
-    mean_by_dag["memory_rss"] = mean_by_dag.memory_full_info_rss.apply(lambda value: format_bytes(value))
+    mean_by_dag["memory_rss"] = mean_by_dag.memory_full_info_rss.apply(
+        lambda value: format_bytes(value)  # skipcq PYL-W0108
+    )
     if sys.platform == "linux":
-        mean_by_dag["memory_pss"] = mean_by_dag.memory_full_info_pss.apply(lambda value: format_bytes(value))
-        mean_by_dag["memory_shared"] = mean_by_dag.memory_full_info_shared.apply(
+        mean_by_dag["memory_pss"] = mean_by_dag.memory_full_info_pss.apply(
             lambda value: format_bytes(value)
+        )  # skipcq PYL-W0108
+        mean_by_dag["memory_shared"] = mean_by_dag.memory_full_info_shared.apply(
+            lambda value: format_bytes(value)  # skipcq PYL-W0108
         )
 
-    mean_by_dag["total_time"] = mean_by_dag["duration"].apply(lambda ms_time: format_time(ms_time))
+    mean_by_dag["total_time"] = mean_by_dag["duration"].apply(
+        lambda ms_time: format_time(ms_time)  # skipcq PYL-W0108
+    )
 
     mean_by_dag["cpu_time_system"] = (
         mean_by_dag["cpu_time_system"] + mean_by_dag["cpu_time_children_system"]
-    ).apply(lambda ms_time: format_time(ms_time))
+    ).apply(
+        lambda ms_time: format_time(ms_time)  # skipcq PYL-W0108
+    )
     mean_by_dag["cpu_time_user"] = (
         mean_by_dag["cpu_time_user"] + mean_by_dag["cpu_time_children_user"]
-    ).apply(lambda ms_time: format_time(ms_time))
+    ).apply(
+        lambda ms_time: format_time(ms_time)  # skipcq PYL-W0108
+    )
 
     summary = mean_by_dag[SUMMARY_FIELDS]
     content = get_content(summary)

--- a/python-sdk/tests/benchmark/analyse.py
+++ b/python-sdk/tests/benchmark/analyse.py
@@ -140,9 +140,13 @@ def analyse_results(df: pd.DataFrame, output_filepath: str = None):
         lambda text: text.split("load_file_")[-1].split("_into")[0]
     )
 
+    # We should consider removing lambda function
+    # skipcq need because of lambda function
     mean_by_dag["memory_rss"] = mean_by_dag.memory_full_info_rss.apply(
         lambda value: format_bytes(value)  # skipcq PYL-W0108
     )
+    # We should consider removing lambda function
+    # skipcq need because of lambda function
     if sys.platform == "linux":
         mean_by_dag["memory_pss"] = mean_by_dag.memory_full_info_pss.apply(
             lambda value: format_bytes(value)
@@ -151,15 +155,22 @@ def analyse_results(df: pd.DataFrame, output_filepath: str = None):
             lambda value: format_bytes(value)  # skipcq PYL-W0108
         )
 
+    # We should consider removing lambda function
+    # skipcq need because of lambda function
     mean_by_dag["total_time"] = mean_by_dag["duration"].apply(
         lambda ms_time: format_time(ms_time)  # skipcq PYL-W0108
     )
 
+    # We should consider removing lambda function
+    # skipcq need because of lambda function
     mean_by_dag["cpu_time_system"] = (
         mean_by_dag["cpu_time_system"] + mean_by_dag["cpu_time_children_system"]
     ).apply(
         lambda ms_time: format_time(ms_time)  # skipcq PYL-W0108
     )
+
+    # We should consider removing lambda function
+    # skipcq need because of lambda function
     mean_by_dag["cpu_time_user"] = (
         mean_by_dag["cpu_time_user"] + mean_by_dag["cpu_time_children_user"]
     ).apply(

--- a/python-sdk/tests/benchmark/dags/benchmark_gcs_to_big_query.py
+++ b/python-sdk/tests/benchmark/dags/benchmark_gcs_to_big_query.py
@@ -33,7 +33,7 @@ dag = models.DAG(
 )
 create_test_dataset = bash_operator.BashOperator(
     task_id="create_test_dataset",
-    bash_command="bq mk --force=true %s" % DATASET_NAME,
+    bash_command=f"bq mk --force=true {DATASET_NAME}",
     dag=dag,
 )
 

--- a/python-sdk/tests/benchmark/settings.py
+++ b/python-sdk/tests/benchmark/settings.py
@@ -1,6 +1,7 @@
 import os
+from ast import literal_eval
 
-publish_benchmarks = os.getenv("ASTRO_PUBLISH_BENCHMARK_DATA", False)
+publish_benchmarks = literal_eval(os.getenv("ASTRO_PUBLISH_BENCHMARK_DATA", "False"))
 publish_benchmarks_db_conn_id = os.getenv("ASTRO_PUBLISH_BENCHMARK_DB_CONN_ID", "bigquery")
 publish_benchmarks_schema = os.getenv("ASTRO_PUBLISH_BENCHMARK_SCHEMA", "benchmark")
 publish_benchmarks_table = os.getenv("ASTRO_PUBLISH_BENCHMARK_TABLE", "load_files_to_databaseV3")

--- a/python-sdk/tests/custom_backend/test_serializer.py
+++ b/python-sdk/tests/custom_backend/test_serializer.py
@@ -1,0 +1,52 @@
+from collections import deque
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from astro.custom_backend.serializer import serialize
+from astro.files import File
+from astro.table import Table
+
+
+@pytest.mark.parametrize(
+    "req_param,expected",
+    [
+        (
+            Table(name="astro", conn_id="astro_sdk"),
+            {
+                "class": "Table",
+                "conn_id": "astro_sdk",
+                "metadata": {"database": None, "schema": None},
+                "name": "astro",
+                "temp": False,
+            },
+        ),
+        (
+            File(path="astro", conn_id="astro_sdk"),
+            {
+                "class": "File",
+                "conn_id": "astro_sdk",
+                "filetype": None,
+                "is_dataframe": False,
+                "normalize_config": None,
+                "path": "astro",
+            },
+        ),
+        ([1, 2, "astro"], ["1", "2", {"class": "string", "value": "astro"}]),
+        ({"software": "airflow"}, {"software": {"class": "string", "value": "airflow"}}),
+        (pd.DataFrame(data={"col": [1, 2]}), {}),
+        (np.int(2022), "2022"),
+        (np.float(3.14), "3.14"),
+        (np.int_([3, 1, 4]), [3, 1, 4]),
+        ("astro", {"class": "string", "value": "astro"}),
+        (deque(), deque([])),
+    ],
+)
+def test_serialize(req_param, expected):
+    actual = serialize(req_param)
+    if isinstance(req_param, pd.DataFrame):
+        assert actual["path"] is not None
+        assert actual["is_dataframe"] is True
+    else:
+        assert actual == expected

--- a/python-sdk/tests/files/type/test_base.py
+++ b/python-sdk/tests/files/type/test_base.py
@@ -1,0 +1,27 @@
+from astro.constants import FileType
+from astro.files import File
+
+
+def test_str():
+    file = File(path="astro", conn_id="local", filetype=FileType.CSV)
+    assert file.__str__() == "astro"
+
+
+def test_repr():
+    file = File(path="astro", conn_id="local", filetype=FileType.CSV)
+    assert file.__repr__() == (
+        "File(path='astro', conn_id='local', filetype=<FileType.CSV: 'csv'>, "
+        "normalize_config=None, is_dataframe=False, is_bytes=False, "
+        "uri='astro+file://local@/astro?filetype=csv', extra={})"
+    )
+
+
+def test_eq():
+    file1 = File(path="astro", conn_id="local", filetype=FileType.CSV)
+    file2 = File(path="astro", conn_id="local", filetype=FileType.CSV)
+    assert file1.__eq__(file2) is True
+
+
+def test_hash():
+    file = File(path="astro", conn_id="local", filetype=FileType.CSV)
+    assert file.__hash__() is not None

--- a/python-sdk/tests/integration_test_dag.py
+++ b/python-sdk/tests/integration_test_dag.py
@@ -100,7 +100,7 @@ def run_merge(output_table: Table):
         columns={"list": "list", "sell": "sell"},
         if_conflicts="ignore",
     )
-    con1 >> merged_table
+    con1 >> merged_table  # skipcq PYL-W0104
 
 
 @pytest.mark.parametrize(

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -531,14 +531,15 @@ def test_load_file_chunks(sample_dag, database_table_fixture):
         "redshift": "chunksize",
     }[db.sql_type]
 
-    with mock.patch("astro.databases.snowflake.SnowflakeDatabase.truncate_table"):
-        with mock.patch(chunk_function) as mock_chunk_function:
-            with sample_dag:
-                load_file(
-                    input_file=File(path=str(pathlib.Path(CWD.parent, f"../data/sample.{file_type}"))),
-                    output_table=test_table,
-                    use_native_support=False,
-                )
+    with mock.patch("astro.databases.snowflake.SnowflakeDatabase.truncate_table"), mock.patch(
+        chunk_function
+    ) as mock_chunk_function:
+        with sample_dag:
+            load_file(
+                input_file=File(path=str(pathlib.Path(CWD.parent, f"../data/sample.{file_type}"))),
+                output_table=test_table,
+                use_native_support=False,
+            )
             test_utils.run_dag(sample_dag)
 
     _, kwargs = mock_chunk_function.call_args

--- a/python-sdk/tests/sql/operators/test_merge.py
+++ b/python-sdk/tests/sql/operators/test_merge.py
@@ -94,7 +94,7 @@ def run_merge(target_table: Table, source_table: Table, merge_parameters, mode):
         source_table=source_table,
         **merge_parameters,
     )
-    con1 >> merged_table
+    con1 >> merged_table  # skipcq PYL-W0104
     validate_results(df=merged_table, mode=mode)
 
 

--- a/python-sdk/tests/sql/operators/test_snowflake_merge_func.py
+++ b/python-sdk/tests/sql/operators/test_snowflake_merge_func.py
@@ -129,7 +129,7 @@ class TestSnowflakeMerge(unittest.TestCase):
             "source_table": self.source_table_full_name,
         }
 
-    def test_is_valid_snow_identifier(self):
+    def test_is_valid_snow_identifier(self):  # skipcq PYL-R0201
         valid_strings = [
             "ValidName",
             "Valid_Name",

--- a/python-sdk/tests/utils/test_task_id_helper.py
+++ b/python-sdk/tests/utils/test_task_id_helper.py
@@ -1,0 +1,6 @@
+from astro.utils .task_id_helper import get_task_id
+
+
+def test_get_task_id():
+    task_id = get_task_id("_tmp", "s3://tmp/09")
+    assert task_id == "_tmp_09"

--- a/python-sdk/tests/utils/test_task_id_helper.py
+++ b/python-sdk/tests/utils/test_task_id_helper.py
@@ -1,4 +1,4 @@
-from astro.utils .task_id_helper import get_task_id
+from astro.utils.task_id_helper import get_task_id
 
 
 def test_get_task_id():


### PR DESCRIPTION
# Description
## What is the current behavior?
- BAN-B608: We are concatenating the user input table name to build the query string for now I have wrapped the table/schema name with a double quote 
- PYL-W0613: Skipping it because most of the unused param exists because the parent method has it and we are overloading 
- PYL-C0209: Fix some string-building statements but if a string has `{{` double curly bracket then the f-string was behaving weirdly so I'm skipping some 
- PYL-W0212: Mostly skipped because it third party lib private property and we do not have direct control over it.
-  PY-W2000: Fix it
- PTC-W0062: Fix it
- PTC-W0048: Fix it
- PYL-W1641: Fix it. Add `__hash__`
- PYL-W1508: Fix it
- PYL-W0223: Skip it. Anyways we will remove this class in future
- PYL-R0201: Skip it since we do not want to keep them static at least in this PR
- PYL-W0108: Skip it since we do not have a test for benchmarking so it would be difficult to catch any bug here

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
