### PR TITLE
Make `openlineage` an optional dependency

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,4 @@ ignore = A002,W503
 extend-ignore = E203
 per-file-ignores =
      python-sdk/src/astro/sql/__init__.py: F401
+     python-sdk/src/astro/lineage/__init__.py: F401

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -67,7 +67,7 @@ def test_examples_by_dependency(session: nox.Session, extras):
     pytest_args = ["-k", pytest_options]
 
     session.install("-e", f".[{pypi_deps}]")
-    session.install("-e", ".[tests]")
+    session.install("-e", ".[openlineage, tests]")
     session.run("airflow", "db", "init")
 
     # Since pytest is not installed in the nox session directly, we need to set `external=true`.

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -67,7 +67,7 @@ def test_examples_by_dependency(session: nox.Session, extras):
     pytest_args = ["-k", pytest_options]
 
     session.install("-e", f".[{pypi_deps}]")
-    session.install("-e", ".[openlineage, tests]")
+    session.install("-e", ".[tests]")
     session.run("airflow", "db", "init")
 
     # Since pytest is not installed in the nox session directly, we need to set `external=true`.

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
     "pyarrow",
     "python-frontmatter",
     "smart-open",
-    "SQLAlchemy>=1.3.18"
+    "SQLAlchemy>=1.3.18",
+    "openlineage-airflow>=0.15.1",
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow", "elt", "etl", "dag"]

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "python-frontmatter",
     "smart-open",
     "SQLAlchemy>=1.3.18",
-    "openlineage-airflow>=0.15.1",
 ]
 
 keywords = ["airflow", "provider", "astronomer", "sql", "decorator", "task flow", "elt", "etl", "dag"]

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -49,7 +49,6 @@ tests = [
     "pytest-describe",
     "mypy",
     "sqlalchemy-stubs",  # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
-    "openlineage-airflow>=0.15.1"
 ]
 google = [
     "protobuf<=3.20", # Google bigquery client require protobuf <= 3.20.0. We can remove the limitation when this limitation is removed

--- a/python-sdk/src/astro/lineage/__init__.py
+++ b/python-sdk/src/astro/lineage/__init__.py
@@ -1,0 +1,23 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+try:
+    from openlineage.airflow.extractors import TaskMetadata
+    from openlineage.airflow.extractors.base import BaseExtractor
+    from openlineage.airflow.utils import get_job_name
+    from openlineage.client.facet import (
+        BaseFacet,
+        DataQualityMetricsInputDatasetFacet,
+        DataSourceDatasetFacet,
+        OutputStatisticsOutputDatasetFacet,
+        SchemaDatasetFacet,
+        SchemaField,
+        SqlJobFacet,
+    )
+    from openlineage.client.run import Dataset as OpenlineageDataset
+
+    has_openlineage = True
+except ImportError:
+    has_openlineage = False
+    logging.debug("openlineage-airflow python dependency is missing")

--- a/python-sdk/src/astro/lineage/__init__.py
+++ b/python-sdk/src/astro/lineage/__init__.py
@@ -16,8 +16,5 @@ try:
         SqlJobFacet,
     )
     from openlineage.client.run import Dataset as OpenlineageDataset
-
-    has_openlineage = True
 except ImportError:
-    has_openlineage = False
     logging.debug("openlineage-airflow python dependency is missing")

--- a/python-sdk/src/astro/lineage/extractor.py
+++ b/python-sdk/src/astro/lineage/extractor.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
-import logging
-
 import attr
 from airflow.models.taskinstance import TaskInstance
-
-try:
-    from openlineage.airflow.extractors import TaskMetadata
-    from openlineage.airflow.extractors.base import BaseExtractor
-    from openlineage.airflow.utils import get_job_name
-    from openlineage.client.facet import BaseFacet
-    from openlineage.client.run import Dataset as OpenlineageDataset
-except ImportError:
-    logging.warning("Install openlineage-airflow")
+from openlineage.airflow.extractors import TaskMetadata
+from openlineage.airflow.extractors.base import BaseExtractor
+from openlineage.airflow.utils import get_job_name
+from openlineage.client.facet import BaseFacet
+from openlineage.client.run import Dataset as OpenlineageDataset
 
 
 @attr.define

--- a/python-sdk/src/astro/lineage/extractor.py
+++ b/python-sdk/src/astro/lineage/extractor.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import logging
+
 import attr
 from airflow.models.taskinstance import TaskInstance
