### PR TITLE
Add load local file to databricks Delta Table

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -171,6 +171,7 @@ jobs:
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+      AIRFLOW__ASTRO_SDK__DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
 
   Run-Unit-tests-Airflow-2-5:
     if: >-
@@ -245,6 +246,7 @@ jobs:
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+      AIRFLOW__ASTRO_SDK__DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
 
   Run-Unit-tests-Airflow-2-2-5:
     if: >-
@@ -311,6 +313,7 @@ jobs:
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+      AIRFLOW__ASTRO_SDK__DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
 
   Generate-Constraints:
     strategy:

--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -14,6 +14,7 @@ from airflow.utils.session import create_session, provide_session
 
 from astro.constants import Database, FileLocation, FileType
 from astro.databases import create_database
+from astro.databricks.load_options import default_delta_options
 from astro.table import MAX_TABLE_NAME_LENGTH, Table, TempTable
 from tests.sql.operators import utils as test_utils
 
@@ -140,8 +141,13 @@ def database_table_fixture(request):
 
     database.populate_table_metadata(table)
     database.create_schema_if_needed(table.metadata.schema)
+
     if file:
-        database.load_file_to_table(file, table)
+        database.load_file_to_table(
+            file,
+            table,
+            load_options=default_delta_options,
+        )
     yield database, table
     database.drop_table(table)
 
@@ -204,7 +210,11 @@ def multiple_tables_fixture(request, database_table_fixture):
         database.populate_table_metadata(table)
         database.create_schema_if_needed(table.metadata.schema)
         if file:
-            database.load_file_to_table(file, table)
+            database.load_file_to_table(
+                file,
+                table,
+                load_options=default_delta_options,
+            )
         tables.append(table)
 
     yield tables if len(tables) > 1 else tables[0]

--- a/python-sdk/docs/guides/databricks.rst
+++ b/python-sdk/docs/guides/databricks.rst
@@ -1,0 +1,121 @@
+.. _databricks:
+
+======================
+Databricks Integration
+======================
+Introduction
+
+The Astro Python SDK now allows users to easily access and work with data stored in Databricks through the Delta API.
+
+The Astro Python SDK provides a simple, yet powerful interface for working with Spark and Delta tables in Databricks, allowing users to take advantage of the scalability and performance of Databricks while maintaining the flexibility of Airflow DAG authoring and all the benefits of Airflow scheduling.
+
+Installation
+============
+To use the Astro Python SDK with Databricks, complete the following steps:
+
+The first step is to install the databricks submodule of the astro-sdk-python pip library. This can be done by running the following command:
+
+.. code-block:: bash
+
+    pip install 'astro-sdk-python[databricks]'
+
+The second step is to create a connection to your Databricks cluster.
+This requires creating a `personal access token <https://docs.databricks.com/dev-tools/api/latest/authentication.html>`_ in Databricks and creating a cluster with an http_endpoint. Once you have these, you can create a connection using the following syntax:
+
+
+.. code-block:: yaml
+
+    - conn_id: databricks_conn
+      conn_type: databricks
+      host: https://my-cluster.cloud.databricks.com/
+      password: my-token
+      extra:
+        http_path: /sql/1.0/warehouses/foobar
+
+.. note::
+
+    You need to update the ``password`` with your token from Databricks.
+
+You can also set a default databricks cluster to run all jobs against with this environment variable:
+
+.. code-block:: bash
+
+    AIRFLOW__ASTRO_SDK__DATABRICKS_CLUSTER_ID=<my databricks cluster>
+
+Loading Data
+============
+Once you have installed the astro-sdk package and created a connection to your Databricks cluster, you can begin loading data into your Databricks cluster.
+
+To load data into your Databricks cluster, you can use the same ``aql.load_file()`` function that works for all other databases.
+The only thing that is different with delta is that you now can use the ``delta_options`` parameter to specify delta specific parameters(such as ``copy_options`` and ``format_options`` for the ``COPY INTO`` command).
+Please note that when loading data into Delta using ``COPY INTO``, you must specify the filetype as Databricks does not automatically infer the data (this is not the case for autoloader).
+
+Currently, only local files can be loaded using the ``aql.load_file()`` function. Support for loading data from S3 and GCS will be added soon.
+
+To use the ``aql.load_file()`` function, you will need to specify the path to the file you want to load, the target Delta table you want to pass the result to.g
+
+.. code-block:: python
+
+    aql.load_file(
+        input_file=File("data.csv"),
+        output_table=Table(conn_id="my_databricks_conn"),
+    )
+
+If you have extra options you would like to add, you can user the ``load_options`` parameter to pass ``copy_into_parameters`` into the ``COPY INTO`` command.
+
+Please note that we by default set ``header`` and ``inferSchema`` to true, so if you pass in your own commands you will need to set those values explicitly.
+
+.. code-block:: python
+
+    from astro.databricks.load_options import DeltaLoadOptions
+
+    aql.load_file(
+        input_file=File("data.csv"),
+        output_table=Table(conn_id="my_databricks_conn"),
+        databricks_options=DeltaLoadOptions(copy_into_format_options={"header": "true"}),
+    )
+
+We also offer a ``astro.databricks.load_options.default_delta_options`` for those who do not want to manually set options.
+If you wish to use the defaults, you only need to set the ``AIRFLOW__ASTRO_SDK__DATABRICKS_CLUSTER_ID`` env variable
+so the Astro SDK knows where to send your load_file job.
+
+
+Querying Data
+=============
+Once you have loaded your data into Databricks, you can use the ``aql.transform()`` functions to create queries against the Delta tables. We currently do not support arbitrary Spark Python, but users can pass resulting Delta tables into local Pandas DataFrames (though please be careful of how large of a table you are passing).
+
+For example, you can use the ``aql.transform()`` function decorator to create a query that selects all users over the age of 30 and returns the results as a Pandas DataFrame:
+
+.. code-block:: python
+
+    @aql.transform()
+    def get_eligible_users(user_table):
+        return "SELECT * FROM {{user_table}} WHERE age > 30"
+
+
+    with dag:
+        user_table = aql.load_file(
+            input_file=File("data.csv"),
+            output_table=Table(conn_id="my_databricks_conn"),
+            databricks_options={
+                "copy_into_options": {"format_options": {"header": "true"}}
+            },
+        )
+        results = get_eligible_users(user_table)
+
+Parameterized Queries
+=====================
+
+The aql.transform() function in the Astro Python SDK allows users to create parameterized queries that can be executed with different values for the parameters. This is useful for reusing queries and for preventing SQL injection attacks.
+
+To create a parameterized query, you can use double brackets ({{ and }}) to enclose the parameter names in the query string. The aql.transform() function will replace the parameter names with the corresponding values when the query is executed.
+
+For example, you can create a parameterized query to select all users over a specified age like this:
+
+.. code-block:: python
+
+    @aql.transform()
+    def my_query(table: Table, age: int):
+        return "SELECT * FROM {{ table }} WHERE age > {{ age }}"
+
+The aql.transform() function will replace {{ table }} with users and {{ age }} with 30, and then run the resulting query against the Delta table.

