### PR TITLE
Improve airflow configuration

### DIFF
--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -43,32 +43,20 @@ def test(session: nox.Session, airflow: str) -> None:
         session.install("pytest-cov")
         session.install("mypy")
         session.install("types-pyyaml")
+
+        session.log("Installed Dependencies:")
+        session.run("pip3", "freeze")
+
+        session.run("pytest")
     else:
         session.install("poetry")
         session.run("poetry", "install", "--with", "dev")
         session.run("poetry", "run", "pip", "install", f"apache-airflow=={airflow}")
 
-    session.log("Installed Dependencies:")
-    session.run("pip3", "freeze")
+        session.log("Installed Dependencies:")
+        session.run("pip3", "freeze")
 
-    # At the moment flow run depends on the Airflow global Airflow Home - we need to fix this
-    # TODO: refactor so each test does this in their own sandboxed Airflow home
-    # From what I observed, the `run` command is the one using this, due to how the method
-    # utils.airflow.get_dag behaves under Airflow 2.2.0 (it defaults to $HOME/airflow)
-    airflow_home = f"~/sql-cli-python-{session.python}-airflow-{airflow}"
-    session.run(
-        "airflow", "db", "init", env={"AIRFLOW_HOME": airflow_home, "AIRFLOW__CORE__LOAD_EXAMPLES": "False"}
-    )
-
-    session.run(
-        "pytest",
-        *session.posargs,
-        "--cov=sql_cli",
-        "--cov-report=xml",
-        "--cov-branch",
-        env={"AIRFLOW_HOME": airflow_home},
-        external=True,
-    )
+        session.run("poetry", "run", "pytest")
 
 
 @nox.session(python=["3.8"])

--- a/sql-cli/sql_cli/__init__.py
+++ b/sql-cli/sql_cli/__init__.py
@@ -8,7 +8,6 @@ from sql_cli.utils.rich import rich_format_error
 # We monkey-patch rich_format_error to make it environment aware
 typer.rich_utils.rich_format_error = rich_format_error
 
-os.environ["_AIRFLOW__AS_LIBRARY"] = "True"  # to prevent airflow whole initialization on airflow import
 # TODO: Remove AIRFLOW__CORE__ENABLE_XCOM_PICKLING after the `astro-sdk-python` package 1.3 is released
 os.environ["AIRFLOW__CORE__ENABLE_XCOM_PICKLING"] = "True"
 os.environ["AIRFLOW__CORE__LAZY_LOAD_PLUGINS"] = "True"

--- a/sql-cli/sql_cli/__init__.py
+++ b/sql-cli/sql_cli/__init__.py
@@ -8,6 +8,11 @@ from sql_cli.utils.rich import rich_format_error
 # We monkey-patch rich_format_error to make it environment aware
 typer.rich_utils.rich_format_error = rich_format_error
 
-# TODO: Remove after the `astro-sdk-python` package 1.3 is released
+os.environ["_AIRFLOW__AS_LIBRARY"] = "True"  # to prevent airflow whole initialization on airflow import
+# TODO: Remove AIRFLOW__CORE__ENABLE_XCOM_PICKLING after the `astro-sdk-python` package 1.3 is released
 os.environ["AIRFLOW__CORE__ENABLE_XCOM_PICKLING"] = "True"
+os.environ["AIRFLOW__CORE__LAZY_LOAD_PLUGINS"] = "True"
+os.environ["AIRFLOW__CORE__LOAD_EXAMPLES"] = "False"
+os.environ["AIRFLOW__LOGGING__LOGGING_LEVEL"] = "CRITICAL"
+
 __version__ = importlib.metadata.version("astro-sql-cli")

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -72,17 +72,10 @@ def generate(
     ),
 ) -> None:
     from sql_cli.project import Project
-    from sql_cli.utils.airflow import retrieve_airflow_database_conn_from_config, set_airflow_database_conn
 
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute)
     project.load_config(env)
-
-    # Since we are using the Airflow ORM to interact with connections, we need to tell Airflow to use our airflow.db
-    # The usual route is to set $AIRFLOW_HOME before Airflow is imported. However, in the context of the SQL CLI, we
-    # decide this during runtime, depending on the project path and SQL CLI configuration.
-    airflow_meta_conn = retrieve_airflow_database_conn_from_config(project.directory / project.airflow_home)
-    set_airflow_database_conn(airflow_meta_conn)
 
     rprint(
         f"\nGenerating the DAG file from workflow [bold blue]{workflow_name}[/bold blue]"
@@ -113,17 +106,10 @@ def validate(
 ) -> None:
     from sql_cli.connections import validate_connections
     from sql_cli.project import Project
-    from sql_cli.utils.airflow import retrieve_airflow_database_conn_from_config, set_airflow_database_conn
 
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute)
     project.load_config(environment=env)
