### PR TITLE
Fix validate_connection not respecting connection_id

### DIFF
--- a/sql-cli/sql_cli/connections.py
+++ b/sql-cli/sql_cli/connections.py
@@ -15,17 +15,13 @@ def validate_connections(connections: list[Connection], connection_id: str | Non
     Validates that the given connections are valid and registers them to Airflow with replace policy for existing
     connections.
     """
-    config_file_contains_connection = False
-
     for connection in connections:
-        if connection.conn_id == connection_id:
-            config_file_contains_connection = True
         os.environ[f"AIRFLOW_CONN_{connection.conn_id.upper()}"] = connection.get_uri()
         status = "[bold green]PASSED[/bold green]" if _is_valid(connection) else "[bold red]FAILED[/bold red]"
         rprint(f"Validating connection {connection.conn_id:{CONNECTION_ID_OUTPUT_STRING_WIDTH}}", status)
 
-    if not config_file_contains_connection:
-        rprint("Error: Config file does not contain given connection", connection_id)
+    if connection_id and not any(connection.conn_id == connection_id for connection in connections):
+        rprint("[bold red]Error: Config file does not contain given connection[/bold red]", connection_id)
 
 
 def _is_valid(connection: Connection) -> bool:


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we always show `Error: Config file does not contain given connection` if the user does not provide a specific connection id.

related: #1125

## What is the new behavior?

Only print the error message if there is not any connection id matching with the already registered connections.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
