### PR TITLE
Revert "Run jobs when PRs are synchronized from forks (#1311)"

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -14,7 +14,7 @@ on:
   # Run on PRs from forks
   pull_request_target:
     branches: [ 'main' ]
-    types: ['labeled', 'synchronize']
+    types: ['labeled']
     paths:
       - 'python-sdk/**'
       - '.github/workflows/ci-python-sdk.yaml'


### PR DESCRIPTION
This reverts commit 0f075045ce3f02d946b1d6d6d8c914e8d8dcc153.

This is causing tests to be skipped on PRs