### PR TITLE
Tidy up `Table.name` attr handling for better 2.5 XCom support

### DIFF
--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -4,7 +4,7 @@ import random
 import string
 from typing import Any
 
-import attrs
+import attr.setters
 from attr import define, field, fields_dict
 from sqlalchemy import Column, MetaData
 
@@ -55,7 +55,7 @@ class BaseTable:
     # TODO: discuss alternative names to this class, since it contains metadata as opposed to be the
     # SQL table itself
     # Some ideas: TableRef, TableMetadata, TableData, TableDataset
-    name: str = field(default="", on_setattr=attrs.setters.validate)
+    name: str = field(default="", on_setattr=attr.setters.validate)
     conn_id: str = field(default="")
     # Setting converter allows passing a dictionary to metadata arg
     metadata: Metadata = field(

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -66,7 +66,7 @@ class BaseTable:
     temp: bool = field(default=False)
 
     @name.validator
-    def _check_name(self, attr, value):
+    def _check_name(self, _, value):
         self.temp = not value or value.startswith(TEMP_PREFIX)
 
     def __attrs_post_init__(self) -> None:

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -13,7 +13,7 @@ from astro.databases import create_database
 from astro.settings import OPENLINEAGE_EMIT_TEMP_TABLE_EVENT
 
 MAX_TABLE_NAME_LENGTH = 62
-TEMP_PREFIX = "_tmp_"
+TEMP_PREFIX = "_tmp"
 
 
 @define
@@ -71,7 +71,7 @@ class BaseTable:
 
     def __attrs_post_init__(self) -> None:
         if not self.name:
-            self.name = self._create_unique_table_name(TEMP_PREFIX)
+            self.name = self._create_unique_table_name(TEMP_PREFIX + "_")
 
     # We need this method to pickle Table object, without this we cannot push/pull this object from xcom.
     def __getstate__(self):

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -66,7 +66,7 @@ class BaseTable:
     temp: bool = field(default=False)
 
     @name.validator
-    def _check_name(self, _, value):
+    def _check_name(self, _attr, value):
         self.temp = not value or value.startswith(TEMP_PREFIX)
 
     def __attrs_post_init__(self) -> None:

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -4,7 +4,6 @@ import random
 import string
 from typing import Any
 
-import attr.setters
 from attr import define, field, fields_dict
 from sqlalchemy import Column, MetaData
 
@@ -55,7 +54,7 @@ class BaseTable:
     # TODO: discuss alternative names to this class, since it contains metadata as opposed to be the
     # SQL table itself
     # Some ideas: TableRef, TableMetadata, TableData, TableDataset
-    name: str = field(default="", on_setattr=attr.setters.validate)
+    name: str = field(default="")
     conn_id: str = field(default="")
     # Setting converter allows passing a dictionary to metadata arg
     metadata: Metadata = field(
@@ -65,13 +64,12 @@ class BaseTable:
     columns: list[Column] = field(factory=list)
     temp: bool = field(default=False)
 
-    @name.validator
-    def _check_name(self, _attr, value):
-        self.temp = not value or value.startswith(TEMP_PREFIX)
-
     def __attrs_post_init__(self) -> None:
         if not self.name:
             self.name = self._create_unique_table_name(TEMP_PREFIX + "_")
+            self.temp = True
+        if self.name.startswith(TEMP_PREFIX):
+            self.temp = True
 
     # We need this method to pickle Table object, without this we cannot push/pull this object from xcom.
     def __getstate__(self):

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -39,14 +39,6 @@ def test_table_without_name_and_schema():
     assert table.temp
 
 
-def test_table_name_set_after_initialization():
-    """Check that the table is no longer considered temp when the name is set after initialization."""
-    table = Table(conn_id="some_connection")
-    assert table.temp
-    table.name = "something"
-    assert not table.temp
-
-
 def test_table_name_with_temp_prefix():
     """Check that the table is no longer considered temp when the name is set after initialization."""
     table = Table(conn_id="some_connection")

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -33,8 +33,7 @@ def test_table_without_name():
 
 def test_table_without_name_and_schema():
     """Check that the table name is smaller when there is metadata associated to the table."""
-    table = Table(conn_id="some_connection")
-    table.metadata.schema = "abc"
+    table = Table(conn_id="some_connection", metadata=Metadata(schema="abc"))
     assert isinstance(table.name, str)
     assert len(table.name) == 59  # max length limit - len("abc.")
     assert table.temp


### PR DESCRIPTION
We don't need to make it a property, we can just create the temp name in postinit.

(We "could" set the name via `@name.default`, but the default for this attribute is set in "field definition order" which means that we'd try to set the default before `self.metadata` has been set, which causes problems, and we don't really want to re-order the attributes as that affects how our users use this class, and name has to remain as the first arg there)


