### PR TITLE
Update the Google Drive as File stores in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
 | Amazon S3   |
 | Filesystem  |
 | Google GCS  |
+| Google Drive|
 
 ## Available operations
 

--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -118,6 +118,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
 | Amazon S3   |
 | Filesystem  |
 | Google GCS  |
+| Google Drive|
 
 ## Available operations
 


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
- Google drive as file store is missing in README.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1345


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Update the Google Drive as File stores in README


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