--- a/python-sdk/docs/index.rst
+++ b/python-sdk/docs/index.rst
@@ -22,6 +22,7 @@ Welcome to astro-sdk-python's documentation!
    guides/operators.rst
    guides/xcom_backend.rst
    guides/openlineage.rst
+   guides/databricks.rst
 
 .. toctree::
    :maxdepth: 1

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -15,6 +15,7 @@ from astro.dataframes.pandas import PandasDataframe
 
 if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.engine.cursor import CursorResult
+
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
@@ -32,6 +33,7 @@ from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.files.types import create_file_type
 from astro.files.types.base import FileType as FileTypeConstants
+from astro.options import LoadOptions
 from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK, LOAD_TABLE_AUTODETECT_ROWS_COUNT, SCHEMA
 from astro.table import BaseTable, Metadata
 
@@ -398,12 +400,14 @@ class BaseDatabase(ABC):
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
         enable_native_fallback: bool | None = LOAD_FILE_ENABLE_NATIVE_FALLBACK,
+        load_options: LoadOptions = LoadOptions(),
         **kwargs,
     ):
         """
         Load content of multiple files in output_table.
         Multiple files are sourced from the file path, which can also be path pattern.
 
+        :param load_options: Options for loading into specific data warehouses. Currently supports: databricks
         :param input_file: File path and conn_id for object stores
         :param output_table: Table to create
         :param if_exists: Overwrite file if exists
@@ -732,6 +736,28 @@ class BaseDatabase(ABC):
             self.get_table_qualified_name(table),
             self.get_table_qualified_name(table),
         )
+
+    def row_count(self, table: BaseTable):
+        """
+        Returns the number of rows in a table.
+
+        :param table: table to count
+        :return: The number of rows in the table
+        """
+        result = self.run_sql(
+            f"select count(*) from {self.get_table_qualified_name(table)}"  # skipcq: BAN-B608
+        ).scalar()
+        return result
+
+    def parameterize_variable(self, variable: str):
+        """
+        While most databases use sqlalchemy, we want to open up how we paramaterize variables for databases
+        that a) do not use sqlalchemy and b) have different parameterization schemes (namely delta).
+
+        :param variable: The variable to parameterize.
+        :return: Variable with proper parameters
+        """
+        return ":" + variable
 
     def is_native_load_file_available(  # skipcq: PYL-R0201
         self, source_file: File, target_table: BaseTable  # skipcq: PYL-W0613

--- a/python-sdk/src/astro/databricks/api_utils.py
+++ b/python-sdk/src/astro/databricks/api_utils.py
@@ -1,0 +1,138 @@
+import fileinput
+import logging
+import pathlib
+import time
+from pathlib import Path
+
+from airflow.configuration import conf
+from airflow.exceptions import AirflowException
+from databricks_cli.dbfs.api import DbfsApi, DbfsPath
+from databricks_cli.jobs.api import JobsApi
+from databricks_cli.runs.api import RunsApi
+from databricks_cli.sdk.api_client import ApiClient
+
+from astro.databricks.load_file.load_file_python_code_generator import render
+from astro.databricks.load_options import DeltaLoadOptions
+
+cwd = pathlib.Path(__file__).parent
+log = logging.getLogger(__name__)
+
+
+def generate_file(
+    data_source_path: str,
+    table_name: str,
+    source_type: str,
+    output_file_path: Path,
+    load_options: DeltaLoadOptions,
+    file_type: str = "",
+):
+    """
+    In order to run autoloader jobs in databricks, we need to generate a python file that creates a pyspark job.
+    This function uses jinja templating to generate a file with all necessary user inputs
+
+    :param data_source_path: The path where the data we're injesting lives (e.g. the s3 bucket URL)
+    :param table_name: The delta table we would like to push the data into
+    :param source_type: the source location (e.g. s3)
+    :param load_options: any additional load options the user would like to inject into their job
+    :param output_file_path: where the generated file should be placed.
+    :param file_type: when using the COPY INTO command, Spark requires explicitly stating the data type you are loading.
+        For individual files we can infer the file type, but if you are loading a directory please explicitly state
+        the file type in the File object.
+    :return: output file path
+    """
+    render(
+        Path("jinja_templates/load_file_to_delta.py.jinja2"),
+        {
+            "source_type": source_type,
+            "table_name": table_name,
+            "load_options": load_options,
+            "input_path": data_source_path,
+            "file_type": file_type.upper(),
+        },
+        output_file_path,
+    )
+
+    # Since we had to use jinja2 safe strings, we want to inline replace \' with '
+    # This is not a security concern now that jinja2 is no longer running.
+    for line in fileinput.input(output_file_path, inplace=True):
+        print(line.replace("\\'", "'"), end="")
+    log.debug("Created file %s", output_file_path)
+    return output_file_path
+
+
+def load_file_to_dbfs(local_file_path: Path, file_name: str, api_client: ApiClient) -> Path:
+    # TODO we should allow arbitrary dbfs paths set by env vars/users
+    """Load a file into DBFS. Used to move a python file into DBFS, so we can run the jobs as pyspark jobs.
+    Currently saves the file to dbfs:/mnt/pyscripts/, but will eventually support more locations.
+
+    :param local_file_path: path of the file to upload
+    :param api_client: Databricks API client
+    :return: path to the file in DBFS
+
+    """
+    log.debug("loading file %s", str(local_file_path))
+    dbfs = DbfsApi(api_client=api_client)
+    file_path = DbfsPath("dbfs:/mnt/pyscripts/")
+    dbfs.mkdirs(file_path)
+    dbfs.delete(file_path.join(file_name), recursive=False)
+    dbfs.put_file(src_path=str(local_file_path), dbfs_path=file_path.join(file_name), overwrite=True)
+    return Path("dbfs:/mnt/pyscripts") / file_name
+
+
+def create_and_run_job(
+    api_client,
+    file_to_run: str,
+    databricks_job_name: str,
+    existing_cluster_id=None,
+    new_cluster_specs=None,
+) -> None:
+    """Creates a databricks job and runs it to completion.
+
+    :param databricks_job_name: Name of the job to submit
+    :param file_to_run: path to file we will run with the job
+    :param api_client: databricks API client
+    :param existing_cluster_id: If you want to run this job on an existing cluster, you can give the cluster ID
+    :param new_cluster_specs: If you want to run this job on a new cluster, you can give the cluster specs
+        as a python dictionary.
+
+    """
+    jobs_api = JobsApi(api_client=api_client)
+    json_info = {
+        "name": databricks_job_name,
+        "spark_python_task": {"python_file": file_to_run},
+    }
+
+    if new_cluster_specs:
+        log.debug("creating new spark cluster with spec", new_cluster_specs)
+        json_info["new_cluster"] = new_cluster_specs
+    elif existing_cluster_id:
+        log.debug("Using existing cluster %s", existing_cluster_id)
+        json_info["existing_cluster_id"] = existing_cluster_id
+    else:
+        raise AirflowException("Error, must have a new cluster spec or an existing cluster ID for spark job")
+
+    # TODO find a way to link to existing job so we're not creating a new job id every time
+    job = jobs_api.create_job(json=json_info)
+    log.debug("Created job %s", job["job_id"])
+    run_id = jobs_api.run_now(
+        job_id=job["job_id"],
+        jar_params=None,
+        notebook_params=None,
+        python_params=None,
+        spark_submit_params=None,
+    )["run_id"]
+
+    runs_api = RunsApi(api_client)
+    ping_interval = int(conf.get("astro_sdk", "databricks_ping_interval", fallback=5))
+    while runs_api.get_run(run_id)["state"]["life_cycle_state"] == "PENDING":
+        log.info("job pending")
+        time.sleep(ping_interval)
+
+    while runs_api.get_run(run_id)["state"]["life_cycle_state"] == "RUNNING":
+        log.info("job running")
+        time.sleep(ping_interval)
+    final_job_state = runs_api.get_run(run_id)
+    final_state = final_job_state["state"]["result_state"]
+    log.info("final state: %s", {final_state})
+    if final_state == "FAILED":
+        raise AirflowException(f"Databricks job failed. Job info {final_job_state}")

--- a/python-sdk/src/astro/databricks/delta.py
+++ b/python-sdk/src/astro/databricks/delta.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 from textwrap import dedent
 
 import pandas
+from airflow.providers.databricks.hooks.databricks import DatabricksHook
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook
 from databricks.sql.client import Cursor
+from databricks_cli.sdk.api_client import ApiClient
 from sqlalchemy.engine.base import Engine as SqlAlchemyEngine
 from sqlalchemy.sql import ClauseElement
 
 from astro.constants import DEFAULT_CHUNK_SIZE, ColumnCapitalization, LoadExistStrategy, MergeConflictStrategy
 from astro.databases.base import BaseDatabase
+from astro.databricks.load_file.load_file_job import load_file_to_delta
+from astro.databricks.load_options import DeltaLoadOptions, default_delta_options
 from astro.files import File
+from astro.options import LoadOptions
 from astro.table import BaseTable, Metadata
 
 
@@ -25,8 +30,8 @@ class DeltaDatabase(BaseDatabase):
         # TODO: Do we need default configurations for a delta table?
         """
         Given a table, populates the "metadata" field with what we would consider as "defaults"
