### PR TITLE
Serialize dataframe to dict instead of JSON for XCom

### DIFF
--- a/python-sdk/src/astro/dataframes/pandas.py
+++ b/python-sdk/src/astro/dataframes/pandas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import ClassVar
 
-from pandas import DataFrame, read_json
+from pandas import DataFrame
 
 from astro import settings
 
@@ -20,7 +20,7 @@ class PandasDataframe(DataFrame):
         df_size = self.memory_usage(deep=True).sum()
         if df_size < (settings.MAX_DATAFRAME_MEMORY_FOR_XCOM_DB * 1024):
             logger.info("Dataframe size: %s bytes. Storing it in Airflow's metadata DB", df_size)
-            return self.to_json()
+            return self.to_dict()
         else:
             # Avoid cyclic dependency
             from astro.utils.dataframe import convert_dataframe_to_file
@@ -34,7 +34,7 @@ class PandasDataframe(DataFrame):
             return convert_dataframe_to_file(self).to_json()
 
     @staticmethod
-    def deserialize(data: dict | str, version: int):
+    def deserialize(data: dict, version: int):
         if version > 1:
             raise TypeError(f"version > {PandasDataframe.version}")
         if isinstance(data, dict) and data.get("class") == "File":
@@ -45,8 +45,8 @@ class PandasDataframe(DataFrame):
             if file.is_dataframe:
                 logger.info("Retrieving file from %s using %s conn_id ", file.path, file.conn_id)
                 return file.export_to_dataframe()
-            return File
-        return PandasDataframe.from_pandas_df(read_json(data))
+            return file
+        return PandasDataframe.from_pandas_df(PandasDataframe.from_dict(data))
 
     @classmethod
     def from_pandas_df(cls, df: DataFrame) -> PandasDataframe:

--- a/python-sdk/tests/dataframes/pandas.py
+++ b/python-sdk/tests/dataframes/pandas.py
@@ -67,7 +67,7 @@ def test_serialize_deserialize_with_smaller_df():
     # Test that the serialize method will not serialize all the dataframe records to string
     # and instead create a file object and store the records in a file
     s_df = df.serialize()
-    assert s_df == '{"id":{"0":1},"name":{"0":"xyz"}}'
+    assert s_df == {"id": {0: 1}, "name": {0: "xyz"}}
 
     # assert df.equals(exported_file.export_to_dataframe())
     assert df.equals(PandasDataframe.deserialize(s_df, version=1))


### PR DESCRIPTION
There was a bug in https://github.com/astronomer/astro-sdk/issues/1319 where I was converting Dataframe to str, but Airflow's XCom expects it to be a dict as described in http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/concepts/taskflow.html#passing-arbitrary-objects-as-arguments

This meant that when I tried to check Airflow's Xcom page, I saw the following error in Webserver logs:

```
dev-airflow-webserver-1  | [2022-11-30 15:22:34,709] {app.py:1741} ERROR - Exception on /xcom/list/ [GET]
dev-airflow-webserver-1  | Traceback (most recent call last):
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 2525, in wsgi_app
dev-airflow-webserver-1  |     response = self.full_dispatch_request()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1822, in full_dispatch_request
dev-airflow-webserver-1  |     rv = self.handle_user_exception(e)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1820, in full_dispatch_request
dev-airflow-webserver-1  |     rv = self.dispatch_request()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1796, in dispatch_request
dev-airflow-webserver-1  |     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask_appbuilder/security/decorators.py", line 133, in wraps
dev-airflow-webserver-1  |     return f(self, *args, **kwargs)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask_appbuilder/views.py", line 554, in list
dev-airflow-webserver-1  |     widgets = self._list()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask_appbuilder/baseviews.py", line 1164, in _list
dev-airflow-webserver-1  |     widgets = self._get_list_widget(
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask_appbuilder/baseviews.py", line 1063, in _get_list_widget
dev-airflow-webserver-1  |     count, lst = self.datamodel.query(
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/flask_appbuilder/models/sqla/interface.py", line 471, in query
dev-airflow-webserver-1  |     query_results = query.all()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 2759, in all
dev-airflow-webserver-1  |     return self._iter().all()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 1361, in all
dev-airflow-webserver-1  |     return self._allrows()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 400, in _allrows
dev-airflow-webserver-1  |     rows = self._fetchall_impl()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 1274, in _fetchall_impl
dev-airflow-webserver-1  |     return self._real_result._fetchall_impl()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/result.py", line 1686, in _fetchall_impl
dev-airflow-webserver-1  |     return list(self.iterator)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/loading.py", line 151, in chunks
dev-airflow-webserver-1  |     rows = [proc(row) for row in fetch]
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/loading.py", line 151, in <listcomp>
dev-airflow-webserver-1  |     rows = [proc(row) for row in fetch]
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/loading.py", line 984, in _instance
dev-airflow-webserver-1  |     state.manager.dispatch.load(state, context)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/event/attr.py", line 343, in __call__
dev-airflow-webserver-1  |     fn(*args, **kw)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/mapper.py", line 3600, in _event_on_load
dev-airflow-webserver-1  |     instrumenting_mapper._reconstructor(state.obj())
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/airflow/models/xcom.py", line 125, in init_on_load
dev-airflow-webserver-1  |     self.value = self.orm_deserialize_value()
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/airflow/models/xcom.py", line 672, in orm_deserialize_value
dev-airflow-webserver-1  |     return BaseXCom._deserialize_value(self, True)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/airflow/models/xcom.py", line 654, in _deserialize_value
dev-airflow-webserver-1  |     return json.loads(result.value.decode("UTF-8"), cls=XComDecoder, object_hook=object_hook)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/json/__init__.py", line 359, in loads
dev-airflow-webserver-1  |     return cls(**kw).decode(s)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/json/decoder.py", line 337, in decode
dev-airflow-webserver-1  |     obj, end = self.raw_decode(s, idx=_w(s, 0).end())
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/json/decoder.py", line 353, in raw_decode
dev-airflow-webserver-1  |     obj, end = self.scan_once(s, idx)
dev-airflow-webserver-1  |   File "/usr/local/lib/python3.9/site-packages/airflow/utils/json.py", line 255, in orm_object_hook
dev-airflow-webserver-1  |     for k, v in data.items():
dev-airflow-webserver-1  | AttributeError: 'str' object has no attribute 'items'
```



### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
