### PR TITLE
`LoadFile` should return a dataframe if not using XCom backend

### DIFF
--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -10,6 +10,7 @@ from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy
 from astro.databases import create_database
 from astro.databases.base import BaseDatabase
+from astro.dataframes.pandas import PandasDataframe
 from astro.files import File, check_if_connection_exists, resolve_file_path_pattern
 from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
@@ -140,6 +141,9 @@ class LoadFileOperator(AstroSQLBaseOperator):
                 )
             else:
                 df = file.export_to_dataframe(columns_names_capitalization=self.columns_names_capitalization)
+
+        if not isinstance(df, PandasDataframe):
+            PandasDataframe.from_pandas_df(df)
 
         self.log.info("Completed loading the data into dataframe.")
         return df

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -14,7 +14,6 @@ from astro.files import File, check_if_connection_exists, resolve_file_path_patt
 from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.table import BaseTable
-from astro.utils.dataframe import convert_dataframe_to_file
 from astro.utils.typing_compat import Context
 
 
@@ -83,13 +82,13 @@ class LoadFileOperator(AstroSQLBaseOperator):
             context["ti"].xcom_push(key="output_table_name", value=str(self.output_table.name))
         return self.load_data(input_file=self.input_file)
 
-    def load_data(self, input_file: File) -> BaseTable | File:
+    def load_data(self, input_file: File) -> BaseTable | pd.DataFrame:
 
         self.log.info("Loading %s into %s ...", self.input_file.path, self.output_table)
         if self.output_table:
             return self.load_data_to_table(input_file)
         else:
-            return convert_dataframe_to_file(self.load_data_to_dataframe(input_file))
+            return self.load_data_to_dataframe(input_file)
 
     def load_data_to_table(self, input_file: File) -> BaseTable:
         """


### PR DESCRIPTION
Currently, the `LoadFileOperator` converts dataframe to a File object when returning. However, this should be handled by the Custom XCom backend and not in `LoadFileOperator`. Otherwise, we won't be consistent with dataframe and transform decorators who, too returns dataframes.

From Airflow 2.5 and above, this should be handled automatically, for older versions, users should use our Custom XCom backend so that their XCom table isn't fully of GBs of data.

part of https://github.com/astronomer/astro-sdk/issues/1337

## Does this introduce a breaking change?
No, if you are using our XCom backend. Yes, if you are not! but this fixes the behaviour and makes it consistent with other decorators and operators that return dataframes

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
