### PR TITLE
Correct file path for computing hash used in key for storing cache

### DIFF
--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -46,7 +46,7 @@ jobs:
              ~/.cache/pip
              sql-cli/.nox
              .local
-           key: ${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+           key: type-check-${{ runner.os }}-${{ hashFiles('sql-cli/pyproject.toml') }}
       - run: pip3 install nox
       - run: nox -s type_check
 


### PR DESCRIPTION
Observing that the hash is empty as the filepath is wrong.

<img width="469" alt="Screenshot 2022-12-06 at 8 31 21 PM" src="https://user-images.githubusercontent.com/10206082/205978158-a4d02268-6081-47a8-9d6c-cf93311aa037.png">
