### PR TITLE
Refactor cli tests to rely on large terminal

### DIFF
--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -99,6 +99,7 @@ jobs:
     env:
       AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
       AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
+      TERMINAL_WIDTH: 3000
       _TYPER_FORCE_DISABLE_TERMINAL: 1
 
 

--- a/sql-cli/Makefile
+++ b/sql-cli/Makefile
@@ -31,7 +31,7 @@ pre-commit:  # Run pre-commit
 flow:  # Build and run the latest version of flow
 
 test:  # Run tests
-	@_TYPER_FORCE_DISABLE_TERMINAL=1 PYTHONWARNINGS="ignore" poetry run pytest -s --cov --cov-branch --cov-report=term-missing tests
+	@TERMINAL_WIDTH=3000 _TYPER_FORCE_DISABLE_TERMINAL=1 PYTHONWARNINGS="ignore" poetry run pytest -s --cov --cov-branch --cov-report=term-missing tests
 
 release:  # Build a package
 	@echo -e "If this is your first time, please, manually follow these two steps: \n" \

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import typer
 from dotenv import load_dotenv
-from rich import print as rprint
 from typer import Exit
 
 import sql_cli
@@ -14,6 +13,7 @@ from sql_cli.astro.command import AstroCommand
 from sql_cli.astro.group import AstroGroup
 from sql_cli.constants import DEFAULT_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER
 from sql_cli.exceptions import ConnectionFailed, DagCycle, EmptyDag, SqlFilesDirectoryNotFound
+from sql_cli.utils.rich import rprint
 
 if TYPE_CHECKING:
     from sql_cli.project import Project

--- a/sql-cli/sql_cli/connections.py
+++ b/sql-cli/sql_cli/connections.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 from airflow.models import Connection
 from airflow.utils.session import create_session
-from rich import print as rprint
+
+from sql_cli.utils.rich import rprint
 
 CONNECTION_ID_OUTPUT_STRING_WIDTH = 25
 

--- a/sql-cli/sql_cli/utils/rich.py
+++ b/sql-cli/sql_cli/utils/rich.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import IO, Any, Optional, Union
 
 import click
 from rich.panel import Panel
@@ -39,9 +39,6 @@ def rich_format_error(self: click.ClickException) -> None:
             title_align=ALIGN_ERRORS_PANEL,
         )
     )