-from openlineage.airflow.extractors import TaskMetadata
-from openlineage.airflow.extractors.base import BaseExtractor
-from openlineage.airflow.utils import get_job_name
-from openlineage.client.facet import BaseFacet
-from openlineage.client.run import Dataset as OpenlineageDataset
+
+try:
+    from openlineage.airflow.extractors import TaskMetadata
+    from openlineage.airflow.extractors.base import BaseExtractor
+    from openlineage.airflow.utils import get_job_name
+    from openlineage.client.facet import BaseFacet
+    from openlineage.client.run import Dataset as OpenlineageDataset
+except ImportError:
+    logging.warning("Install openlineage-airflow")
 
 
 @attr.define

--- a/python-sdk/src/astro/lineage/extractor.py
+++ b/python-sdk/src/astro/lineage/extractor.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 import attr
 from airflow.models.taskinstance import TaskInstance
-from openlineage.airflow.extractors import TaskMetadata
-from openlineage.airflow.extractors.base import BaseExtractor
-from openlineage.airflow.utils import get_job_name
-from openlineage.client.facet import BaseFacet
-from openlineage.client.run import Dataset as OpenlineageDataset
+
+from astro.lineage import BaseExtractor, BaseFacet, OpenlineageDataset, TaskMetadata, get_job_name
 
 
 @attr.define

--- a/python-sdk/src/astro/lineage/facets.py
+++ b/python-sdk/src/astro/lineage/facets.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import attr
-from openlineage.client.facet import BaseFacet
 
 from astro.constants import ExportExistsStrategy, FileType, MergeConflictStrategy
+from astro.lineage import BaseFacet
 from astro.table import Column, Metadata
 
 

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
-from openlineage.client.facet import (
-    BaseFacet,
-    DataQualityMetricsInputDatasetFacet,
-    DataSourceDatasetFacet,
-    OutputStatisticsOutputDatasetFacet,
-    SchemaDatasetFacet,
-    SchemaField,
-    SqlJobFacet,
-)
-from openlineage.client.run import Dataset as OpenlineageDataset
+
+try:
+    from openlineage.client.facet import (
+        BaseFacet,
+        DataQualityMetricsInputDatasetFacet,
+        DataSourceDatasetFacet,
+        OutputStatisticsOutputDatasetFacet,
+        SchemaDatasetFacet,
+        SchemaField,
+        SqlJobFacet,
+    )
+    from openlineage.client.run import Dataset as OpenlineageDataset
+except ImportError:
+    logging.warning("Install openlineage-airflow")
 
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database

--- a/python-sdk/src/astro/sql/operators/append.py
+++ b/python-sdk/src/astro/sql/operators/append.py
@@ -1,29 +1,12 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
-try:
-    from openlineage.client.facet import (
-        BaseFacet,
-        DataQualityMetricsInputDatasetFacet,
-        DataSourceDatasetFacet,
-        OutputStatisticsOutputDatasetFacet,
-        SchemaDatasetFacet,
-        SchemaField,
-        SqlJobFacet,
-    )
-    from openlineage.client.run import Dataset as OpenlineageDataset
-except ImportError:
-    logging.warning("Install openlineage-airflow")
-
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
-from astro.lineage.extractor import OpenLineageFacets
-from astro.lineage.facets import TableDatasetFacet
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.table import BaseTable
 from astro.utils.typing_compat import Context
@@ -81,10 +64,23 @@ class AppendOperator(AstroSQLBaseOperator):
         context["ti"].xcom_push(key="append_query", value=str(db.sql))
         return self.target_table
 
-    def get_openlineage_facets(self, task_instance) -> OpenLineageFacets:
+    def get_openlineage_facets(self, task_instance):
         """
         Collect the input, output, job and run facets for append operator
         """
+        from astro.lineage import (
+            BaseFacet,
+            DataQualityMetricsInputDatasetFacet,
+            DataSourceDatasetFacet,
+            OpenlineageDataset,
+            OutputStatisticsOutputDatasetFacet,
+            SchemaDatasetFacet,
+            SchemaField,
+            SqlJobFacet,
+        )
+        from astro.lineage.extractor import OpenLineageFacets
+        from astro.lineage.facets import TableDatasetFacet
+
         append_query = task_instance.xcom_pull(task_ids=task_instance.task_id, key="append_query")
         source_table_rows = self.source_table.row_count
         input_dataset: list[OpenlineageDataset] = [OpenlineageDataset(namespace=None, name=None, facets={})]

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -1,32 +1,16 @@
 from __future__ import annotations
 
 import inspect
-import logging
 from typing import Any, Sequence, cast
 
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
 from airflow.exceptions import AirflowException
