### PR TITLE
Fix bug with datetime not being serialized

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,16 @@ repos:
       - id: trailing-whitespace
       - id: pretty-format-json
         args: ['--autofix']
-
+      - id: name-tests-test
+        args: ['--pytest-test-first']
+        exclude: |
+          (?x)
+          ^python-sdk/tests/benchmark/.*|
+          ^python-sdk/tests/utils/.*|
+          ^python-sdk/tests/sql/operators/utils.py|
+          ^python-sdk/tests/integration_test_dag.py|
+          ^sql-cli/tests/test_dag/.*$|
+          ^sql-cli/tests/utils.py
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:

--- a/python-sdk/tests/dataframes/test_pandas.py
+++ b/python-sdk/tests/dataframes/test_pandas.py
@@ -67,7 +67,6 @@ def test_serialize_deserialize_with_smaller_df():
     # Test that the serialize method will not serialize all the dataframe records to string
     # and instead create a file object and store the records in a file
     s_df = df.serialize()
-    assert s_df == {"id": {0: 1}, "name": {0: "xyz"}}
+    assert s_df == {"data": '{"id":{"0":1},"name":{"0":"xyz"}}'}
 
-    # assert df.equals(exported_file.export_to_dataframe())
     assert df.equals(PandasDataframe.deserialize(s_df, version=1))


### PR DESCRIPTION
Since Airflow still doesn't support serializing sets or datetime, it would be better to serialize dataframes to string instead of dict.

This PR also adds pre-commit hook so we don't miss `test_`  prefix in the test files