### PR TITLE
Pass task_id to be used for parent class on LoadFileOperator initialisation

### DIFF
--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -31,6 +31,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
     :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
     :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
+    :param task_id: ID of the task instance of the operator
 
     :return: If ``output_table`` is passed this operator returns a Table object. If not
         passed, returns a dataframe.
@@ -49,14 +50,17 @@ class LoadFileOperator(AstroSQLBaseOperator):
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
         enable_native_fallback: bool | None = LOAD_FILE_ENABLE_NATIVE_FALLBACK,
+        task_id: str | None = None,
         **kwargs,
     ) -> None:
+        task_id = task_id or get_unique_task_id("load_file")
         super().__init__(
+            task_id=task_id,
             **kwargs_with_datasets(
                 kwargs=kwargs,
                 input_datasets=input_file,
                 output_datasets=output_table,
-            )
+            ),
         )
         self.output_table = output_table
         self.input_file = input_file

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -31,7 +31,6 @@ class LoadFileOperator(AstroSQLBaseOperator):
     :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
     :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
-    :param task_id: ID of the task instance of the operator
 
     :return: If ``output_table`` is passed this operator returns a Table object. If not
         passed, returns a dataframe.
@@ -50,17 +49,15 @@ class LoadFileOperator(AstroSQLBaseOperator):
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
         enable_native_fallback: bool | None = LOAD_FILE_ENABLE_NATIVE_FALLBACK,
-        task_id: str | None = None,
         **kwargs,
     ) -> None:
-        task_id = task_id or get_unique_task_id("load_file")
+        kwargs.setdefault("task_id", get_unique_task_id("load_file"))
         super().__init__(
-            task_id=task_id,
             **kwargs_with_datasets(
                 kwargs=kwargs,
                 input_datasets=input_file,
                 output_datasets=output_table,
-            ),
+            )
         )
         self.output_table = output_table
         self.input_file = input_file


### PR DESCRIPTION
The SQL CLI render task for the load_file interface when calling LoadFileOperator needs task_id to be available
as part of the initialisation, hence generate a task_id if it is not provided already and pass it to the parent class for initialisation.
## Does this introduce a breaking change?
No


Issue screenshot:
<img width="1657" alt="Screenshot 2022-11-16 at 10 12 26 PM" src="https://user-images.githubusercontent.com/10206082/202240926-fe4250b8-c0db-4d37-97ca-1266fc68eb91.png">
