### PR TITLE
Run python-sdk tests with airflow 2.5.0

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -171,9 +171,6 @@ jobs:
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-      # TODO: remove the following env vars after Airflow 2.5 is released
-      AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
-      AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
 
   Run-Unit-tests-Airflow-2-5:
     if: >-
@@ -314,8 +311,6 @@ jobs:
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-      AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
-      AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
 
   Generate-Constraints:
     strategy:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -47,7 +47,6 @@ env:
   SNOWFLAKE_REGION: us-east-1
   SNOWFLAKE_ROLE: AIRFLOW_TEST_USER
   AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: True
-  AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES: airflow.* astro.*
   AIRFLOW_VAR_FOO: templated_file_name
   AWS_BUCKET: tmp9
   GOOGLE_BUCKET: dag-authoring
@@ -176,7 +175,7 @@ jobs:
       AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
       AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
 
-  Run-Unit-tests-Airflow-2-4:
+  Run-Unit-tests-Airflow-2-5:
     if: >-
       github.event_name == 'push' ||
       (
@@ -227,12 +226,12 @@ jobs:
           path: |
             ~/.cache/pip
             .nox
-          key: ${{ runner.os }}-2.3-${{ hashFiles('python-sdk/pyproject.toml') }}
+          key: ${{ runner.os }}-2.5-${{ hashFiles('python-sdk/pyproject.toml') }}
       - run: cat ../.github/ci-test-connections.yaml > test-connections.yaml
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.4')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.5.0')" -- --splits 12 --group ${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:
@@ -249,8 +248,6 @@ jobs:
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-      AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
-      AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
 
   Run-Unit-tests-Airflow-2-2-5:
     if: >-
@@ -325,7 +322,7 @@ jobs:
       fail-fast: false
       matrix:
         python: [ 3.7, 3.8, 3.9 ]
