### PR TITLE
Redirect default airflow_home to tmp directory in tests

### DIFF
--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -140,8 +140,6 @@ jobs:
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
       AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
       AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
-      TERMINAL_WIDTH: 3000
-      _TYPER_FORCE_DISABLE_TERMINAL: 1
 
 
   Code-Coverage:

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -42,8 +42,8 @@ def test(session: nox.Session, airflow: str) -> None:
         )
         # We are duplicating the tests dependencies until we find a better solution.
         # The solution might be to move out of poetry.
-        dev = ("pytest", "pytest-cov", "mypy", "types-pyyaml")
-        session.run("poetry", "run", "pip", "install", "-e", ".", *dev, "-c", constraints_url)
+        dev_deps = ("pytest", "pytest-cov", "mypy", "types-pyyaml")
+        session.run("poetry", "run", "pip", "install", "-e", ".", *dev_deps, "-c", constraints_url)
         session.run("poetry", "run", "pip", "install", f"apache-airflow=={airflow}", "-c", constraints_url)
     else:
         session.run("poetry", "install", "--with", "dev")

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -54,7 +54,11 @@ def test(session: nox.Session, airflow: str) -> None:
     session.log("Installed Dependencies:")
     session.run("poetry", "run", "pip", "freeze")
 
-    session.run("poetry", "run", "pytest", *session.posargs)
+    pytest_env = {
+        "TERMINAL_WIDTH": "3000",
+        "_TYPER_FORCE_DISABLE_TERMINAL": "1",
+    }
+    session.run("poetry", "run", "pytest", *session.posargs, env=pytest_env)
 
 
 @nox.session(python=["3.8"])

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -25,11 +25,13 @@ def dev(session: nox.Session) -> None:
 def test(session: nox.Session, airflow: str) -> None:
     """Run both unit and integration tests."""
 
-    session.virtualenv.env = {
-        # Airflow automatically creates the ~/airflow directory on importing airflow
-        # but we are not using this directory hence we change the home to a tmp directory to avoid side effects.
-        "AIRFLOW_HOME": session.create_tmp(),
-    }
+    session.virtualenv.env.update(
+        {
+            # Airflow automatically creates the ~/airflow directory on importing airflow
+            # but we are not using this directory hence we change the home to a tmp directory to avoid side effects.
+            "AIRFLOW_HOME": session.create_tmp(),
+        }
+    )
 
     session.install("poetry")
 

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -34,16 +34,16 @@ def test(session: nox.Session, airflow: str) -> None:
     session.install("poetry")
 
     if airflow.startswith("2.2."):
-        # We are duplicating the tests dependencies until we find a better solution.
-        # The solution might be to move out of poetry.
-        dev = ("pytest", "pytest-cov", "mypy", "types-pyyaml")
-        session.run("poetry", "run", "pip", "install", "-e", ".", *dev)
         # To install some versions of Airflow, we need constraints, due to issues like:
         # https://github.com/apache/airflow/issues/19804
         constraints_url = (
             "https://raw.githubusercontent.com/apache/airflow/"
             f"constraints-{airflow}/constraints-{session.python}.txt"
         )
+        # We are duplicating the tests dependencies until we find a better solution.
+        # The solution might be to move out of poetry.
+        dev = ("pytest", "pytest-cov", "mypy", "types-pyyaml")
+        session.run("poetry", "run", "pip", "install", "-e", ".", *dev, "-c", constraints_url)
         session.run("poetry", "run", "pip", "install", f"apache-airflow=={airflow}", "-c", constraints_url)
     else:
         session.run("poetry", "install", "--with", "dev")

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -45,6 +45,8 @@ def test(session: nox.Session, airflow: str) -> None:
         # We are duplicating the tests dependencies until we find a better solution.
         # The solution might be to move out of poetry.
         dev_deps = ("pytest", "pytest-cov", "mypy", "types-pyyaml")
+        # Poetry does not support constraints:
+        # https://github.com/python-poetry/poetry/issues/3225
         session.run("poetry", "run", "pip", "install", "-e", ".", *dev_deps, "-c", constraints_url)
         session.run("poetry", "run", "pip", "install", f"apache-airflow=={airflow}", "-c", constraints_url)
     else:

--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -34,8 +34,8 @@ def test(session: nox.Session, airflow: str) -> None:
     if airflow.startswith("2.2."):
         # We are duplicating the tests dependencies until we find a better solution.
         # The solution might be to move out of poetry.
-        session.install("-e", ".", "pytest", "pytest-cov", "mypy", "types-pyyaml")
-
+        dev = ("pytest", "pytest-cov", "mypy", "types-pyyaml")
+        session.install("-e", ".", *dev)
         # To install some versions of Airflow, we need constraints, due to issues like:
         # https://github.com/apache/airflow/issues/19804
         constraints_url = (


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, when testing with different versions of airflow locally, sometimes airflow still writes to the default airflow home directory. However, we are not using the default.

**Note:**
We are setting the `AIRFLOW_HOME` on project init, but not before that. Therefore any airflow import before that will write to the default airflow home directory.

## What is the new behavior?

Set the default airflow home to a new tmp directory. So that any call before calling project init writes to the tmp directory.

We also migrate all installs to explicitly use `poetry run` to ensure we are always installing to the correct venv. And we move typer env vars from workflow file to noxfile to be able to run nox locally with the same required env vars.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
