### PR TITLE
Automatically add `from __future__ import annotations`

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,3 +6,4 @@ profile=black
 line_length=110
 combine_as_imports=true
 known_first_party=astro,tests,sql_cli
+add_imports=from __future__ import annotations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,7 +122,7 @@ repos:
       rev: v3.3.1
       hooks:
       -   id: pyupgrade
-          args: [--py37-plus]
+          args: [--py37-plus,--keep-runtime-typing]
           # Exclude auto-generated example files from being changed
           exclude: ^sql-cli/include/base/.airflow/dags
 

--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import string
 from copy import deepcopy

--- a/python-sdk/dev/local_flask_lineage_server.py
+++ b/python-sdk/dev/local_flask_lineage_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/python-sdk/docs/conf.py
+++ b/python-sdk/docs/conf.py
@@ -4,8 +4,9 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
+from __future__ import annotations
 
+# -- Path setup --------------------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/python-sdk/example_dags/calculate_popular_movies.py
+++ b/python-sdk/example_dags/calculate_popular_movies.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 from airflow import DAG

--- a/python-sdk/example_dags/calculate_popular_movies_df.py
+++ b/python-sdk/example_dags/calculate_popular_movies_df.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 import pandas as pd

--- a/python-sdk/example_dags/example_amazon_s3_postgres.py
+++ b/python-sdk/example_dags/example_amazon_s3_postgres.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
 

--- a/python-sdk/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/python-sdk/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from airflow.decorators import dag

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import time
 from datetime import datetime, timedelta

--- a/python-sdk/example_dags/example_append.py
+++ b/python-sdk/example_dags/example_append.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from datetime import datetime, timedelta
 

--- a/python-sdk/example_dags/example_bigquery_dynamic_map_task.py
+++ b/python-sdk/example_dags/example_bigquery_dynamic_map_task.py
@@ -6,6 +6,8 @@ This Example DAG:
     n copy of ``summarize_campaign`` task will be created dynamically
     using dynamic task mapping
 """
+from __future__ import annotations
+
 import os
 from datetime import datetime
 

--- a/python-sdk/example_dags/example_dataframe_api.py
+++ b/python-sdk/example_dags/example_dataframe_api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from datetime import datetime
 from io import StringIO

--- a/python-sdk/example_dags/example_datasets.py
+++ b/python-sdk/example_dags/example_datasets.py
@@ -17,6 +17,8 @@ Pre-requisites:
  - Install dependencies for Astro Python SDK with Postgres, refer to README.md
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 
 from airflow import DAG

--- a/python-sdk/example_dags/example_dynamic_task_template.py
+++ b/python-sdk/example_dags/example_dynamic_task_template.py
@@ -7,8 +7,9 @@ This Example DAG:
 - Dynamically expand on the list of rows to calculate average rating if rating is a valid number.
 """
 
-# [START howto_operator_get_file_list]
+from __future__ import annotations
 
+# [START howto_operator_get_file_list]
 import os
 from datetime import datetime
 

--- a/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
+++ b/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
@@ -12,6 +12,8 @@ Pre-requisites:
  - You can either specify a service account key file and set `GOOGLE_APPLICATION_CREDENTIALS`
     with the file path to the service account.
 """
+from __future__ import annotations
+
 import os
 
 import pandas as pd

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -16,6 +16,8 @@ Pre-requisites for load_file_example_19:
     For sharing a file/folder
     please refer https://www.labnol.org/google-api-service-account-220404#4-share-a-drive-folder
 """
+from __future__ import annotations
+
 import os
 import pathlib
 from datetime import datetime, timedelta

--- a/python-sdk/example_dags/example_merge.py
+++ b/python-sdk/example_dags/example_merge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from datetime import datetime, timedelta
 

