### PR TITLE
Add `no cover` to skip code-cov type_check and import_error

### DIFF
--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -11,7 +11,7 @@ from airflow.hooks.dbapi import DbApiHook
 from pandas.io.sql import SQLDatabase
 from sqlalchemy import column, insert, select
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -12,7 +12,7 @@ from airflow.models.dagrun import DagRun
 try:
     # Airflow >= 2.3
     from airflow.models.mappedoperator import MappedOperator
-except ImportError:
+except ImportError:  # pragma: no cover
     # Airflow < 2.3
     MappedOperator = None
 
@@ -235,7 +235,7 @@ class CleanupOperator(AstroSQLBaseOperator):
                     for t in task.output.resolve(context):
                         if isinstance(t, BaseTable):
                             res.append(t)
-            except AirflowException:
+            except AirflowException:  # pragma: no cover
                 self.log.info(
                     "xcom output for %s not found. Will not clean up this task",
                     task.task_id,

--- a/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
+++ b/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
@@ -3,7 +3,7 @@ from airflow.exceptions import AirflowException
 try:
     # Airflow >= 2.3
     from airflow.models.abstractoperator import AbstractOperator
-except ImportError:
+except ImportError:  # pragma: no cover
     # Airflow < 2.3
     from airflow.models.baseoperator import BaseOperator as AbstractOperator
 

--- a/python-sdk/src/astro/utils/table.py
+++ b/python-sdk/src/astro/utils/table.py
@@ -101,7 +101,7 @@ def find_first_table(
 
     if op_args:
         first_table = _find_first_table_from_op_args(op_args=op_args, context=context)
-    if not first_table and op_kwargs and python_callable:
+    if not first_table and op_kwargs and python_callable is not None:
         first_table = _find_first_table_from_op_kwargs(
             op_kwargs=op_kwargs,
             python_callable=python_callable,


### PR DESCRIPTION
# Description
## What is the current behavior?
Add `no cover` type_check and import_error to skip code coverage for an import statement. I'll fix it in more organized way in https://github.com/astronomer/astro-sdk/pull/1207


## What is the new behavior?


## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
