### PR TITLE
Do not process example_dags in sql-cli check for import errors

### DIFF
--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -127,4 +127,6 @@ def check_for_dag_import_errors(dag_file: Path) -> dict[str, str]:
     from airflow.models import DagBag
     from airflow.utils.cli import process_subdir
 
-    return DagBag(process_subdir(str(dag_file))).import_errors
+    dag_folder = process_subdir(str(dag_file))
+    dagbag = DagBag(dag_folder, include_examples=False)
+    return dagbag.import_errors


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we parse the example_dags as well when checking for import errors.

related: https://astronomer.slack.com/archives/C042ZUJ7QG2/p1668418304172329?thread_ts=1668416742.317539&cid=C042ZUJ7QG2

## What is the new behavior?

We don't parse the example dags anymore.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