--- a/python-sdk/example_dags/example_snowflake_partial_table_with_append.py
+++ b/python-sdk/example_dags/example_snowflake_partial_table_with_append.py
@@ -8,6 +8,8 @@ filtering. The data is then loaded by appending to an existing reporting table.
 This example DAG creates the reporting table & truncates it by the end of the execution.
 """
 
+from __future__ import annotations
+
 import os
 import time
 from datetime import datetime

--- a/python-sdk/example_dags/example_sqlite_load_transform.py
+++ b/python-sdk/example_dags/example_sqlite_load_transform.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 from datetime import datetime
 

--- a/python-sdk/example_dags/example_transform.py
+++ b/python-sdk/example_dags/example_transform.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 
 import pandas as pd

--- a/python-sdk/example_dags/example_transform_file.py
+++ b/python-sdk/example_dags/example_transform_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from pathlib import Path
 

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -1,5 +1,7 @@
 """Nox automation definitions."""
 
+from __future__ import annotations
+
 import pathlib
 
 import nox

--- a/python-sdk/src/astro/__init__.py
+++ b/python-sdk/src/astro/__init__.py
@@ -1,5 +1,7 @@
 """A decorator that allows users to run SQL queries natively in Airflow."""
 
+from __future__ import annotations
+
 __version__ = "1.4.0.dev1"
 
 

--- a/python-sdk/src/astro/custom_backend/astro_custom_backend.py
+++ b/python-sdk/src/astro/custom_backend/astro_custom_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
@@ -41,7 +43,7 @@ class AstroCustomXcomBackend(BaseXCom):
         return BaseXCom.serialize_value(value, **kwargs)
 
     @staticmethod
-    def deserialize_value(result: "XCom") -> Any:
+    def deserialize_value(result: XCom) -> Any:
         """
         Deserializing the result of a xcom_pull before passing th result to the next task.
         :param result:

--- a/python-sdk/src/astro/databricks/api_utils.py
+++ b/python-sdk/src/astro/databricks/api_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import fileinput
 import logging
 import pathlib

--- a/python-sdk/src/astro/exceptions.py
+++ b/python-sdk/src/astro/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class NonExistentTableException(Exception):
     """Raised if an operation expected a SQL table to exist, but it does not exist"""
 

--- a/python-sdk/src/astro/files/__init__.py
+++ b/python-sdk/src/astro/files/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from astro.files.base import File, resolve_file_path_pattern  # noqa: F401 # skipcq: PY-W2000
@@ -6,7 +8,7 @@ if TYPE_CHECKING:
     from airflow.models.xcom_arg import XComArg
 
 