-
         These defaults are determined based on environment variables and the connection settings.
+
         :param table: table to be populated
         :return:
         """
@@ -37,6 +42,20 @@ class DeltaDatabase(BaseDatabase):
             else:
                 table.metadata = self.default_metadata
         return table
+
+    @property
+    def api_client(self) -> ApiClient:
+        """
+        Returns the databricks API client. Used for interacting with databricks services like
+        DBFS, Jobs, etc.
+
+        :return: A databricks ApiClient
+        """
+        conn = DatabricksHook(
+            databricks_conn_id=self.conn_id
+        ).get_conn()  # add this because DatabricksSqlHook does not expose password
+        api_client = ApiClient(host=conn.host, token=conn.password)
+        return api_client
 
     @property
     def sql_type(self):
@@ -91,13 +110,19 @@ class DeltaDatabase(BaseDatabase):
         use_native_support: bool = True,
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
-        enable_native_fallback: bool | None = True,
+        enable_native_fallback: bool | None = None,
+        load_options: LoadOptions = DeltaLoadOptions(),
+        databricks_job_name: str = "",
         **kwargs,
     ):
         """
         Load content of multiple files in output_table.
         Multiple files are sourced from the file path, which can also be path pattern.
 
+        :param load_options: options for passing into COPY INTO. currently we support
+            ``format_options`` and ``copy_options``
+        :param databricks_job_name: Create a consistent job name so that we don't litter the databricks job screen.
+            This should be <dag_id>_<task_id>
         :param input_file: File path and conn_id for object stores
         :param output_table: Table to create
         :param if_exists: Overwrite file if exists
