### PR TITLE
Bump dev `astro-runtime` image to 6.0.3

### DIFF
--- a/python-sdk/dev/Dockerfile
+++ b/python-sdk/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:6.0.2-base
+FROM quay.io/astronomer/astro-runtime:6.0.3-base
 
 USER root
 RUN apt-get update -y && apt-get install -y git


### PR DESCRIPTION
# Description
## What is the current behavior?
dev Dockerfile is using old astro runtime image 6.0.2

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
Bump astro-runtime image to 6.0.3


## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