-
-try:
-    from openlineage.client.facet import (
-        BaseFacet,
-        DataSourceDatasetFacet,
-        OutputStatisticsOutputDatasetFacet,
-        SchemaDatasetFacet,
-        SchemaField,
-        SqlJobFacet,
-    )
-    from openlineage.client.run import Dataset as OpenlineageDataset
-except ImportError:
-    logging.warning("Install openlineage-airflow")
-
 from sqlalchemy.sql.functions import Function
 
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.databases import create_database
 from astro.databases.base import BaseDatabase
-from astro.lineage.extractor import OpenLineageFacets
 from astro.sql.operators.upstream_task_mixin import UpstreamTaskMixin
 from astro.table import BaseTable, Table
 from astro.utils.table import find_first_table
@@ -209,10 +193,21 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         if context:
             self.sql = self.render_template(self.sql, context)
 
-    def get_openlineage_facets(self, task_instance) -> OpenLineageFacets:
+    def get_openlineage_facets(self, task_instance):
         """
         Returns the lineage data
         """
+        from astro.lineage import (
+            BaseFacet,
+            DataSourceDatasetFacet,
+            OpenlineageDataset,
+            OutputStatisticsOutputDatasetFacet,
+            SchemaDatasetFacet,
+            SchemaField,
+            SqlJobFacet,
+        )
+        from astro.lineage.extractor import OpenLineageFacets
+
         input_dataset: list[OpenlineageDataset] = []
         output_dataset: list[OpenlineageDataset] = []
         if (

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -1,20 +1,26 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from typing import Any, Sequence, cast
 
 import pandas as pd
 from airflow.decorators.base import DecoratedOperator
 from airflow.exceptions import AirflowException
-from openlineage.client.facet import (
-    BaseFacet,
-    DataSourceDatasetFacet,
-    OutputStatisticsOutputDatasetFacet,
-    SchemaDatasetFacet,
-    SchemaField,
-    SqlJobFacet,
-)
-from openlineage.client.run import Dataset as OpenlineageDataset
+
+try:
+    from openlineage.client.facet import (
+        BaseFacet,
+        DataSourceDatasetFacet,
+        OutputStatisticsOutputDatasetFacet,
+        SchemaDatasetFacet,
+        SchemaField,
+        SqlJobFacet,
+    )
+    from openlineage.client.run import Dataset as OpenlineageDataset
+except ImportError:
+    logging.warning("Install openlineage-airflow")
+
 from sqlalchemy.sql.functions import Function
 
 from astro.airflow.datasets import kwargs_with_datasets

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -12,17 +12,20 @@ from astro.airflow.datasets import kwargs_with_datasets
 try:
     from airflow.decorators.base import TaskDecorator, task_decorator_factory
 except ImportError:  # pragma: no cover
-    from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
+    from airflow.decorators.base import task_decorator_factory
 
-from openlineage.client.facet import (
-    BaseFacet,
-    DataSourceDatasetFacet,
-    OutputStatisticsOutputDatasetFacet,
-    SchemaDatasetFacet,
-    SchemaField,
-)
-from openlineage.client.run import Dataset as OpenlineageDataset
+try:
+    from openlineage.client.facet import (
+        BaseFacet,
+        DataSourceDatasetFacet,
+        OutputStatisticsOutputDatasetFacet,
+        SchemaDatasetFacet,
+        SchemaField,
+    )
+    from openlineage.client.run import Dataset as OpenlineageDataset
+except ImportError:
+    logging.warning("Install openlineage-airflow")
 
 from astro.constants import ColumnCapitalization
 from astro.databases import create_database

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -15,22 +15,9 @@ except ImportError:  # pragma: no cover
     from airflow.decorators import _TaskDecorator as TaskDecorator
     from airflow.decorators.base import task_decorator_factory
 
-try:
-    from openlineage.client.facet import (
-        BaseFacet,
-        DataSourceDatasetFacet,
-        OutputStatisticsOutputDatasetFacet,
-        SchemaDatasetFacet,
-        SchemaField,
-    )
-    from openlineage.client.run import Dataset as OpenlineageDataset
-except ImportError:
-    logging.warning("Install openlineage-airflow")
-
 from astro.constants import ColumnCapitalization
 from astro.databases import create_database
 from astro.files import File
-from astro.lineage.extractor import OpenLineageFacets
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.sql.table import BaseTable, Table
 from astro.utils.dataframe import convert_columns_names_capitalization
@@ -228,10 +215,20 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
             )
         return function_output
 