@@ -108,8 +133,16 @@ class DeltaDatabase(BaseDatabase):
         :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
         :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
+
         """
-        raise NotImplementedError("Load is not yet implemented")
+        if not isinstance(load_options, DeltaLoadOptions):
+            raise ValueError("Please use a DeltaLoadOption for the load_options parameter")
+        load_file_to_delta(
+            input_file=input_file,
+            delta_table=output_table,
+            databricks_job_name=databricks_job_name,
+            delta_load_options=load_options or default_delta_options,
+        )
 
     def openlineage_dataset_name(self, table: BaseTable) -> str:
         return ""
@@ -134,7 +167,22 @@ class DeltaDatabase(BaseDatabase):
         statement = self._create_table_statement.format(
             self.get_table_qualified_name(target_table), statement
         )
-        self.run_sql(sql=statement, parameters=None)
+        self.run_sql(sql=statement, parameters=parameters)
+
+    def parameterize_variable(self, variable: str) -> str:
+        """
+        Parameterize a variable in a way that the Databricks SQL API can recognize.
+        :param variable: Variable to parameterize
+        :return: The number of rows in the table
+        """
+        return "%(" + variable + ")s"
+
+    def row_count(self, table: BaseTable):
+        result = self.run_sql(
+            f"SELECT COUNT(*) FROM {self.get_table_qualified_name(table)}",
+            handler=lambda x: x.fetchone(),
+        )  # skipcq: BAN-B608
+        return result.asDict()["count(1)"]
 
     def run_sql(
         self,
@@ -213,6 +261,7 @@ class DeltaDatabase(BaseDatabase):
         """
 
         def convert_delta_table_to_df(cur: Cursor) -> pandas.DataFrame:
-            return cur.fetchall_arrow().to_pandas()
+            df = cur.fetchall_arrow().to_pandas()
+            return df
 
-        return self.hook.run(f"SELECT * FROM {source_table.name}", handler=convert_delta_table_to_df)[1]
+        return self.hook.run(f"SELECT * FROM {source_table.name}", handler=convert_delta_table_to_df)

