### PR TITLE
Change default to generate tasks in generate and run command

### DIFF
--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -66,7 +66,7 @@ def generate(
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
     generate_tasks: bool = typer.Option(
-        default=False,
+        default=True,
         help="whether to explicitly generate the tasks in your SQL CLI "
         "DAG. By default we will keep the DAGs smaller and read SQL "
         "files at runtime",
@@ -153,7 +153,7 @@ def run(
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
     generate_tasks: bool = typer.Option(
-        default=False,
+        default=True,
         help="whether to explicitly generate the tasks in your SQL CLI "
         "DAG. By default we will keep the DAGs smaller and read SQL "
         "files at runtime",

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -67,9 +67,7 @@ def generate(
     ),
     generate_tasks: bool = typer.Option(
         default=True,
-        help="whether to explicitly generate the tasks in your SQL CLI "
-        "DAG. By default we will keep the DAGs smaller and read SQL "
-        "files at runtime",
+        help="whether to explicitly generate the tasks in your SQL CLI DAG",
         show_default=True,
     ),
 ) -> None:
@@ -154,9 +152,7 @@ def run(
     ),
     generate_tasks: bool = typer.Option(
         default=True,
-        help="whether to explicitly generate the tasks in your SQL CLI "
-        "DAG. By default we will keep the DAGs smaller and read SQL "
-        "files at runtime",
+        help="whether to explicitly generate the tasks in your SQL CLI DAG",
         show_default=True,
     ),
     verbose: bool = typer.Option(False, help="Whether to show airflow logs", show_default=True),

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -18,6 +18,45 @@ CWD = pathlib.Path(__file__).parent
 
 
 @pytest.mark.parametrize(
+    "command,options",
+    [
+        (
+            "generate",
+            {
+                "--env": "default",
+                "--generate-tasks": "generate-tasks",
+            },
+        ),
+        (
+            "run",
+            {
+                "--env": "default",
+                "--generate-tasks": "generate-tasks",
+            },
+        ),
+        (
+            "validate",
+            {
+                "--env": "default",
+                "--connection": "None",
+            },
+        ),
+    ],
+    ids=[
+        "generate",
+        "run",
+        "validate",
+    ],
+)
+def test_defaults(command, options):
+    result = runner.invoke(app, [command, "--help"])
+    assert result.exit_code == 0
+    for name, value in options.items():
+        # We expect option name and option value to appear on the same line.
+        assert any(name in line and f"[default: {value}]" in line for line in result.stdout.splitlines())
+
+
+@pytest.mark.parametrize(
     "args",
     [
         ["--help"],


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, the default for generating a DAG is rendering, but temporarily until we have the related PR merged. 

related: #1278

## What is the new behavior?

We should default to generate tasks. So that the user does not need sql-cli installed in the Airflow environment to be able to run the DAGs.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