-        airflow: [ 2.2.5, 2.3.4, 2.4.2 ]
+        airflow: [ 2.2.5, 2.3.4, 2.4.2, 2.5.0 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -356,7 +353,7 @@ jobs:
   Code-Coverage:
     if: github.event.action != 'labeled'
     needs:
-      - Run-Unit-tests-Airflow-2-4
+      - Run-Unit-tests-Airflow-2-5
       - Run-Optional-Packages-tests-python-sdk
     runs-on: ubuntu-latest
     steps:
@@ -388,7 +385,7 @@ jobs:
     if: github.event_name == 'release'
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     needs:
-      - Run-Unit-tests-Airflow-2-4
+      - Run-Unit-tests-Airflow-2-5
       - Run-Unit-tests-Airflow-2-2-5
       - Run-Optional-Packages-tests-python-sdk
       - Generate-Constraints

--- a/python-sdk/example_dags/example_dataframe_api.py
+++ b/python-sdk/example_dags/example_dataframe_api.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 from io import StringIO
 from typing import List
@@ -15,6 +16,8 @@ This DAG means to serve as an example of how you can use the @aql.dataframe deco
 API hooks. By requesting the expected data and returning it as a dataframe, our results can now easily pass into
 @task or @aql.transform tasks.
 """
+
+ALLOWED_DESERIALIZATION_CLASSES = os.getenv("AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES")
 
 
 def _load_covid_data():
@@ -45,7 +48,10 @@ def find_worst_covid_month(dfs: List[pd.DataFrame]):
     """
     res = {}
     for covid_month_data in dfs:
-        covid_month = datetime.fromtimestamp(covid_month_data.Date_YMD.iloc[0] / 1e3).strftime("%Y-%m")
+        if ALLOWED_DESERIALIZATION_CLASSES == "airflow.* astro.*":
+            covid_month = datetime.fromtimestamp(covid_month_data.Date_YMD.iloc[0] / 1e3).strftime("%Y-%m")
+        else:
+            covid_month = covid_month_data.Date_YMD.iloc[0].__format__("%Y-%m")
         num_deceased = covid_month_data["Daily Deceased"].sum()
         res[covid_month] = num_deceased
         print(f"Found {num_deceased} dead for month {covid_month}")

--- a/python-sdk/example_dags/example_dataframe_api.py
+++ b/python-sdk/example_dags/example_dataframe_api.py
@@ -45,7 +45,7 @@ def find_worst_covid_month(dfs: List[pd.DataFrame]):
     """
     res = {}
     for covid_month_data in dfs:
-        covid_month = covid_month_data.Date_YMD.iloc[0].__format__("%Y-%m")
+        covid_month = datetime.fromtimestamp(covid_month_data.Date_YMD.iloc[0] / 1e3).strftime("%Y-%m")
         num_deceased = covid_month_data["Daily Deceased"].sum()
         res[covid_month] = num_deceased
         print(f"Found {num_deceased} dead for month {covid_month}")

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -20,7 +20,7 @@ def dev(session: nox.Session) -> None:
 
 
 @nox.session(python=["3.7", "3.8", "3.9"])
-@nox.parametrize("airflow", ["2.2.5", "2.4"])
+@nox.parametrize("airflow", ["2.2.5", "2.4", "2.5.0"])
 def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
     # 2.2.5 requires a certain version of pandas and sqlalchemy
@@ -37,9 +37,26 @@ def test(session: nox.Session, airflow) -> None:
     session.log("Installed Dependencies:")
     session.run("pip3", "freeze")
     AIRFLOW_HOME = f"~/airflow-{airflow}-{session.python}"
-    session.run("airflow", "db", "init", env={"AIRFLOW_HOME": AIRFLOW_HOME})
+    AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES = "airflow.* astro.*"
+    session.run(
+        "airflow",
+        "db",
+        "init",
+        env={
+            "AIRFLOW_HOME": AIRFLOW_HOME,
+            "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES,
+        },
+    )
     # Since pytest is not installed in the nox session directly, we need to set `external=true`.
-    session.run("pytest", *session.posargs, env={"AIRFLOW_HOME": AIRFLOW_HOME}, external=True)
+    session.run(
+        "pytest",
+        *session.posargs,
+        env={
+            "AIRFLOW_HOME": AIRFLOW_HOME,
+            "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES,
+        },
+        external=True,
+    )
 
 
 @nox.session(python=["3.8"])

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -24,7 +24,7 @@ def dev(session: nox.Session) -> None:
 def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
     env = {
-        "AIRFLOW_HOME": f"~/airflow-{airflow}-{session.python}",
+        "AIRFLOW_HOME": f"~/airflow-{airflow}-python-{session.python}",
     }
 
     if airflow == "2.2.5":
@@ -83,10 +83,9 @@ def test_examples_by_dependency(session: nox.Session, extras):
     pytest_args = ["-k", pytest_options]
 
     env = {
-        "AIRFLOW_HOME": f"~/airflow-latest-{session.python}",
+        "AIRFLOW_HOME": "~/airflow-latest-python-latest",
+        "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": "airflow.* astro.*",
     }
-
-    env["AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES"] = "airflow.* astro.*"
 
     session.install("-e", f".[{pypi_deps}]")
     session.install("-e", ".[tests]")

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -23,40 +23,39 @@ def dev(session: nox.Session) -> None:
 @nox.parametrize("airflow", ["2.2.5", "2.4", "2.5.0"])
 def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
-    # 2.2.5 requires a certain version of pandas and sqlalchemy
-    # Otherwise it fails with
-    # Pandas requires version '1.4.0' or newer of 'sqlalchemy' (version '1.3.24' currently installed).
-    constraints_url = (
-        "https://raw.githubusercontent.com/apache/airflow/"
-        f"constraints-{airflow}/constraints-{session.python}.txt"
-    )
-    constraints = ["-c", constraints_url] if airflow == "2.2.5" else []
-    session.install(f"apache-airflow=={airflow}", *constraints)
-    session.install("-e", ".[all,tests]", *constraints)
+    env = {
+        "AIRFLOW_HOME": f"~/airflow-{airflow}-{session.python}",
+    }
+
+    if airflow == "2.2.5":
+        env[
+            "AIRFLOW__CORE__XCOM_BACKEND"
+        ] = "astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend"
+        env["AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV"] = "True"
+
+        # 2.2.5 requires a certain version of pandas and sqlalchemy
+        # Otherwise it fails with
+        # Pandas requires version '1.4.0' or newer of 'sqlalchemy' (version '1.3.24' currently installed).
+        constraints_url = (
+            "https://raw.githubusercontent.com/apache/airflow/"
+            f"constraints-{airflow}/constraints-{session.python}.txt"
+        )
+        session.install(f"apache-airflow=={airflow}", "-c", constraints_url)
+        session.install("-e", ".[all,tests]", "-c", constraints_url)
+    else:
+        env["AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES"] = "airflow.* astro.*"
+
+        session.install(f"apache-airflow=={airflow}")
+        session.install("-e", ".[all,tests]")
+
     # Log all the installed dependencies
     session.log("Installed Dependencies:")
     session.run("pip3", "freeze")
-    AIRFLOW_HOME = f"~/airflow-{airflow}-{session.python}"
-    AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES = "airflow.* astro.*"
-    session.run(
-        "airflow",
-        "db",
-        "init",
-        env={
-            "AIRFLOW_HOME": AIRFLOW_HOME,
-            "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES,
-        },
-    )
+
+    session.run("airflow", "db", "init", env=env)
+
     # Since pytest is not installed in the nox session directly, we need to set `external=true`.
-    session.run(
-        "pytest",
-        *session.posargs,
-        env={
-            "AIRFLOW_HOME": AIRFLOW_HOME,
-            "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES,
-        },
-        external=True,
-    )
+    session.run("pytest", *session.posargs, env=env, external=True)
 
 
 @nox.session(python=["3.8"])

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -632,7 +632,7 @@ class SnowflakeDatabase(BaseDatabase):
                 raise DatabaseCustomError(rows)
         except TypeError:
             # Handle case for apache-airflow-providers-snowflake>=4.0.1
-            if any(row[0]["status"] == COPY_INTO_COMMAND_FAIL_STATUS for row in rows):
+            if any(row[0] == COPY_INTO_COMMAND_FAIL_STATUS for row in rows):
                 raise DatabaseCustomError(rows)
 
     def load_pandas_dataframe_to_table(

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -740,7 +740,7 @@ class SnowflakeDatabase(BaseDatabase):
             created_schemas = [x["SCHEMA_NAME"] for x in schemas]
         except TypeError:
             # Handle case for apache-airflow-providers-snowflake>=4.0.1
-            created_schemas = [x[0]["SCHEMA_NAME"] for x in schemas]
+            created_schemas = [x[0] for x in schemas]
         return len(created_schemas) == 1
 
     def merge_table(

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -137,13 +137,14 @@ class LoadFileOperator(AstroSQLBaseOperator):
                         file.export_to_dataframe(
                             columns_names_capitalization=self.columns_names_capitalization
                         ),
-                    ]
+                    ],
+                    ignore_index=True,
                 )
             else:
                 df = file.export_to_dataframe(columns_names_capitalization=self.columns_names_capitalization)
 
         if not isinstance(df, PandasDataframe):
-            PandasDataframe.from_pandas_df(df)
+            df = PandasDataframe.from_pandas_df(df)
 
         self.log.info("Completed loading the data into dataframe.")
         return df

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -10,6 +10,8 @@ except ImportError:
     from airflow.decorators.base import task_decorator_factory
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
+from sqlalchemy.engine.row import LegacyRow
+
 from astro import settings
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
@@ -39,6 +41,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
 
         if self.handler:
             response = self.handler(result)
+            response = [SdkLegacyRow.from_legacy_row(r) if isinstance(r, LegacyRow) else r for r in response]
             if 0 <= self.response_limit < len(response):
                 raise IllegalLoadToDatabaseException()  # pragma: no cover
             if self.response_size >= 0:
@@ -47,6 +50,21 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
                 return response
         else:
             return None
+
+
+class SdkLegacyRow(LegacyRow):
+    version: int = 1
+
+    def serialize(self):
+        return {"key_map": self._keymap, "key_style": self._key_style, "data": self._data}
+
+    @staticmethod
+    def deserialize(data: dict, version: int):  # skipcq: PYL-W0613
+        return SdkLegacyRow(None, None, data["key_map"], data["key_style"], data["data"])
+
+    @staticmethod
+    def from_legacy_row(obj):
+        return SdkLegacyRow(None, None, obj._keymap, obj._key_style, obj._data)  # skipcq: PYL-W0212
 
 
 def run_raw_sql(

--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -59,7 +59,7 @@ def test_dataframe_from_sql_basic(sample_dag, database_table_fixture):
         from astro.dataframes.pandas import PandasDataframe
 
         assert isinstance(df, PandasDataframe)
-        return df.sell.count()
+        return df.sell.count().tolist()
 
     with sample_dag:
         f = my_df_func(df=test_table)
@@ -151,7 +151,7 @@ def test_dataframe_from_sql_basic_op_arg(sample_dag, database_table_fixture):
         database=getattr(test_table.metadata, "database", None),
     )
     def my_df_func(df: pandas.DataFrame):  # skipcq: PY-D0003
-        return df.sell.count()
+        return df.sell.count().tolist()
 
     with sample_dag:
         res = my_df_func(test_table)
@@ -199,7 +199,7 @@ def test_dataframe_from_sql_basic_op_arg_and_kwarg(
         database=getattr(test_table.metadata, "database", None),
     )
     def my_df_func(df_1: pandas.DataFrame, df_2: pandas.DataFrame):  # skipcq: PY-D0003
-        return df_1.sell.count() + df_2.sell.count()
+        return (df_1.sell.count() + df_2.sell.count()).tolist()
 
     with sample_dag:
         res = my_df_func(test_table, df_2=test_table)

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -321,6 +321,7 @@ def test_aql_load_file_local_file_pattern_dataframe(sample_dag):
     test_df = pd.read_csv(filename)
     test_df_2 = pd.read_csv(filename_2)
     test_df = pd.concat([test_df, test_df_2])
+    test_df.reset_index(drop=True, inplace=True)
 
     from airflow.decorators import task
 

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -1195,37 +1195,6 @@ def test_load_file_col_cap_native_path(sample_dag, database_table_fixture):
     assert cols == ["Acres", "Age", "Baths", "Beds", "List", "Living", "Rooms", "Sell", "Taxes"]
 
 
-@pytest.mark.integration
-@pytest.mark.parametrize(
-    "database_table_fixture",
-    [
-        {
-            "database": Database.SNOWFLAKE,
-        }
-    ],
-    indirect=True,
-    ids=["snowflake"],
-)
-def test_load_file_snowflake_error_out_provider_3_2_0(sample_dag, database_table_fixture):
-    """
-    Test that snowflake errors are bubbled up when the query fails. Loading in snowflake fails with
-     `Numeric value 'id' is not recognized`
-    """
-    _, test_table = database_table_fixture
-    with pytest.raises(DatabaseCustomError):
-        with sample_dag:
-            load_file(
-                input_file=File(
-                    "gs://astro-sdk/benchmark/synthetic-dataset/csv/ten_kb.csv", conn_id="bigquery"
-                ),
-                output_table=test_table,
-                use_native_support=True,
-                enable_native_fallback=False,
-                native_support_kwargs={"storage_integration": "gcs_int_python_sdk"},
-            )
-        test_utils.run_dag(sample_dag)
-
-
 @pytest.mark.parametrize(
     "database_table_fixture",
     [


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we are not running tests on python-sdk with airflow 2.5.0.

related: #1232 

## What is the new behavior?

We add airflow 2.5.0 to noxfile and modify the github workflow to run it.

## Does this introduce a breaking change?

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
