### PR TITLE
Enable benchmark GKE cluster teardown

### DIFF
--- a/python-sdk/tests/benchmark/Makefile
+++ b/python-sdk/tests/benchmark/Makefile
@@ -1,4 +1,4 @@
-all: clean setup_gke container run_job wait_for_completion
+all: clean setup_gke container run_job wait_for_completion teardown_gke
 .PHONY: all
 
 GCP_PROJECT ?= astronomer-dag-authoring


### PR DESCRIPTION
# Description
## What is the current behavior?
currently, the benchmark GKE cluster is up all time

## What is the new behavior?
Delete it since we are running the job just once a week

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
