### PR TITLE
Add proper GCS path to export file in `example_google_bigquery_gcs_load_and_save` dag 

### DIFF
--- a/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
+++ b/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
@@ -56,7 +56,7 @@ with DAG(
         task_id="save_file_to_gcs",
         input_data=t1,
         output_file=File(
-            path=f"{gcs_bucket}/{{ task_instance_key_str }}/all_movies.csv",
+            path=f"{gcs_bucket}/{{{{ task_instance_key_str }}}}/all_movies.csv",
             conn_id="gcp_conn",
         ),
         if_exists="replace",
@@ -68,7 +68,7 @@ with DAG(
         task_id="save_dataframe_to_gcs",
         input_data=t2,
         output_file=File(
-            path=f"{gcs_bucket}/{{ task_instance_key_str }}/top_5_movies.csv",
+            path=f"{gcs_bucket}/{{{{ task_instance_key_str }}}}/top_5_movies.csv",
             conn_id="gcp_conn",
         ),
         if_exists="replace",


### PR DESCRIPTION

# Description
## What is the current behavior?
It currently creates a folder with the name {task_instance_key_str} rather than replacing its value in the GCS bucket.
When running openlineage we had an issue. Slack conversation 
https://astronomer.slack.com/archives/C03RTC9BQ4F/p1669884241533159.
![image](https://user-images.githubusercontent.com/92459020/205053334-14c3aad6-e175-4a50-b47a-2d9c1994b234.png)
<!--
-->

## What is the new behavior?
With this PR now a proper GCS path is being created and openlineage runs successfully.
<img width="1845" alt="image" src="https://user-images.githubusercontent.com/92459020/205053683-9d7b3f57-9abc-4218-b984-594ce4af7edc.png">


## Does this introduce a breaking change?
No


closes: #1339 