### PR TITLE
Fix test: `test_col_case_is_preserved`

### DIFF
--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -432,7 +432,7 @@ def test_col_case_is_preserved(sample_dag):
     def validate(df):  # skipcq: PY-D0003
         cols = list(df.columns)
         cols.sort()
-        return df.columns == ["Colors", "Numbers"]
+        return cols == ["Colors", "Numbers"]
 
     with sample_dag:
         task1 = sample_df_1()


### PR DESCRIPTION
This test was checking a wrong thing, see below:

```python
In [1]: import pandas

In [2]: df = pandas.DataFrame({"Numbers": [1, 2, 3], "Colors": ["red", "white", "blue"]})

In [3]: df.columns
Out[3]: Index(['Numbers', 'Colors'], dtype='object')

In [4]: cols = list(df.columns)

In [5]: cols.sort()

In [6]: df.columns == ["Colors", "Numbers"]
Out[6]: array([False, False])
```

It was returning a numpy array with `False, False` values, instead the test actually was meant to test whether the column case was preserved or not.

part of https://github.com/astronomer/astro-sdk/issues/1337


### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