-    def get_openlineage_facets(self, task_instance) -> OpenLineageFacets:  # skipcq: PYL-W0613
+    def get_openlineage_facets(self, task_instance):  # skipcq: PYL-W0613
         """
         Collect the input, output, job and run facets for DataframeOperator
         """
+        from astro.lineage import (
+            BaseFacet,
+            DataSourceDatasetFacet,
+            OpenlineageDataset,
+            OutputStatisticsOutputDatasetFacet,
+            SchemaDatasetFacet,
+            SchemaField,
+        )
+        from astro.lineage.extractor import OpenLineageFacets
+
         output_dataset: list[OpenlineageDataset] = []
 
         if self.output_table and self.output_table.openlineage_emit_temp_table_event():  # pragma: no cover

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
-from openlineage.client.facet import (
-    BaseFacet,
-    DataQualityMetricsInputDatasetFacet,
-    DataSourceDatasetFacet,
-    OutputStatisticsOutputDatasetFacet,
-    SchemaDatasetFacet,
-    SchemaField,
-)
-from openlineage.client.run import Dataset as OpenlineageDataset
+
+try:
+    from openlineage.client.facet import (
+        BaseFacet,
+        DataQualityMetricsInputDatasetFacet,
+        DataSourceDatasetFacet,
+        OutputStatisticsOutputDatasetFacet,
+        SchemaDatasetFacet,
+        SchemaField,
+    )
+    from openlineage.client.run import Dataset as OpenlineageDataset
+except ImportError:
+    logging.warning("Install openlineage-airflow")
 
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import ExportExistsStrategy

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -1,25 +1,16 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
-try:
-    from openlineage.client.facet import BaseFacet, DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField
-    from openlineage.client.run import Dataset as OpenlineageDataset
-except ImportError:
-    logging.warning("Install openlineage-airflow")
-
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
 from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
-from astro.lineage.extractor import OpenLineageFacets
-from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
 from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.table import BaseTable
@@ -190,10 +181,18 @@ class LoadFileOperator(AstroSQLBaseOperator):
 
         return normalize_config
 
-    def get_openlineage_facets(self, task_instance) -> OpenLineageFacets:  # skipcq: PYL-W0613
-        """
-        Returns the lineage data
-        """
+    def get_openlineage_facets(self, task_instance):  # skipcq: PYL-W0613
+        """Returns the lineage data"""
+        from astro.lineage import (
+            BaseFacet,
+            DataSourceDatasetFacet,
+            OpenlineageDataset,
+            SchemaDatasetFacet,
+            SchemaField,
+        )
+        from astro.lineage.extractor import OpenLineageFacets
+        from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
+
         # if the input_file is a folder or pattern, it needs to be resolved to
         # list the files
         input_files = resolve_file_path_pattern(

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pandas as pd
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
-from openlineage.client.facet import BaseFacet, DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField
-from openlineage.client.run import Dataset as OpenlineageDataset
+
+try:
+    from openlineage.client.facet import BaseFacet, DataSourceDatasetFacet, SchemaDatasetFacet, SchemaField
+    from openlineage.client.run import Dataset as OpenlineageDataset
+except ImportError:
+    logging.warning("Install openlineage-airflow")
 
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy

--- a/python-sdk/src/astro/sql/operators/merge.py
+++ b/python-sdk/src/astro/sql/operators/merge.py
@@ -1,19 +1,24 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
-from openlineage.client.facet import (
-    BaseFacet,
-    DataQualityMetricsInputDatasetFacet,
-    DataSourceDatasetFacet,
-    OutputStatisticsOutputDatasetFacet,
-    SchemaDatasetFacet,
-    SchemaField,
-    SqlJobFacet,
-)
-from openlineage.client.run import Dataset as OpenlineageDataset
+
+try:
+    from openlineage.client.facet import (
+        BaseFacet,
+        DataQualityMetricsInputDatasetFacet,
+        DataSourceDatasetFacet,
+        OutputStatisticsOutputDatasetFacet,
+        SchemaDatasetFacet,
+        SchemaField,
+        SqlJobFacet,
+    )
+    from openlineage.client.run import Dataset as OpenlineageDataset
+except ImportError:
+    logging.warning("Install openlineage-airflow")
 
 from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import MergeConflictStrategy


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
We shouldn’t import the openlineage package at top level if it is optional.
Refer to https://astronomer.slack.com/archives/C02B8SPT93K/p1668186729410429

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1243


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Add a try except for import error
- Remove the open lineage from test in pyproject

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