--- a/python-sdk/src/astro/databricks/load_file/jinja_templates/copy_into.py.jinja2
+++ b/python-sdk/src/astro/databricks/load_file/jinja_templates/copy_into.py.jinja2
@@ -1,0 +1,15 @@
+{% macro copy_into_command(file_format, load_options) -%}
+spark.sql(f"CREATE TABLE IF NOT EXISTS {table_name}")
+spark.sql(
+    f"""COPY INTO {table_name} FROM '{src_data_path}' FILEFORMAT={{ file_format }}
+    {%- if load_options.copy_into_format_options|length %}
+    FORMAT_OPTIONS ({{ load_options.convert_format_options_to_string()| safe }})
+    {%-endif %}
+
+    {%- if load_options.copy_into_copy_options|length %}
+    COPY_OPTIONS ({{ load_options.convert_copy_options_to_string()| safe }})
+    {%-endif %}
+    """
+)
+
+{%- endmacro -%}

--- a/python-sdk/src/astro/databricks/load_file/jinja_templates/load_file_to_delta.py.jinja2
+++ b/python-sdk/src/astro/databricks/load_file/jinja_templates/load_file_to_delta.py.jinja2
@@ -1,0 +1,10 @@
+from pyspark.sql.functions import input_file_name, current_timestamp
+
+{% from 'jinja_templates/copy_into.py.jinja2' import copy_into_command -%}
+
+src_data_path = "{{ input_path }}"
+username = spark.sql("SELECT regexp_replace(current_user(), '[^a-zA-Z0-9]', '_')").first()[0]
+table_name = f"{{ table_name }}" # This can be generated based on task ID and dag ID or just entirely random
+checkpoint_path = f"/tmp/{username}/_checkpoint/etl_3_quickstart"
+
+{{ copy_into_command(file_type, load_options) }}

--- a/python-sdk/src/astro/databricks/load_file/load_file_job.py
+++ b/python-sdk/src/astro/databricks/load_file/load_file_job.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pathlib
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from databricks_cli.sdk.api_client import ApiClient
+
+from astro.constants import FileLocation
+from astro.databricks.api_utils import create_and_run_job, generate_file, load_file_to_dbfs
+from astro.databricks.load_options import DeltaLoadOptions
+from astro.files import File
+from astro.table import BaseTable
+
+cwd = pathlib.Path(__file__).parent
+
+supported_file_locations = [FileLocation.LOCAL]
+
+
+def load_file_to_delta(
+    input_file: File,
+    delta_table: BaseTable,
+    databricks_job_name: str,
+    delta_load_options: DeltaLoadOptions,
+):
+    """
+    Load a file object into a databricks delta table
+
+    :param delta_load_options: Loading options for passing data into delta. Things like COPY_OPTIONS, cluster_id, etc.
+    :param databricks_job_name: The name of the job as it will show up in databricks.
+    :param input_file: File to load into delta
+    :param delta_table: a Table object with necessary metadata for accessing the cluster.
+    """
+    from astro.databricks.delta import DeltaDatabase
+
+    db = DeltaDatabase(conn_id=delta_table.conn_id)
+    api_client = db.api_client
+    if input_file.location.location_type not in supported_file_locations:
+        raise ValueError(
+            f"File location {input_file.location.location_type} not yet supported. "
+            f"Currently supported locations: {','.join([str(s) for s in supported_file_locations])}"
+        )
+    dbfs_file_path = None
+    if input_file.location.location_type == FileLocation.LOCAL:
+        dbfs_file_path = _load_load_file_to_dbfs(api_client, input_file)
+
+    with tempfile.NamedTemporaryFile(suffix=".py") as tfile:
+        dbfs_file_path = _create_load_file_pyspark_file(
+            api_client, delta_load_options, dbfs_file_path, delta_table, input_file, tfile
+        )
+    create_and_run_job(
+        api_client=api_client,
+        databricks_job_name=databricks_job_name,
+        existing_cluster_id=delta_load_options.existing_cluster_id,
+        file_to_run=str(dbfs_file_path),
+    )
+
+
+def _create_load_file_pyspark_file(
+    api_client: ApiClient,
+    databricks_options: DeltaLoadOptions,
+    dbfs_file_path: Path | None,
+    delta_table: BaseTable,
+    input_file: File,
+    output_file: Any,
+):
+    if input_file.filetype:
+        file_type = str(input_file.filetype)
+    else:
+        if "." in input_file.path:
+            file_type = input_file.path.split(".")[-1]
+        else:
+            raise ValueError("Can not determine filetype, please include filetype in file class")
+    file_path = generate_file(
+        data_source_path=str(dbfs_file_path) if dbfs_file_path else input_file.path,
+        table_name=delta_table.name,
+        source_type=str(input_file.location.location_type),
+        output_file_path=Path(output_file.name),
+        file_type=file_type or "",
+        load_options=databricks_options,
+    )
+    dbfs_file_path = load_file_to_dbfs(
+        file_path, file_name=f"load_file_{delta_table.name}.py", api_client=api_client
+    )
+    return dbfs_file_path
+
+
+def _load_load_file_to_dbfs(api_client: ApiClient, input_file: File):
+    file_path = Path(input_file.path)
+    dbfs_file_path = load_file_to_dbfs(
+        local_file_path=Path(input_file.path), file_name=file_path.name, api_client=api_client
+    )
+    return dbfs_file_path