-from typing import IO, Any, Optional
-
-from typer.rich_utils import _get_rich_console
 
 
 def rprint(

--- a/sql-cli/sql_cli/utils/rich.py
+++ b/sql-cli/sql_cli/utils/rich.py
@@ -49,7 +49,7 @@ def rprint(
     sep: str = " ",
     end: str = "\n",
     file: Optional[IO[str]] = None,
-    flush: bool = False,
+    flush: bool = False,  # skipcq: PYL-W0613
 ) -> None:
     r"""Print object(s) supplied via positional arguments.
     This function has an identical signature to the built-in print.

--- a/sql-cli/sql_cli/utils/rich.py
+++ b/sql-cli/sql_cli/utils/rich.py
@@ -39,3 +39,32 @@ def rich_format_error(self: click.ClickException) -> None:
             title_align=ALIGN_ERRORS_PANEL,
         )
     )
+from typing import IO, Any, Optional
+
+from typer.rich_utils import _get_rich_console
+
+
+def rprint(
+    *objects: Any,
+    sep: str = " ",
+    end: str = "\n",
+    file: Optional[IO[str]] = None,
+    flush: bool = False,
+) -> None:
+    r"""Print object(s) supplied via positional arguments.
+    This function has an identical signature to the built-in print.
+    For more advanced features, see the :class:`~rich.console.Console` class.
+
+    Args:
+        sep (str, optional): Separator between printed objects. Defaults to " ".
+        end (str, optional): Character to write at end of output. Defaults to "\\n".
+        file (IO[str], optional): File to write to, or None for stdout. Defaults to None.
+        flush (bool, optional): Has no effect as Rich always flushes output. Defaults to False.
+
+    """
+    from rich.console import Console
+
+    # We use the rich console from typer which allows us to set FORCE_TERMINAL & MAX_WIDTH
+    # both we use for consistent output locally (via Makefile) and in CI
+    write_console = _get_rich_console() if file is None else Console(file=file)
+    return write_console.print(*objects, sep=sep, end=end)

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -59,7 +59,7 @@ def test_usage(env, usage, args):
 def test_invalid_option(env, try_message):
     result = runner.invoke(app, ["--foo"], env=env)
     assert result.exit_code == 2
-    assert try_message in get_stdout(result)
+    assert try_message in result.stdout
 
 
 def test_about():

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -17,17 +17,6 @@ runner = CliRunner()
 CWD = pathlib.Path(__file__).parent
 
 
-def get_stdout(result) -> str:
-    """
-    Get the results stdout without line breaks.
-
-    :params result: The result object.
-
-    :returns: the stdout without line breaks.
-    """
-    return result.stdout.replace("\n", "")
-
-
 @pytest.mark.parametrize(
     "args",
     [
@@ -53,7 +42,7 @@ def get_stdout(result) -> str:
 def test_usage(env, usage, args):
     result = runner.invoke(app, args, env=env)
     assert result.exit_code == 0
-    assert usage in get_stdout(result)
+    assert usage in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -76,13 +65,13 @@ def test_invalid_option(env, try_message):
 def test_about():
     result = runner.invoke(app, ["about"])
     assert result.exit_code == 0
-    assert "Find out more: https://docs.astronomer.io/astro/cli/sql-cli" == get_stdout(result)
+    assert "Find out more: https://docs.astronomer.io/astro/cli/sql-cli" in result.stdout
 
 
 def test_version():
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
-    assert f"Astro SQL CLI {__version__}" == get_stdout(result)
+    assert f"Astro SQL CLI {__version__}" in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -107,10 +96,9 @@ def test_generate(workflow_name, environment, initialised_project, generate_task
         ],
     )
     assert result.exit_code == 0, result.output
-    result_stdout = get_stdout(result)
     assert (
         f"The DAG file {initialised_project.airflow_dags_folder}/{workflow_name}.py has been successfully generated. 🎉"
-        in result_stdout
+        in result.stdout
     )
 
 
@@ -140,8 +128,7 @@ def test_generate_invalid(workflow_name, message, initialised_project_with_tests
         ],
     )
     assert result.exit_code == 1
-    result_stdout = get_stdout(result)
-    assert message in result_stdout
+    assert message in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -164,9 +151,8 @@ def test_validate(env, connection, status, initialised_project_with_test_config)
         ],
     )
     assert result.exit_code == 0, result.exception
-    output = get_stdout(result)
-    assert f"Validating connection(s) for environment '{env}'" in output
-    assert f"Validating connection {connection:{CONNECTION_ID_OUTPUT_STRING_WIDTH}} {status}" in output
+    assert f"Validating connection(s) for environment '{env}'" in result.stdout
+    assert f"Validating connection {connection:{CONNECTION_ID_OUTPUT_STRING_WIDTH}} {status}" in result.stdout
 
 
 def test_validate_all(initialised_project_with_test_config):
@@ -178,8 +164,7 @@ def test_validate_all(initialised_project_with_test_config):
         ],
     )
     assert result.exit_code == 0
-    output = get_stdout(result)
-    assert output.startswith("Validating connection(s)")
+    assert "Validating connection(s)" in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -204,8 +189,7 @@ def test_run(workflow_name, environment, initialised_project, generate_tasks):
         ],
     )
     assert result.exit_code == 0, result.output
-    result_stdout = get_stdout(result)
-    assert f"Completed running the workflow {workflow_name}." in result_stdout
+    assert f"Completed running the workflow {workflow_name}." in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -244,8 +228,7 @@ def test_run_state(mock_run_dag, initialised_project, generate_tasks, dag_run_st
         ],
     )
     assert result.exit_code == 0, result.output
-    result_stdout = get_stdout(result)
-    assert f"Final state: {final_state}" in result_stdout
+    assert f"Final state: {final_state}" in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -280,15 +263,13 @@ def test_run_invalid(workflow_name, message, initialised_project_with_tests_work
         ],
     )
     assert result.exit_code == 1
-    result_stdout = get_stdout(result)
-    assert message in result_stdout
+    assert message in result.stdout
 
 
 def test_init_with_directory(tmp_path):
     result = runner.invoke(app, ["init", tmp_path.as_posix()])
     assert result.exit_code == 0
-    expected_msg = f"Initialized an Astro SQL project at {tmp_path.as_posix()}"
-    assert expected_msg in get_stdout(result)
+    assert f"Initialized an Astro SQL project at {tmp_path.as_posix()}" in result.stdout
     assert list_dir(tmp_path.as_posix())
 
 
@@ -298,8 +279,7 @@ def test_init_with_custom_airflow_config(tmp_path):
         app, ["init", tmp_path.as_posix(), "--airflow-home", tmp_dir, "--airflow-dags-folder", tmp_dir]
     )
     assert result.exit_code == 0
-    expected_msg = f"Initialized an Astro SQL project at {tmp_path.as_posix()}"
-    assert expected_msg in get_stdout(result)
+    assert f"Initialized an Astro SQL project at {tmp_path.as_posix()}" in result.stdout
     assert list_dir(tmp_path.as_posix())
 
 
@@ -310,9 +290,7 @@ def test_init_without_directory():
         assert not list_dir(temp_dir)
         result = runner.invoke(app, ["init"])
         assert result.exit_code == 0
-        expected_msg = "Initialized an Astro SQL project at"
-        result_stdout = get_stdout(result)
         # We are not checking the full temp_dir because in MacOS the temp directory starts with /private
-        assert result_stdout.startswith(expected_msg)
-        assert result_stdout.endswith(temp_dir)
+        assert "Initialized an Astro SQL project at" in result.stdout
+        assert temp_dir in result.stdout
         assert list_dir(temp_dir)


### PR DESCRIPTION
Instead of changing the stdout via get_stdout, we just set the TERMINAL_WIDTH to a very large number to avoid new lines. The configuration has been copied from https://github.com/tiangolo/typer/blob/master/scripts/test.sh

**EDIT:**

I have also created https://github.com/tiangolo/typer/pull/509 to fix that in typer.