### PR TITLE
Fix database setting in PostgresDatabase

### DIFF
--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -42,7 +42,7 @@ class PostgresDatabase(BaseDatabase):
         conn = PostgresHook(postgres_conn_id=self.conn_id).get_connection(self.conn_id)
         kwargs = {}
         if (conn.schema is None) and (self.table and self.table.metadata and self.table.metadata.database):
-            kwargs.update({"database": self.table.metadata.schema})
+            kwargs.update({"database": self.table.metadata.database})
         return PostgresHook(postgres_conn_id=self.conn_id, **kwargs)
 
     @property

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -41,7 +41,7 @@ class PostgresDatabase(BaseDatabase):
         """Retrieve Airflow hook to interface with the Postgres database."""
         conn = PostgresHook(postgres_conn_id=self.conn_id).get_connection(self.conn_id)
         kwargs = {}
-        if (conn.schema is None) and (self.table and self.table.metadata and self.table.metadata.schema):
+        if (conn.schema is None) and (self.table and self.table.metadata and self.table.metadata.database):
             kwargs.update({"database": self.table.metadata.schema})
         return PostgresHook(postgres_conn_id=self.conn_id, **kwargs)
 

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -5,8 +5,6 @@ from airflow.configuration import conf
 from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
-# Airflow hook does have option to set the postgres search path or schema's.
-# Let's set postgres_default_schema fallback to public
 POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback=SCHEMA)
 BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHEMA)
 SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -5,7 +5,8 @@ from airflow.configuration import conf
 from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
-POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback=SCHEMA)
+# TODO: Add comments
+POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback="public")
 BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHEMA)
 SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)
 REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHEMA)

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -7,7 +7,7 @@ from astro.constants import DEFAULT_SCHEMA
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
 # Airflow hook does have option to set the postgres search path or schema's.
 # Let's set postgres_default_schema fallback to public
-POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback="public")
+POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback=SCHEMA)
 BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHEMA)
 SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)
 REDSHIFT_SCHEMA = conf.get("astro_sdk", "redshift_default_schema", fallback=SCHEMA)

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -5,7 +5,8 @@ from airflow.configuration import conf
 from astro.constants import DEFAULT_SCHEMA
 
 SCHEMA = conf.get("astro_sdk", "sql_schema", fallback=DEFAULT_SCHEMA)
-# TODO: Add comments
+# Airflow hook does have option to set the postgres search path or schema's.
+# Let's set postgres_default_schema fallback to public
 POSTGRES_SCHEMA = conf.get("astro_sdk", "postgres_default_schema", fallback="public")
 BIGQUERY_SCHEMA = conf.get("astro_sdk", "bigquery_default_schema", fallback=SCHEMA)
 SNOWFLAKE_SCHEMA = conf.get("astro_sdk", "snowflake_default_schema", fallback=SCHEMA)


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, the CI is failing for postgres related tests, because the postgres database is set to the table schema.

**More details:**

In https://github.com/astronomer/astro-sdk/commit/313f6da5fc572a8a35c6fa3db90373a7586be4de#diff-9fcbc9dc6fc68bf0a0d62a485508779f5b1f6d749a197e0f1ab1758983d1eb1e we added `kwargs.update({"database"` but PostgresHook did not support `database` kwarg at that time. This is why it basically did not do anything. Now after https://github.com/apache/airflow/pull/26744 got released in the latest provider, it is being picked up and it shows that we wrongly set `{"database": self.table.metadata.schema}`

## What is the new behavior?

We correctly set the database to the table's database.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
