### PR TITLE
Run jobs when PRs are synchronized from forks

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -14,7 +14,7 @@ on:
   # Run on PRs from forks
   pull_request_target:
     branches: [ 'main' ]
-    types: ['labeled']
+    types: ['labeled', 'synchronize']
     paths:
       - 'python-sdk/**'
       - '.github/workflows/ci-python-sdk.yaml'


### PR DESCRIPTION
Currently, PRs from forks are only run when label is created (or recreated) but not when more commits are added to the existing PR that already has the label as shown in https://github.com/astronomer/astro-sdk/pull/1275


### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
