### PR TITLE
Update snowflake-sqlalchemy version

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -62,7 +62,7 @@ google = [
 ]
 snowflake = [
     "apache-airflow-providers-snowflake",
-    "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
+    "snowflake-sqlalchemy>=1.2.0",
     "snowflake-connector-python[pandas]",
 ]
 postgres = [
@@ -82,7 +82,7 @@ all = [
     "apache-airflow-providers-snowflake",
     "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]",
-    "snowflake-sqlalchemy>=1.2.0,<=1.2.4",
+    "snowflake-sqlalchemy>=1.2.0",
     "sqlalchemy-bigquery>=1.3.0",
     "s3fs",
     "protobuf<=3.20", # Google bigquery client require protobuf <= 3.20.0. We can remove the limitation when this limitation is removed

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -23,10 +23,7 @@ dependencies = [
     "pyarrow",
     "python-frontmatter",
     "smart-open",
-    "SQLAlchemy>=1.3.18,<1.4.42" # Pinning it to <1.4.42 because sqlalchemy 1.4.42
-    # has renamed all of the rfc 1738 stuff so imports like `from sqlalchemy.engine.url import _rfc_1738_quote` fails.
-    # which is breaking in snowflake-sqlalchemy and we cannot change the version of snowflake-sqlalchemy to anything
-    # other than 1.2.4 because airflow 2.2.5 has a constraint.
+    "SQLAlchemy>=1.3.18"
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow", "elt", "etl", "dag"]


### PR DESCRIPTION
# Description
## What is the current behavior?
closes: https://github.com/astronomer/astro-sdk/issues/1226
closes: #1187 


## What is the new behavior?
Remove snowflake-sqlalchemy version restrion

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