--- a/python-sdk/src/astro/databricks/load_file/load_file_python_code_generator.py
+++ b/python-sdk/src/astro/databricks/load_file/load_file_python_code_generator.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jinja2.environment import Environment
+from jinja2.loaders import FileSystemLoader
+from jinja2.runtime import StrictUndefined
+
+
+def render(template_file: Path, context: dict[str, Any], output_file: Path) -> None:
+    """
+    Render the template_file with context to a file.
+
+    :param template_file: The path to the template file.
+    :param context: The context to pass to the template file.
+    :param output_file: The file to output the rendered version.
+    """
+    (
+        Environment(
+            loader=FileSystemLoader(Path(__file__).parent),
+            undefined=StrictUndefined,
+            autoescape=True,
+            keep_trailing_newline=True,
+        )
+        .get_template(template_file.as_posix())
+        .stream(**context)
+        .dump(output_file.as_posix())
+    )

--- a/python-sdk/src/astro/databricks/load_options.py
+++ b/python-sdk/src/astro/databricks/load_options.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from airflow.configuration import conf
+from attr import define, field
+
+from astro.options import LoadOptions
+
+
+@define
+class DeltaLoadOptions(LoadOptions):
+    """Helper class for rendering options into COPY_INTO Databricks SQL statements"""
+
+    copy_into_format_options: dict = field(init=True, factory=dict)
+    copy_into_copy_options: dict = field(init=True, factory=dict)
+    existing_cluster_id: str = conf.get("astro_sdk", "databricks_cluster_id")
+    new_cluster_spec: dict = field(init=True, factory=dict)
+
+    def empty(self):
+        return not (
+            self.copy_into_copy_options
+            and self.copy_into_format_options
+            and self.new_cluster_spec
+            and self.existing_cluster_id
+        )
+
+    def convert_format_options_to_string(self):
+        return ",".join([f"'{k}' = '{v}'" for k, v in self.copy_into_format_options.items()])
+
+    def convert_copy_options_to_string(self):
+        return ",".join([f"'{k}' = '{v}'" for k, v in self.copy_into_copy_options.items()])
+
+
+default_delta_options = DeltaLoadOptions(
+    copy_into_format_options={"header": "true", "inferSchema": "true"},
+    copy_into_copy_options={"mergeSchema": "true"},
+    existing_cluster_id=conf.get("astro_sdk", "databricks_cluster_id"),
+)

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -1,0 +1,7 @@
+from attrs import define
+
+
+@define
+class LoadOptions:
+    def empty(self):
+        return NotImplementedError()

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -188,7 +188,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
                 context[k] = jinja_table_identifier
                 self.parameters[k] = jinja_table_parameter_value
             else:
-                context[k] = ":" + k
+                context[k] = self.database_impl.parameterize_variable(k)
 
         # Render templating in sql query
         if context:

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -13,6 +13,7 @@ from astro.databases import create_database
 from astro.databases.base import BaseDatabase
 from astro.dataframes.pandas import PandasDataframe
 from astro.files import File, resolve_file_path_pattern
+from astro.options import LoadOptions
 from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.sql.operators.base_operator import AstroSQLBaseOperator
 from astro.table import BaseTable
@@ -48,6 +49,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         ndjson_normalize_sep: str = "_",
         use_native_support: bool = True,
         native_support_kwargs: dict | None = None,
+        load_options: LoadOptions = LoadOptions(),
         columns_names_capitalization: ColumnCapitalization = "original",
         enable_native_fallback: bool | None = LOAD_FILE_ENABLE_NATIVE_FALLBACK,
         **kwargs,
@@ -71,6 +73,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         self.native_support_kwargs: dict[str, Any] = native_support_kwargs or {}
         self.columns_names_capitalization = columns_names_capitalization
         self.enable_native_fallback = enable_native_fallback
+        self.load_options = load_options
 
     def execute(self, context: Context) -> BaseTable | File:  # skipcq: PYL-W0613
         """
@@ -82,17 +85,17 @@ class LoadFileOperator(AstroSQLBaseOperator):
         if self.output_table:
             context["ti"].xcom_push(key="output_table_conn_id", value=str(self.output_table.conn_id))
             context["ti"].xcom_push(key="output_table_name", value=str(self.output_table.name))
-        return self.load_data(input_file=self.input_file)
+        return self.load_data(input_file=self.input_file, context=context)
 
-    def load_data(self, input_file: File) -> BaseTable | pd.DataFrame:
+    def load_data(self, input_file: File, context: Context) -> BaseTable | pd.DataFrame:
 
         self.log.info("Loading %s into %s ...", self.input_file.path, self.output_table)
         if self.output_table:
-            return self.load_data_to_table(input_file)
+            return self.load_data_to_table(input_file, context)
         else:
             return self.load_data_to_dataframe(input_file)
 
-    def load_data_to_table(self, input_file: File) -> BaseTable:
+    def load_data_to_table(self, input_file: File, context: Context) -> BaseTable:
         """
         Loads csv/parquet table from local/S3/GCS with Pandas.
         Infers SQL database type based on connection then loads table to db.