-
-    # Since we are using the Airflow ORM to interact with connections, we need to tell Airflow to use our airflow.db
-    # The usual route is to set $AIRFLOW_HOME before Airflow is imported. However, in the context of the SQL CLI, we
-    # decide this during runtime, depending on the project path and SQL CLI configuration.
-    airflow_meta_conn = retrieve_airflow_database_conn_from_config(project.directory / project.airflow_home)
-    set_airflow_database_conn(airflow_meta_conn)
 
     rprint(f"Validating connection(s) for environment '{env}'")
     validate_connections(connections=project.connections, connection_id=connection)
@@ -161,22 +147,12 @@ def run(
 
     from sql_cli import run_dag as dag_runner
     from sql_cli.project import Project
-    from sql_cli.utils.airflow import (
-        get_dag,
-        retrieve_airflow_database_conn_from_config,
-        set_airflow_database_conn,
-    )
+    from sql_cli.utils.airflow import get_dag
 
     project_dir_absolute = project_dir.resolve() if project_dir else Path.cwd()
     project = Project(project_dir_absolute)
     project.update_config(environment=env)
     project.load_config(env)
-
-    # Since we are using the Airflow ORM to interact with connections, we need to tell Airflow to use our airflow.db
-    # The usual route is to set $AIRFLOW_HOME before Airflow is imported. However, in the context of the SQL CLI, we
-    # decide this during runtime, depending on the project path and SQL CLI configuration.
-    airflow_meta_conn = retrieve_airflow_database_conn_from_config(project.directory / project.airflow_home)
-    set_airflow_database_conn(airflow_meta_conn)
 
     dag_file = _generate_dag(project=project, workflow_name=workflow_name, generate_tasks=generate_tasks)
     dag = get_dag(dag_id=workflow_name, subdir=dag_file.parent.as_posix(), include_examples=False)

--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -34,6 +34,10 @@ def initialise(airflow_home: Path, airflow_dags_folder: Path) -> None:
     # Set airflow environment variables prior to database initialization
     os.environ["AIRFLOW_HOME"] = airflow_home.as_posix()
     os.environ["AIRFLOW__CORE__DAGS_FOLDER"] = airflow_dags_folder.as_posix()
+    if version() >= Version("2.3"):
+        os.environ.pop("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN", None)
+    else:
+        os.environ.pop("AIRFLOW__CORE__SQL_ALCHEMY_CONN", None)
 
     # Reload airflow configuration after setting environment variables
     from airflow import configuration

--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -44,24 +44,8 @@ def initialise(airflow_home: Path, airflow_dags_folder: Path) -> None:
 
     importlib.reload(configuration)
 
-    if version() >= Version("2.4"):
-        # Initialise Airflow settings which is normally being done in __init__
-        from airflow import settings
-
-        importlib.reload(settings)
-        settings.initialize()
-
-        # Initialise the airflow database & hide all logs
-        import logging
-
-        logging.disable()
-        from airflow.utils import db
-
-        importlib.reload(db)
-        db.initdb()
-    else:
-        # Initialise the airflow database & hide all logs
-        os.system("airflow db init &> /dev/null")  # skipcq: BAN-B605
+    # Initialise the airflow database & hide all logs
+    os.system("airflow db init &> /dev/null")  # skipcq: BAN-B605
 
 
 def reload(airflow_home: Path) -> None:
@@ -86,17 +70,10 @@ def reload(airflow_home: Path) -> None:
 
     importlib.reload(configuration)
 
-    if version() >= Version("2.4"):
-        # Initialise airflow settings
-        from airflow import settings
+    # Re-initialise airflow settings
+    import airflow
 
-        importlib.reload(settings)
-        settings.initialize()
-    else:
-        # Re-initialise airflow settings
-        import airflow
-
-        importlib.reload(airflow)
+    importlib.reload(airflow)
 
 
 # The following function was copied from Apache Airflow

--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -45,7 +45,7 @@ def initialise(airflow_home: Path, airflow_dags_folder: Path) -> None:
     importlib.reload(configuration)
 
     # Initialise the airflow database & hide all logs
-    os.system("airflow db init &> /dev/null")  # skipcq: BAN-B605
+    os.system("airflow db init > /dev/null 2>&1")  # skipcq: BAN-B605
 
 
 def reload(airflow_home: Path) -> None:

--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -45,7 +45,7 @@ def initialise(airflow_home: Path, airflow_dags_folder: Path) -> None:
     importlib.reload(configuration)
 
     # Initialise the airflow database & hide all logs
-    os.system("airflow db init > /dev/null 2>&1")  # skipcq: BAN-B605
+    os.system("airflow db init > /dev/null 2>&1")  # skipcq: BAN-B605,BAN-B607
 
 
 def reload(airflow_home: Path) -> None:


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, our airflow configuration consists of settings in the config file as well as in env vars. This PR addresses it by using a single approach.

closes: https://github.com/astronomer/astro-sdk/issues/1219

## What is the new behavior?

We only use env vars for setting airflow configuration. Unfortunately every time we set those, we need to reload the modules for them to read the updated env var.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
