### PR TITLE
clean table in dataframe test `test_dataframe_replace_table_if_exist`

### DIFF
--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -484,14 +484,17 @@ def test_dataframe_replace_table_if_exist(sample_dag, conn_id):
         arr = {"col1": [1, 2]}
         return pandas.DataFrame(data=arr)
 
-    output_tb = Table(
-        name="ci_df_replace_table",
-        conn_id=conn_id,
-    )
+    output_tb = Table(conn_id=conn_id)
     with sample_dag:
         get_empty_dataframe(output_table=output_tb)
+
     test_utils.run_dag(sample_dag)
     assert output_tb.row_count == 2
     # re-run dag to and make sure it is replacing table
     test_utils.run_dag(sample_dag)
     assert output_tb.row_count == 2
+
+    # drop the table to avoid issue with concurrent
+    with sample_dag:
+        aql.drop_table(table=output_tb)
+    test_utils.run_dag(sample_dag)

--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -494,7 +494,7 @@ def test_dataframe_replace_table_if_exist(sample_dag, conn_id):
     test_utils.run_dag(sample_dag)
     assert output_tb.row_count == 2
 
-    # drop the table to avoid issue with concurrent
+    # drop the table to avoid issue with concurrent test run
     with sample_dag:
         aql.drop_table(table=output_tb)
     test_utils.run_dag(sample_dag)


### PR DESCRIPTION
# Description
Recently, I created a [commit](https://github.com/astronomer/astro-sdk/commit/5f74f26b114c0038a2bde127b8041c0823598720) in which has `test_dataframe_replace_table_if_exist` but this test does not clean up the table and that is causing an issue in the concurrent run  https://github.com/astronomer/astro-sdk/actions/runs/3523069879/jobs/5906787666

## What is the current behavior?
`test_dataframe_replace_table_if_exist` test does not cleanup table

## What is the new behavior?
clean the table which `test_dataframe_replace_table_if_exist`  test is creating and create a tmp table

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