@@ -115,6 +118,8 @@ class LoadFileOperator(AstroSQLBaseOperator):
             native_support_kwargs=self.native_support_kwargs,
             columns_names_capitalization=self.columns_names_capitalization,
             enable_native_fallback=self.enable_native_fallback,
+            databricks_job_name=f"Load data {self.dag_id}_{self.task_id}",
+            load_options=self.load_options,
         )
         self.log.info("Completed loading the data into %s.", self.output_table)
         return self.output_table

--- a/python-sdk/src/astro/table.py
+++ b/python-sdk/src/astro/table.py
@@ -117,10 +117,7 @@ class BaseTable:
         Return the row count of table.
         """
         db = create_database(self.conn_id)
-        result = db.run_sql(
-            f"select count(*) from {db.get_table_qualified_name(self)}"  # skipcq: BAN-B608
-        ).scalar()
-        return result
+        return db.row_count(self)
 
     @property
     def sql_type(self) -> Any:

--- a/python-sdk/tests/databricks/test_databricks_api_util.py
+++ b/python-sdk/tests/databricks/test_databricks_api_util.py
@@ -1,0 +1,56 @@
+import pathlib
+from unittest import mock
+from unittest.mock import call
+
+from astro.databricks.api_utils import create_and_run_job, load_file_to_dbfs
+
+CWD = pathlib.Path(__file__).parent
+
+
+@mock.patch("databricks_cli.sdk.api_client.ApiClient")
+def test_create_and_run_job(mock_api_client):
+    create_and_run_job(
+        api_client=mock_api_client,
+        file_to_run="/foo/bar.py",
+        databricks_job_name="my-db-job",
+        existing_cluster_id="foobar",
+    )
+    mock_api_client.perform_query.__getitem__("job_id").return_value = 123
+    calls = [
+        call.perform_query(
+            "POST",
+            "/jobs/create",
+            data={
+                "name": "my-db-job",
+                "spark_python_task": {"python_file": "/foo/bar.py"},
+                "existing_cluster_id": "foobar",
+            },
+            headers=None,
+            version=None,
+        ),
+    ]
+    mock_api_client.assert_has_calls(calls)
+
+
+@mock.patch("databricks_cli.sdk.api_client.ApiClient")
+def test_load_to_dbfs(mock_api_client):
+    load_file_to_dbfs(
+        local_file_path=CWD / "__init__.py", file_name="my_table.py", api_client=mock_api_client
+    )
+    calls = [
+        call.perform_query("POST", "/dbfs/mkdirs", data={"path": "dbfs:/mnt/pyscripts/"}, headers=None),
+        call.perform_query(
+            "POST",
+            "/dbfs/delete",
+            data={"path": "dbfs:/mnt/pyscripts/my_table.py", "recursive": False},
+            headers=None,
+        ),
+        call.perform_query(
+            "POST",
+            "/dbfs/put",
+            data={"path": "dbfs:/mnt/pyscripts/my_table.py", "overwrite": True},
+            headers={"Content-Type": None},
+            files={"file": mock.ANY},
+        ),
+    ]
+    mock_api_client.assert_has_calls(calls)

--- a/python-sdk/tests/databricks/test_delta.py
+++ b/python-sdk/tests/databricks/test_delta.py
@@ -1,7 +1,6 @@
 """Tests specific to the Sqlite Database implementation."""
 import pathlib
 
-import pandas as pd
 import pytest
 import sqlalchemy
 from databricks.sql.types import Row
@@ -10,8 +9,7 @@ from astro.constants import Database
 from astro.databases import create_database
 from astro.databricks.delta import DeltaDatabase
 from astro.files import File
-from astro.table import Table
-from tests.sql.operators import utils as test_utils
+from astro.table import Table, TempTable
 
 DEFAULT_CONN_ID = "databricks_conn"
 CUSTOM_CONN_ID = "databricks_conn"
@@ -37,14 +35,13 @@ def test_delta_run_sql():
     assert response.asDict()["(1 + 1)"] == 2
 
 
-@pytest.mark.xfail
 @pytest.mark.integration
 def test_delta_run_sql_with_parameters():
     """Test running a SQL query using SQLAlchemy templating engine"""
-    statement = "SELECT 1 + ${value};"
+    statement = "SELECT 1 + %(value)s;"
     database = DeltaDatabase(DEFAULT_CONN_ID)
     response = database.run_sql(statement, parameters={"value": 1}, handler=lambda x: x.fetchone())
-    assert response.first()[0] == 2
+    assert response.asDict()["(1 + 1)"] == 2
 
 
 @pytest.mark.integration
@@ -115,7 +112,7 @@ def test_existing_table_exists(database_table_fixture):
     [
         {
             "database": Database.DELTA,
-            "file": File(str(pathlib.Path(CWD.parent, "data/sample.csv"))),
+            "file": File("s3://tmp9/databricks-test/", conn_id="default_aws"),
         }
     ],
     indirect=True,
@@ -125,14 +122,13 @@ def test_create_table_from_select_statement(database_table_fixture):
     """Create a table given a SQL select statement"""
     database, original_table = database_table_fixture
 
-    statement = f"SELECT * FROM {database.get_table_qualified_name(original_table)} WHERE id = 1;"
-    target_table = Table()
+    statement = f"SELECT * FROM {database.get_table_qualified_name(original_table)}"
+    target_table = TempTable(conn_id=database.conn_id)
     database.create_table_from_select_statement(statement, target_table)
 
     df = database.hook.get_pandas_df(f"SELECT * FROM {target_table.name}")
-    assert len(df) == 1
-    expected = pd.DataFrame([{"id": 1, "name": "First"}])
-    test_utils.assert_dataframes_are_equal(df, expected)
+    assert len(df) == 26
+    assert df.NAME[0] == "Dancer"
     database.drop_table(target_table)
 
 

--- a/python-sdk/tests/databricks/test_load.py
+++ b/python-sdk/tests/databricks/test_load.py
@@ -1,0 +1,59 @@
+import pathlib
+
+import pytest
+
+from astro.constants import Database
+from astro.databricks.load_options import default_delta_options
+from astro.files import File
+
+CWD = pathlib.Path(__file__).parent
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.DELTA,
+        }
+    ],
+    indirect=True,
+    ids=["delta"],
+)
+def test_autoloader_load_file_local(database_table_fixture):
+    filepath = str(pathlib.Path(CWD.parent, "data/sample.csv"))
+    database, table = database_table_fixture
+    database.load_file_to_table(
+        input_file=File(filepath),
+        output_table=table,
+        load_options=default_delta_options,
+        databricks_job_name="test_local_local",
+    )
+    assert database.table_exists(table)
+    df = database.export_table_to_pandas_dataframe(table)
+    assert not df.empty
+    assert len(df) == 3
+    assert df.columns.to_list() == ["id", "name"]
+    database.drop_table(table)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.DELTA,
+        }
+    ],
+    indirect=True,
+    ids=["delta"],
+)
+def test_autoloader_load_file_s3(database_table_fixture):
+    with pytest.raises(ValueError):
+        file = File("s3://tmp9/databricks-test/", conn_id="default_aws")
+        database, table = database_table_fixture
+        database.load_file_to_table(
+            input_file=file,
+            output_table=table,
+            load_options=default_delta_options,
+        )

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -19,6 +19,7 @@ from airflow.utils.timezone import datetime
 
 import astro.sql as aql
 from astro.constants import SUPPORTED_DATABASES, Database
+from astro.databricks.load_options import default_delta_options
 from astro.files import File
 from astro.sql.operators.cleanup import CleanupOperator
 from astro.sql.operators.load_file import LoadFileOperator
@@ -33,7 +34,6 @@ SUPPORTED_DATABASES_OBJECTS = [
         "database": database,
     }
     for database in Database
-    if database != Database.DELTA
 ]
 SUPPORTED_DATABASES_OBJECTS_WITH_FILE = [
     {
@@ -41,9 +41,7 @@ SUPPORTED_DATABASES_OBJECTS_WITH_FILE = [
         "file": File(DEFAULT_FILEPATH),
     }
     for database in Database
-    if database != Database.DELTA
 ]
-SUPPORTED_DATABASES.remove("delta")  # pop delta from this value for this class
 
 
 @pytest.mark.integration
@@ -173,9 +171,7 @@ def test_cleanup_multiple_table(database_table_fixture, multiple_tables_fixture)
     [
         {
             "items": [
-                {
-                    "file": File(DEFAULT_FILEPATH),
-                },
+                {"file": File(path=DEFAULT_FILEPATH)},
                 {
                     "file": File(DEFAULT_FILEPATH),
                 },
@@ -220,6 +216,7 @@ def test_cleanup_mapped_task(sample_dag, database_temp_table_fixture):
                 {
                     "input_file": File(path=(CWD.parent.parent / "data/sample.csv").as_posix()),
                     "output_table": temp_table,
+                    "load_options": default_delta_options,
                 }
             ]
         )
@@ -246,6 +243,7 @@ def test_cleanup_default_all_tables_mapped_task(sample_dag, database_temp_table_
                 {
                     "input_file": File(path=(CWD.parent.parent / "data/sample.csv").as_posix()),
                     "output_table": temp_table,
+                    "load_options": default_delta_options,
                 }
             ]
         )

--- a/python-sdk/tests/test_constants.py
+++ b/python-sdk/tests/test_constants.py
@@ -12,5 +12,5 @@ def test_supported_file_types():
 
 
 def test_supported_databases():
-    expected = ["bigquery", "postgres", "redshift", "snowflake", "sqlite"]
+    expected = ["bigquery", "delta", "postgres", "redshift", "snowflake", "sqlite"]
     assert sorted(SUPPORTED_DATABASES) == expected


### PR DESCRIPTION
# Description
## What is the current behavior?

As a first pass for loading files into delta, we will take out any complexity of external data stores and autoloader. This first pass allows loading local files into DBFS that can then become delta tables. That said, everything here is built with the understanding that we will expand into these features.Future PRs.


## What is the new behavior?

Users can now load local files into delta tables using the aql.load_file function.

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