-def get_file_list(path: str, conn_id: str, **kwargs) -> "XComArg":
+def get_file_list(path: str, conn_id: str, **kwargs) -> XComArg:
     """
     List file path from a remote object store or the local filesystem based on the given path pattern.
     It is not advisable to fetch huge number of files since it would overload the XCOM and

--- a/python-sdk/src/astro/files/locations/__init__.py
+++ b/python-sdk/src/astro/files/locations/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 from pathlib import Path
 from typing import Optional

--- a/python-sdk/src/astro/lineage/__init__.py
+++ b/python-sdk/src/astro/lineage/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 log = logging.getLogger(__name__)

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import attr
 
 

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 
 from airflow.configuration import conf

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from airflow.configuration import conf
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg

--- a/python-sdk/src/astro/sql/operators/base_operator.py
+++ b/python-sdk/src/astro/sql/operators/base_operator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC
 
 from airflow.models.baseoperator import BaseOperator

--- a/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
+++ b/python-sdk/src/astro/sql/operators/upstream_task_mixin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from airflow.exceptions import AirflowException
 
 try:

--- a/python-sdk/src/astro/sql/table.py
+++ b/python-sdk/src/astro/sql/table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from astro.table import (  # noqa: F401 # skipcq: PY-W2000
     MAX_TABLE_NAME_LENGTH,
     TEMP_PREFIX,

--- a/python-sdk/src/astro/utils/load.py
+++ b/python-sdk/src/astro/utils/load.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 from typing import Optional
 

--- a/python-sdk/src/astro/utils/typing_compat.py
+++ b/python-sdk/src/astro/utils/typing_compat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, MutableMapping
 
 # The ``airflow.utils.context.Context`` class was not available in Apache Airflow until 2.3.3. This class is

--- a/python-sdk/tests/airflow/test_datasets.py
+++ b/python-sdk/tests/airflow/test_datasets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from unittest import mock
 

--- a/python-sdk/tests/benchmark/analyse.py
+++ b/python-sdk/tests/benchmark/analyse.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import argparse
 import json
 import os

--- a/python-sdk/tests/benchmark/dags/benchmark_gcs_to_big_query.py
+++ b/python-sdk/tests/benchmark/dags/benchmark_gcs_to_big_query.py
@@ -1,6 +1,8 @@
 """
 This DAG is to benchmark GCSToBigQueryOperator for various dataset
 """
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
 

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import gc
 import inspect

--- a/python-sdk/tests/benchmark/settings.py
+++ b/python-sdk/tests/benchmark/settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from ast import literal_eval
 

--- a/python-sdk/tests/benchmark/synthetic_csv_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_csv_generator.py
@@ -1,6 +1,8 @@
 """
 Function to generate csv files of various sizes
 """
+from __future__ import annotations
+
 import csv
 import random
 

--- a/python-sdk/tests/benchmark/synthetic_ndjson_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_ndjson_generator.py
@@ -1,6 +1,8 @@
 """
 Function to generate ndjson files of various sizes
 """
+from __future__ import annotations
+
 import ndjson
 from faker import Faker
 

--- a/python-sdk/tests/benchmark/synthetic_parquet_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_parquet_generator.py
@@ -1,6 +1,8 @@
 """
 Function to generate PARQUET files of various sizes
 """
+from __future__ import annotations
+
 import pandas as pd
 from faker import Faker
 

--- a/python-sdk/tests/custom_backend/test_serializer.py
+++ b/python-sdk/tests/custom_backend/test_serializer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import deque
 
 import numpy as np

--- a/python-sdk/tests/databases/test_base_database.py
+++ b/python-sdk/tests/databases/test_base_database.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pytest

--- a/python-sdk/tests/databases/test_bigquery.py
+++ b/python-sdk/tests/databases/test_bigquery.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from unittest import mock
 

--- a/python-sdk/tests/databases/test_redshift.py
+++ b/python-sdk/tests/databases/test_redshift.py
@@ -1,4 +1,6 @@
 """Tests specific to the Sqlite Database implementation."""
+from __future__ import annotations
+
 from unittest import mock
 
 from airflow.models import Connection

--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -1,4 +1,6 @@
 """Tests specific to the Snowflake Database implementation."""
+from __future__ import annotations
+
 import pathlib
 from unittest.mock import patch
 

--- a/python-sdk/tests/databases/test_sqlite.py
+++ b/python-sdk/tests/databases/test_sqlite.py
@@ -1,5 +1,7 @@
 """Tests specific to the Sqlite Database implementation."""
 
+from __future__ import annotations
+
 import pathlib
 
 import pytest

--- a/python-sdk/tests/databricks/load_file/test_load_file_job.py
+++ b/python-sdk/tests/databricks/load_file/test_load_file_job.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 from unittest.mock import call
 

--- a/python-sdk/tests/databricks/load_file/test_load_python_code_generator.py
+++ b/python-sdk/tests/databricks/load_file/test_load_python_code_generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 from pathlib import Path
 

--- a/python-sdk/tests/databricks/test_databricks_api_util.py
+++ b/python-sdk/tests/databricks/test_databricks_api_util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from unittest import mock
 from unittest.mock import call

--- a/python-sdk/tests/dataframes/test_pandas.py
+++ b/python-sdk/tests/dataframes/test_pandas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pandas as pd

--- a/python-sdk/tests/files/locations/test_gcs.py
+++ b/python-sdk/tests/files/locations/test_gcs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock, patch
 

--- a/python-sdk/tests/files/locations/test_google_drive.py
+++ b/python-sdk/tests/files/locations/test_google_drive.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest

--- a/python-sdk/tests/files/locations/test_http.py
+++ b/python-sdk/tests/files/locations/test_http.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pytest

--- a/python-sdk/tests/files/locations/test_local.py
+++ b/python-sdk/tests/files/locations/test_local.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 import shutil

--- a/python-sdk/tests/files/locations/test_location_base.py
+++ b/python-sdk/tests/files/locations/test_location_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import uuid
 

--- a/python-sdk/tests/files/locations/test_s3.py
+++ b/python-sdk/tests/files/locations/test_s3.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from unittest.mock import patch
 

--- a/python-sdk/tests/files/locations/test_wasb.py
+++ b/python-sdk/tests/files/locations/test_wasb.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 from azure.storage.blob import BlobServiceClient

--- a/python-sdk/tests/files/operators/test_files.py
+++ b/python-sdk/tests/files/operators/test_files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from unittest.mock import patch
 

--- a/python-sdk/tests/files/test_file.py
+++ b/python-sdk/tests/files/test_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import pickle
 from datetime import datetime

--- a/python-sdk/tests/files/type/test_base.py
+++ b/python-sdk/tests/files/type/test_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from astro.constants import FileType
 from astro.files import File
 

--- a/python-sdk/tests/files/type/test_csv.py
+++ b/python-sdk/tests/files/type/test_csv.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 

--- a/python-sdk/tests/files/type/test_json.py
+++ b/python-sdk/tests/files/type/test_json.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 

--- a/python-sdk/tests/files/type/test_ndjson.py
+++ b/python-sdk/tests/files/type/test_ndjson.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import pathlib
 import tempfile

--- a/python-sdk/tests/files/type/test_parquet.py
+++ b/python-sdk/tests/files/type/test_parquet.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import tempfile
 

--- a/python-sdk/tests/files/type/test_type_base.py
+++ b/python-sdk/tests/files/type/test_type_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pytest

--- a/python-sdk/tests/sql/operators/test_append.py
+++ b/python-sdk/tests/sql/operators/test_append.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 from unittest import mock

--- a/python-sdk/tests/sql/operators/test_base_decorator.py
+++ b/python-sdk/tests/sql/operators/test_base_decorator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 
 

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 from unittest import mock

--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from unittest import mock
 

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 

--- a/python-sdk/tests/sql/operators/test_load_file.py
+++ b/python-sdk/tests/sql/operators/test_load_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 from unittest import mock

--- a/python-sdk/tests/sql/operators/test_merge.py
+++ b/python-sdk/tests/sql/operators/test_merge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 from unittest import mock

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pytest

--- a/python-sdk/tests/sql/test_table.py
+++ b/python-sdk/tests/sql/test_table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 from datetime import datetime
 from unittest import mock

--- a/python-sdk/tests/test_constants.py
+++ b/python-sdk/tests/test_constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from astro.constants import SUPPORTED_DATABASES, SUPPORTED_FILE_LOCATIONS, SUPPORTED_FILE_TYPES
 
 

--- a/python-sdk/tests/utils/airflow.py
+++ b/python-sdk/tests/utils/airflow.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pendulum

--- a/python-sdk/tests/utils/test_dataframe.py
+++ b/python-sdk/tests/utils/test_dataframe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 
 from astro.dataframes.pandas import PandasDataframe

--- a/python-sdk/tests/utils/test_path.py
+++ b/python-sdk/tests/utils/test_path.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 from astro import databases, settings

--- a/python-sdk/tests/utils/test_table.py
+++ b/python-sdk/tests/utils/test_table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/python-sdk/tests_integration/conftest.py
+++ b/python-sdk/tests_integration/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 import random

--- a/python-sdk/tests_integration/databases/test_all_databases.py
+++ b/python-sdk/tests_integration/databases/test_all_databases.py
@@ -1,4 +1,6 @@
 """Tests all Database implementations."""
+from __future__ import annotations
+
 import pathlib
 from unittest import mock
 

--- a/python-sdk/tests_integration/databases/test_base_database.py
+++ b/python-sdk/tests_integration/databases/test_base_database.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/python-sdk/tests_integration/databases/test_bigquery.py
+++ b/python-sdk/tests_integration/databases/test_bigquery.py
@@ -1,4 +1,6 @@
 """Tests specific to the Sqlite Database implementation."""
+from __future__ import annotations
+
 import os
 import pathlib
 from unittest import mock

--- a/python-sdk/tests_integration/databases/test_postgres.py
+++ b/python-sdk/tests_integration/databases/test_postgres.py
@@ -1,4 +1,6 @@
 """Tests specific to the Sqlite Database implementation."""
+from __future__ import annotations
+
 import os
 import pathlib
 from urllib.parse import urlparse

--- a/python-sdk/tests_integration/databases/test_redshift.py
+++ b/python-sdk/tests_integration/databases/test_redshift.py
@@ -1,4 +1,6 @@
 """Tests specific to the Sqlite Database implementation."""
+from __future__ import annotations
+
 import os
 import pathlib
 import re

--- a/python-sdk/tests_integration/databases/test_snowflake.py
+++ b/python-sdk/tests_integration/databases/test_snowflake.py
@@ -1,4 +1,6 @@
 """Tests specific to the Snowflake Database implementation."""
+from __future__ import annotations
+
 import os
 import pathlib
 from unittest import mock

--- a/python-sdk/tests_integration/databases/test_sqlite.py
+++ b/python-sdk/tests_integration/databases/test_sqlite.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 

--- a/python-sdk/tests_integration/databricks/test_databricks_api_util.py
+++ b/python-sdk/tests_integration/databricks/test_databricks_api_util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from unittest import mock
 from unittest.mock import Mock, call

--- a/python-sdk/tests_integration/databricks/test_delta.py
+++ b/python-sdk/tests_integration/databricks/test_delta.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pytest

--- a/python-sdk/tests_integration/databricks/test_load.py
+++ b/python-sdk/tests_integration/databricks/test_load.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pytest

--- a/python-sdk/tests_integration/extractors/test_extractor.py
+++ b/python-sdk/tests_integration/extractors/test_extractor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pandas as pd

--- a/python-sdk/tests_integration/files/locations/test_gcs.py
+++ b/python-sdk/tests_integration/files/locations/test_gcs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from google.cloud.storage import Client
 

--- a/python-sdk/tests_integration/files/locations/test_google_drive.py
+++ b/python-sdk/tests_integration/files/locations/test_google_drive.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest

--- a/python-sdk/tests_integration/files/locations/test_http.py
+++ b/python-sdk/tests_integration/files/locations/test_http.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from astro.files.locations import create_file_location

--- a/python-sdk/tests_integration/files/locations/test_s3.py
+++ b/python-sdk/tests_integration/files/locations/test_s3.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from astro.files.locations.amazon.s3 import S3Location

--- a/python-sdk/tests_integration/files/locations/test_wasb.py
+++ b/python-sdk/tests_integration/files/locations/test_wasb.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/python-sdk/tests_integration/files/test_file.py
+++ b/python-sdk/tests_integration/files/test_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import mock_open, patch
 
 import pandas as pd

--- a/python-sdk/tests_integration/integration_test_dag.py
+++ b/python-sdk/tests_integration/integration_test_dag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pandas as pd

--- a/python-sdk/tests_integration/sql/operators/test_append.py
+++ b/python-sdk/tests_integration/sql/operators/test_append.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pandas as pd

--- a/python-sdk/tests_integration/sql/operators/test_cleanup.py
+++ b/python-sdk/tests_integration/sql/operators/test_cleanup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import airflow

--- a/python-sdk/tests_integration/sql/operators/test_dataframe.py
+++ b/python-sdk/tests_integration/sql/operators/test_dataframe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 from unittest import mock

--- a/python-sdk/tests_integration/sql/operators/test_drop_table.py
+++ b/python-sdk/tests_integration/sql/operators/test_drop_table.py
@@ -1,5 +1,7 @@
 """Tests to cover the drop table function"""
 
+from __future__ import annotations
+
 import pathlib
 
 import pandas

--- a/python-sdk/tests_integration/sql/operators/test_export_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_export_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 import tempfile

--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 from unittest import mock

--- a/python-sdk/tests_integration/sql/operators/test_merge.py
+++ b/python-sdk/tests_integration/sql/operators/test_merge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import pathlib
 

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import pathlib
 

--- a/python-sdk/tests_integration/sql/operators/test_snowflake_merge_func.py
+++ b/python-sdk/tests_integration/sql/operators/test_snowflake_merge_func.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/python-sdk/tests_integration/sql/operators/test_upstream_tasks.py
+++ b/python-sdk/tests_integration/sql/operators/test_upstream_tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 
 import pytest

--- a/python-sdk/tests_integration/sql/operators/test_upstream_tasks.py
+++ b/python-sdk/tests_integration/sql/operators/test_upstream_tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pathlib
 
+import pandas
 import pytest
 
 from astro import sql as aql
@@ -27,7 +28,6 @@ cwd = pathlib.Path(__file__).parent
     ids=["snowflake", "bigquery", "postgresql", "sqlite"],
 )
 def test_raw_sql_chained_queries(database_table_fixture, sample_dag):
-    import pandas
 
     db, test_table = database_table_fixture
 

--- a/python-sdk/tests_integration/sql/operators/transform/test_postgres_transform.py
+++ b/python-sdk/tests_integration/sql/operators/transform/test_postgres_transform.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pandas as pd
 import pytest
 from airflow.models import DAG, DagRun, TaskInstance as TI

--- a/python-sdk/tests_integration/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests_integration/sql/operators/transform/test_transform.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pathlib
 

--- a/python-sdk/tests_integration/sql/test_table.py
+++ b/python-sdk/tests_integration/sql/test_table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import socket
 from unittest import mock
 

--- a/python-sdk/tests_integration/utils/test_table.py
+++ b/python-sdk/tests_integration/utils/test_table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from astro.constants import Database

--- a/sql-cli/conftest.py
+++ b/sql-cli/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import shutil
 import string

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -1,5 +1,7 @@
 """Nox automation definitions."""
 
+from __future__ import annotations
+
 import pathlib
 
 import nox

--- a/sql-cli/sql_cli/__init__.py
+++ b/sql-cli/sql_cli/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.metadata
 import os
 

--- a/sql-cli/sql_cli/astro/command.py
+++ b/sql-cli/sql_cli/astro/command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 import typer
 from typer.core import TyperCommand

--- a/sql-cli/sql_cli/astro/group.py
+++ b/sql-cli/sql_cli/astro/group.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 import typer
 from typer.core import TyperGroup

--- a/sql-cli/sql_cli/astro/utils.py
+++ b/sql-cli/sql_cli/astro/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 

--- a/sql-cli/sql_cli/constants.py
+++ b/sql-cli/sql_cli/constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 CONFIG_DIR = "config"
 GLOBAL_CONFIG_FILENAME = "global.yml"
 CONFIG_FILENAME = "configuration.yml"

--- a/sql-cli/sql_cli/exceptions.py
+++ b/sql-cli/sql_cli/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class DagCycle(Exception):
     """An exception raised when DAG contains a cycle."""
 

--- a/sql-cli/sql_cli/utils/rich.py
+++ b/sql-cli/sql_cli/utils/rich.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import IO, Any, Optional, Union
 
 import click

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from tempfile import gettempdir
 from unittest import mock

--- a/sql-cli/tests/test_configuration.py
+++ b/sql-cli/tests/test_configuration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from sql_cli.configuration import Config

--- a/sql-cli/tests/test_connections.py
+++ b/sql-cli/tests/test_connections.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from unittest.mock import patch
 

--- a/sql-cli/tests/test_dag/dataframe_dag.py
+++ b/sql-cli/tests/test_dag/dataframe_dag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime
 from io import StringIO

--- a/sql-cli/tests/test_dag/sqlite_test.py
+++ b/sql-cli/tests/test_dag/sqlite_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from datetime import datetime

--- a/sql-cli/tests/test_dag_generator.py
+++ b/sql-cli/tests/test_dag_generator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/sql-cli/tests/test_project.py
+++ b/sql-cli/tests/test_project.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from sql_cli.project import Project

--- a/sql-cli/tests/test_run_dag.py
+++ b/sql-cli/tests/test_run_dag.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import sqlite3
 from unittest import mock

--- a/sql-cli/tests/test_workflow_directory_parser.py
+++ b/sql-cli/tests/test_workflow_directory_parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 


### PR DESCRIPTION
This PR automatically adds `from __future__ import annotations` to all the Python files so that we can take advantage of the lazy imports

It uses https://pycqa.github.io/isort/docs/configuration/options.html#add-imports from isort


