### PR TITLE
Release SQL CLI 0.2.1

### DIFF
--- a/sql-cli/CHANGELOG.md
+++ b/sql-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.1
+
+A patch release containing the following change:
+
+* the `load_file` example now uses SQLite, like the other workflows
+
 ## 0.2.0
 
 A feature release containing the following major features:

--- a/sql-cli/pyproject.toml
+++ b/sql-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astro-sql-cli"
-version = "0.2.0"
+version = "0.2.1"
 description = "Empower analysts to build workflows to transform data using SQL"
 authors = [
     "Astronomer <humans@astronomer.io>",


### PR DESCRIPTION
# Description
## What is the current behavior?
Users are not able to run the `load_file` example workflow when using the `astro flow run` command, from Astro CLI.

## What is the new behavior?
Users are able to run the `load_file` example workflow when using the `astro flow run` command, from Astro CLI.

## Does this introduce a breaking change?
No
