### PR TITLE
Fix error when can't connect to remote connection

### DIFF
--- a/sql-cli/sql_cli/run_dag.py
+++ b/sql-cli/sql_cli/run_dag.py
@@ -160,7 +160,7 @@ def _run_task(ti: TaskInstance, session: Session) -> None:
         rprint("[bold red]FAILED[/bold red]")
         orig_exception = operational_exception.orig
         orig_message = orig_exception.args[0]
-        raise ConnectionFailed(orig_message, conn_id=ti.task.conn_id) from orig_exception
+        raise ConnectionFailed(orig_message, conn_id=getattr(ti.task, "conn_id", "")) from orig_exception
     except AstroCleanupException:
         rprint("aql.cleanup async, continuing")
     except Exception:


### PR DESCRIPTION
Currently, we see the following error when Airflow is not able to connect to the remote system using specified by a connection. We make an assumption that `ti.task` will always have an attribute with `conn_id` -- which is a wrong assumption. For example, `LoadFileOperator` does not have that attribute.

Steps to reproduce:

Use the following YAML file in your project to generate the DAG file

```yaml
load_file:
  input_file:
    path: "https://raw.githubusercontent.com/astronomer/astro-sdk/main/tests/data/imdb.csv"
  output_table:
    conn_id: "sqlite_conn"
    metadata:
      schema: "non_existent"
```

It will error with the following:

```
FAILED
  'LoadFileOperator' object has no attribute 'conn_id'
```

However, the actual error is:

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unknown database "non_existent"
[SQL: PRAGMA "non_existent".table_info("load_imdb_movies")]
(Background on this error at: https://sqlalche.me/e/14/e3q8)
```
