### PR TITLE
Generate constraints file for multiple Python and Airflow version

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -338,7 +338,7 @@ jobs:
       - run: pip3 list --format=freeze > constraints-${{ matrix.python }}-${{ matrix.airflow }}
       - run: cat constraints-${{ matrix.python }}-${{ matrix.airflow }}
       - name: Upload constraints
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: constraints-${{ matrix.python }}-${{ matrix.airflow }}
           path: ./python-sdk/constraints-${{ matrix.python }}-${{ matrix.airflow }}

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -311,6 +311,39 @@ jobs:
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
 
+  Generate-Constraints:
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [ 3.7, 3.8, 3.9 ]
+        airflow: [ 2.2.5, 2.3.4, 2.4.2 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '${{ matrix.python }}'
+          architecture: 'x64'
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "pip_cache_dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.pip_cache_dir }}
+          key: constraints-${{ matrix.python }}-${{ matrix.airflow }}-${{ hashFiles('python-sdk/pyproject.toml') }}
+      - run: pip3 install -U pip wheel build nox
+      - run: nox -s build
+      - run: pip3 install 'apache-airflow==${{ matrix.airflow }}' "$(ls dist/*.whl)[all]"
+      - run: pip3 list --format=freeze > constraints-${{ matrix.python }}-${{ matrix.airflow }}
+      - run: cat constraints-${{ matrix.python }}-${{ matrix.airflow }}
+      - name: Upload constraints
+        uses: actions/upload-artifact@v2
+        with:
+          name: constraints-${{ matrix.python }}-${{ matrix.airflow }}
+          path: ./python-sdk/constraints-${{ matrix.python }}-${{ matrix.airflow }}
+          if-no-files-found: error
+
   Code-Coverage:
     if: github.event.action != 'labeled'
     needs:
@@ -349,6 +382,7 @@ jobs:
       - Run-Unit-tests-Airflow-2-4
       - Run-Unit-tests-Airflow-2-2-5
       - Run-Optional-Packages-tests-python-sdk
+      - Generate-Constraints
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -111,6 +111,20 @@ def build_docs(session: nox.Session) -> None:
     session.run("make", "html")
 
 
+@nox.session(python=["3.7", "3.8", "3.9"])
+@nox.parametrize("airflow", ["2.2.5", "2.3.4", "2.4.2"])
+def generate_constraints(session: nox.Session, airflow) -> None:
+    """Generate constraints file"""
+    session.install("wheel")
+    session.install(f"apache-airflow=={airflow}", ".[all]")
+    # Log all the installed dependencies
+    session.log("Installed Dependencies:")
+    out = session.run("pip3", "list", "--format=freeze", external=True, silent=True)
+    pathlib.Path(f"constraints-{session.python}-{airflow}.txt").write_text(out)
+    print()
+    print(out)
+
+
 @nox.session()
 def release(session: nox.Session) -> None:
     """Publish a release."""


### PR DESCRIPTION
closes https://github.com/astronomer/astro-sdk/issues/1226

This will display the set of "installable" constraints for a particular Python (3.7, 3.8, 3.9( and Airflow version (2.2.5, 2.3.4, 2.4.2)

As part of every new release, we could push the constraints to a separate branch like in Airflow.

These are also pushed to https://github.com/astronomer/astro-sdk/tree/constraints-1.2.3


