### PR TITLE
Fix `README.md` to include Xcom pickling enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
 
     ```shell
     export AIRFLOW_HOME=`pwd`
-    export AIRFLOW__CORE__ENABLE_XCOM_PICKLING=True
     airflow db init
     ```
 
-   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled for `astro-sdk-python`. This functionality is now deprecated as our custom xcom backend handles serialization.
-
+   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from `astro-sdk-python` release 1.2 and above. This functionality is now deprecated as our custom xcom backend handles serialization.
+    Users can either use a custom XCom backend [`AstroCustomXcomBackend`](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html) with Xcom pickling disabled (or) enable Xcom pickling.
     Currently, custom XCom backends are limited to data types that are json serializable. Since Dataframes are not json serializable, we need to enable XCom pickling to store dataframes.
 
     The data format used by pickle is Python-specific. This has the advantage that there are no restrictions imposed by external standards such as JSON or XDR (which can’t represent pointer sharing); however it means that non-Python programs may not be able to reconstruct pickled Python objects.


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The quickstart guide for astro sdk doesnt clearly mention the Xcom pickling enhancement introduced in release 1.2

closes: #1203 


## What is the new behavior?

- Included description on pickling and usage of custom xcom backend in `README.md`


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
