### PR TITLE
Fix error help for astro-cli

### DIFF
--- a/sql-cli/sql_cli/__init__.py
+++ b/sql-cli/sql_cli/__init__.py
@@ -1,6 +1,13 @@
 import importlib.metadata
 import os
 
+import typer.rich_utils
+
+from sql_cli.utils.rich import rich_format_error
+
+# We monkey-patch rich_format_error to make it environment aware
+typer.rich_utils.rich_format_error = rich_format_error
+
 # TODO: Remove after the `astro-sdk-python` package 1.3 is released
 os.environ["AIRFLOW__CORE__ENABLE_XCOM_PICKLING"] = "True"
 __version__ = importlib.metadata.version("astro-sql-cli")

--- a/sql-cli/sql_cli/utils/rich.py
+++ b/sql-cli/sql_cli/utils/rich.py
@@ -1,0 +1,41 @@
+from typing import Union
+
+import click
+from rich.panel import Panel
+from typer.rich_utils import (
+    ALIGN_ERRORS_PANEL,
+    ERRORS_PANEL_TITLE,
+    STYLE_ERRORS_PANEL_BORDER,
+    STYLE_ERRORS_SUGGESTION,
+    _get_rich_console,
+    highlighter,
+)
+
+from sql_cli.astro.utils import resolve_command_path
+
+
+def rich_format_error(self: click.ClickException) -> None:
+    """Print richly formatted click errors.
+
+    Called by custom exception handler to print richly formatted click errors.
+    Mimics original click.ClickException.echo() function but with rich formatting.
+    """
+    console = _get_rich_console(stderr=True)
+    ctx: Union[click.Context, None] = getattr(self, "ctx", None)
+    if ctx is not None:
+        console.print(ctx.get_usage())
+
+    if ctx is not None and ctx.command.get_help_option(ctx) is not None:
+        console.print(
+            f"Try [blue]'{resolve_command_path(ctx.command_path)} {ctx.help_option_names[0]}'[/] for help.",
+            style=STYLE_ERRORS_SUGGESTION,
+        )
+
+    console.print(
+        Panel(
+            highlighter(self.format_message()),
+            border_style=STYLE_ERRORS_PANEL_BORDER,
+            title=ERRORS_PANEL_TITLE,
+            title_align=ALIGN_ERRORS_PANEL,
+        )
+    )

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -56,6 +56,23 @@ def test_usage(env, usage, args):
     assert usage in get_stdout(result)
 
 
+@pytest.mark.parametrize(
+    "env,try_message",
+    [
+        ({}, "Try 'flow"),
+        ({"ASTRO_CLI": "Yes"}, "Try 'astro flow"),
+    ],
+    ids=[
+        "sql-cli",
+        "astro-cli",
+    ],
+)
+def test_invalid_option(env, try_message):
+    result = runner.invoke(app, ["--foo"], env=env)
+    assert result.exit_code == 2
+    assert try_message in get_stdout(result)
+
+
 def test_about():
     result = runner.invoke(app, ["about"])
     assert result.exit_code == 0


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, when using an unknown flag in astro-cli, it raises (under the condition that the flag is implemented in cobra but not in sql-cli):
> Try 'flow -h' for help.

In case the flag is not implemented in astro-cli cobra, we currently see cobra error output
> Error: unknown flag: --foo

^this needs to be fixed on astro-cli cobra side.

## What is the new behavior?

Monkey-patch rich_format_error to make it environment aware. So that when running in astro-cli it says:
> Try 'astro flow -h' for help.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
