### PR TITLE
Silence astronomer logger

### DIFF
--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -31,6 +31,10 @@ airflow_logger = logging.getLogger("airflow")
 airflow_logger.setLevel(logging.CRITICAL)
 airflow_logger.propagate = False
 
+astronomer_logger = logging.getLogger("astronomer")
+astronomer_logger.setLevel(logging.CRITICAL)
+astronomer_logger.propagate = False
+
 
 @app.command(
     cls=AstroCommand,


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, in when running sql-cli in the astro-runtime environment, we see the following logs:
```
[2022-11-22 12:12:08,174] {plugin.py:79} INFO - Creating DB tables for astronomer.airflow.version_check.plugin
[2022-11-22 12:12:08,182] {plugin.py:88} INFO - Create
```

## What is the new behavior?

We silence these logs as we want, by default, to only expose our logs.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
