### PR TITLE
Add working examples and tests for all supported connection types

### DIFF
--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -91,6 +91,7 @@ jobs:
             sql-cli/.nox
             .local/
           key: sql-cli-tests-os-${{ runner.os }}-python-${{ matrix.python }}-airflow-${{ matrix.airflow }}-deps-${{ hashFiles('sql-cli/poetry.lock') }}
+      - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: pip3 install nox
       - run: nox -s "test-${{ matrix.python }}(airflow='${{ matrix.airflow }}')"
       - name: Upload coverage
@@ -99,6 +100,8 @@ jobs:
           name: coverage-${{ matrix.python }}-${{ matrix.airflow }}
           path: ./sql-cli/.coverage
     env:
+      GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
       AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
       AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
       TERMINAL_WIDTH: 3000

--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -46,6 +46,19 @@ jobs:
   Type-Check:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: dimberman/pagila-test
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --name postgres
+        ports:
+          - 5432:5432
     env:
       MYPY_FORCE_COLOR: 1
       TERM: xterm-color

--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -46,19 +46,6 @@ jobs:
   Type-Check:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: dimberman/pagila-test
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          --name postgres
-        ports:
-          - 5432:5432
     env:
       MYPY_FORCE_COLOR: 1
       TERM: xterm-color
@@ -99,6 +86,19 @@ jobs:
         python: [ 3.8, 3.9 ]
         airflow: [ 2.2.5, 2.3.4, 2.4, 2.5 ]
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: dimberman/pagila-test
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          --name postgres
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'

--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -26,6 +26,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# This list should only have non-sensitive env vars
+# Env vars with secrets should be in the specific jobs
+env:
+  POSTGRES_HOST: postgres
+  POSTGRES_PORT: 5432
+  REDSHIFT_DATABASE: dev
+  REDSHIFT_HOST: utkarsh-cluster.cdru7mxqmtyx.us-east-2.redshift.amazonaws.com
+  SNOWFLAKE_SCHEMA: ASTROFLOW_CI
+  SNOWFLAKE_DATABASE: SANDBOX
+  SNOWFLAKE_WAREHOUSE: DEMO
+  SNOWFLAKE_HOST: https://gp21411.us-east-1.snowflakecomputing.com
+  SNOWFLAKE_ACCOUNT: gp21411
+  SNOWFLAKE_REGION: us-east-1
+  SNOWFLAKE_ROLE: AIRFLOW_TEST_USER
+
 jobs:
   Type-Check:
     if: github.event.action != 'labeled'
@@ -102,6 +117,14 @@ jobs:
     env:
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN: ${{ secrets.REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN }}
+      REDSHIFT_USERNAME: ${{ secrets.REDSHIFT_USERNAME }}
+      REDSHIFT_PASSWORD: ${{ secrets.REDSHIFT_PASSWORD }}
+      SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
+      SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
       AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
       AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
       TERMINAL_WIDTH: 3000

--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -29,6 +29,7 @@ concurrency:
 # This list should only have non-sensitive env vars
 # Env vars with secrets should be in the specific jobs
 env:
+  GOOGLE_CLOUD_PROJECT: astronomer-dag-authoring
   POSTGRES_HOST: postgres
   POSTGRES_PORT: 5432
   REDSHIFT_DATABASE: dev
@@ -117,6 +118,7 @@ jobs:
     env:
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
+      GOOGLE_CLOUD_KEY_PATH: /tmp/google_credentials.json
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN: ${{ secrets.REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN }}

--- a/.github/workflows/ci-sql-cli.yaml
+++ b/.github/workflows/ci-sql-cli.yaml
@@ -134,12 +134,10 @@ jobs:
       GOOGLE_CLOUD_KEY_PATH: /tmp/google_credentials.json
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN: ${{ secrets.REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN }}
       REDSHIFT_USERNAME: ${{ secrets.REDSHIFT_USERNAME }}
       REDSHIFT_PASSWORD: ${{ secrets.REDSHIFT_PASSWORD }}
       SNOWFLAKE_ACCOUNT_NAME: ${{ secrets.SNOWFLAKE_UNAME }}
       SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
       AIRFLOW__CORE__XCOM_BACKEND: astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend
       AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV: True
       TERMINAL_WIDTH: 3000

--- a/sql-cli/conftest.py
+++ b/sql-cli/conftest.py
@@ -177,15 +177,6 @@ def initialised_project_with_custom_airflow_config(tmp_path):
 
 
 @pytest.fixture()
-def initialised_project_with_test_config(initialised_project: Project):
-    shutil.copytree(
-        src=CWD / "tests" / "config" / "test",
-        dst=initialised_project.directory / "config" / "test",
-    )
-    return initialised_project
-
-
-@pytest.fixture()
 def initialised_project_with_sqlite_non_existent_host_path_config(initialised_project: Project):
     sqlite_non_existent_host_path = "sqlite_non_existent_host_path"
     shutil.copytree(

--- a/sql-cli/conftest.py
+++ b/sql-cli/conftest.py
@@ -177,6 +177,15 @@ def initialised_project_with_custom_airflow_config(tmp_path):
 
 
 @pytest.fixture()
+def initialised_project_with_test_config(initialised_project: Project):
+    shutil.copytree(
+        src=CWD / "tests" / "config" / "test",
+        dst=initialised_project.directory / "config" / "test",
+    )
+    return initialised_project
+
+
+@pytest.fixture()
 def initialised_project_with_sqlite_non_existent_host_path_config(initialised_project: Project):
     sqlite_non_existent_host_path = "sqlite_non_existent_host_path"
     shutil.copytree(

--- a/sql-cli/include/base/config/default/configuration.yml
+++ b/sql-cli/include/base/config/default/configuration.yml
@@ -8,17 +8,15 @@ connections:
     login:
     password:
 
-## Example of Bigquery connection
-#  - conn_id: bigquery_conn
-#    conn_type: bigquery
-#    description: null
-#    extra:
-#      project: "my-gcp-project"
-#    host: null
-#    login: null
-#    password: null
-#    port: null
-#    schema: null
+## Examples of Bigquery connections
+### For bigquery it is recommended to use environment variables. You can set those in a .env file in the root directory of your project.
+  - conn_id: bigquery_conn_with_fallback
+    conn_type: gcpbigquery
+    # Note that you need to set GOOGLE_APPLICATION_CREDENTIALS environment variable.
+  - conn_id: bigquery_conn_with_env_expand
+    conn_type: gcpbigquery
+    extra: '{"extra__google_cloud_platform__project": "$GOOGLE_CLOUD_PROJECT", "extra__google_cloud_platform__key_path": "$GOOGLE_CLOUD_KEY_PATH"}'
+    # Note that you need to set these environment variables.
 
 ## Example of Postgres connection
 #  - conn_id: postgres_conn

--- a/sql-cli/include/base/config/default/configuration.yml
+++ b/sql-cli/include/base/config/default/configuration.yml
@@ -11,51 +11,51 @@ connections:
 ## Examples of Bigquery connections
 ## To use this, either set the corresponding environment variables or
 ## replace the values started by $ inline
-  - conn_id: bigquery_conn
-    conn_type: gcpbigquery
-    extra: '{"extra__google_cloud_platform__project": "$GOOGLE_CLOUD_PROJECT", "extra__google_cloud_platform__key_path": "$GOOGLE_CLOUD_KEY_PATH"}'
+  # - conn_id: bigquery_conn
+  #   conn_type: gcpbigquery
+  #   extra: '{"extra__google_cloud_platform__project": "$GOOGLE_CLOUD_PROJECT", "extra__google_cloud_platform__key_path": "$GOOGLE_CLOUD_KEY_PATH"}'
     # Note that you need to set these environment variables.
-  - conn_id: bigquery_conn_with_fallback
-    conn_type: gcpbigquery
+  # - conn_id: bigquery_conn_with_fallback
+  #   conn_type: gcpbigquery
     # Note that you need to set GOOGLE_APPLICATION_CREDENTIALS environment variable.
 
 ## Example of Postgres connection
 ## To use this, either set the corresponding environment variables or
 ## replace the values started by $ inline
-  - conn_id: postgres_conn
-    conn_type: postgres
-    host: $POSTGRES_HOST
-    schema: $POSTGRES_DATABASE
-    login: $POSTGRES_USERNAME
-    password: $POSTGRES_PASSWORD
-    port: $POSTGRES_PORT
+  # - conn_id: postgres_conn
+  #   conn_type: postgres
+  #   host: $POSTGRES_HOST
+  #   schema: $POSTGRES_DATABASE
+  #   login: $POSTGRES_USERNAME
+  #   password: $POSTGRES_PASSWORD
+  #   port: $POSTGRES_PORT
     # Note that you need to set these environment variables.
 
 ## Example of Redshift connection
 ## To use this, either set the corresponding environment variables or
 ## replace the values started by $ inline
-  - conn_id: redshift_conn
-    conn_type: redshift
-    schema: $REDSHIFT_DATABASE
-    host: $REDSHIFT_HOST
-    port: $REDSHIFT_PORT
-    login: $REDSHIFT_USERNAME
-    password: $REDSHIFT_PASSWORD
+  # - conn_id: redshift_conn
+  #   conn_type: redshift
+  #   schema: $REDSHIFT_DATABASE
+  #   host: $REDSHIFT_HOST
+  #   port: $REDSHIFT_PORT
+  #   login: $REDSHIFT_USERNAME
+  #   password: $REDSHIFT_PASSWORD
     # Note that you need to set these environment variables.
 
 ## Example of Snowflake connection
 ## To use this, either set the corresponding environment variables or
 ## replace the values started by $ inline
-  - conn_id: snowflake_conn
-    conn_type: snowflake
-    host: $SNOWFLAKE_HOST
-    port: $SNOWFLAKE_PORT
-    login: $SNOWFLAKE_ACCOUNT_NAME
-    password: $SNOWFLAKE_PASSWORD
-    schema: $SNOWFLAKE_SCHEMA
-    extra:
-      account: $SNOWFLAKE_ACCOUNT
-      region: $SNOWFLAKE_REGION
-      role: $SNOWFLAKE_ROLE
-      warehouse: $SNOWFLAKE_WAREHOUSE
-      database: $SNOWFLAKE_DATABASE
+  # - conn_id: snowflake_conn
+  #   conn_type: snowflake
+  #   host: $SNOWFLAKE_HOST
+  #   port: $SNOWFLAKE_PORT
+  #   login: $SNOWFLAKE_ACCOUNT_NAME
+  #   password: $SNOWFLAKE_PASSWORD
+  #   schema: $SNOWFLAKE_SCHEMA
+  #   extra:
+  #     account: $SNOWFLAKE_ACCOUNT
+  #     region: $SNOWFLAKE_REGION
+  #     role: $SNOWFLAKE_ROLE
+  #     warehouse: $SNOWFLAKE_WAREHOUSE
+  #     database: $SNOWFLAKE_DATABASE

--- a/sql-cli/include/base/config/default/configuration.yml
+++ b/sql-cli/include/base/config/default/configuration.yml
@@ -50,9 +50,4 @@ connections:
   #   login: $SNOWFLAKE_ACCOUNT_NAME
   #   password: $SNOWFLAKE_PASSWORD
   #   schema: $SNOWFLAKE_SCHEMA
-  #   extra:
-  #     account: $SNOWFLAKE_ACCOUNT
-  #     region: $SNOWFLAKE_REGION
-  #     role: $SNOWFLAKE_ROLE
-  #     warehouse: $SNOWFLAKE_WAREHOUSE
-  #     database: $SNOWFLAKE_DATABASE
+  #   extra: '{"account": "$SNOWFLAKE_ACCOUNT", "region": "$SNOWFLAKE_REGION", "role": "$SNOWFLAKE_ROLE", "warehouse": "$SNOWFLAKE_WAREHOUSE", "database": "$SNOWFLAKE_DATABASE"}'

--- a/sql-cli/include/base/config/default/configuration.yml
+++ b/sql-cli/include/base/config/default/configuration.yml
@@ -24,8 +24,8 @@ connections:
   # - conn_id: postgres_conn
   #   conn_type: postgres
   #   host: $POSTGRES_HOST
-  #   schema: $POSTGRES_DATABASE
-  #   login: $POSTGRES_USERNAME
+  #   schema: pagila
+  #   login: postgres
   #   password: $POSTGRES_PASSWORD
   #   port: $POSTGRES_PORT
 
@@ -36,7 +36,7 @@ connections:
   #   conn_type: redshift
   #   schema: $REDSHIFT_DATABASE
   #   host: $REDSHIFT_HOST
-  #   port: $REDSHIFT_PORT
+  #   port: 5439
   #   login: $REDSHIFT_USERNAME
   #   password: $REDSHIFT_PASSWORD
 
@@ -46,7 +46,7 @@ connections:
   # - conn_id: snowflake_conn
   #   conn_type: snowflake
   #   host: $SNOWFLAKE_HOST
-  #   port: $SNOWFLAKE_PORT
+  #   port: 443
   #   login: $SNOWFLAKE_ACCOUNT_NAME
   #   password: $SNOWFLAKE_PASSWORD
   #   schema: $SNOWFLAKE_SCHEMA

--- a/sql-cli/include/base/config/default/configuration.yml
+++ b/sql-cli/include/base/config/default/configuration.yml
@@ -14,7 +14,6 @@ connections:
   # - conn_id: bigquery_conn
   #   conn_type: gcpbigquery
   #   extra: '{"extra__google_cloud_platform__project": "$GOOGLE_CLOUD_PROJECT", "extra__google_cloud_platform__key_path": "$GOOGLE_CLOUD_KEY_PATH"}'
-    # Note that you need to set these environment variables.
   # - conn_id: bigquery_conn_with_fallback
   #   conn_type: gcpbigquery
     # Note that you need to set GOOGLE_APPLICATION_CREDENTIALS environment variable.
@@ -29,7 +28,6 @@ connections:
   #   login: $POSTGRES_USERNAME
   #   password: $POSTGRES_PASSWORD
   #   port: $POSTGRES_PORT
-    # Note that you need to set these environment variables.
 
 ## Example of Redshift connection
 ## To use this, either set the corresponding environment variables or
@@ -41,7 +39,6 @@ connections:
   #   port: $REDSHIFT_PORT
   #   login: $REDSHIFT_USERNAME
   #   password: $REDSHIFT_PASSWORD
-    # Note that you need to set these environment variables.
 
 ## Example of Snowflake connection
 ## To use this, either set the corresponding environment variables or

--- a/sql-cli/include/base/config/default/configuration.yml
+++ b/sql-cli/include/base/config/default/configuration.yml
@@ -1,57 +1,61 @@
+# IMPORTANT:
+# Please use environment variables to define secrets in connections.
+# You can set those in a .env file in the root directory of your project.
 connections:
 
 ## Example of SQLite connection
   - conn_id: sqlite_conn
     conn_type: sqlite
     host: data/imdb.db
-    schema:
-    login:
-    password:
 
 ## Examples of Bigquery connections
-### For bigquery it is recommended to use environment variables. You can set those in a .env file in the root directory of your project.
-  - conn_id: bigquery_conn_with_fallback
-    conn_type: gcpbigquery
-    # Note that you need to set GOOGLE_APPLICATION_CREDENTIALS environment variable.
-  - conn_id: bigquery_conn_with_env_expand
+## To use this, either set the corresponding environment variables or
+## replace the values started by $ inline
+  - conn_id: bigquery_conn
     conn_type: gcpbigquery
     extra: '{"extra__google_cloud_platform__project": "$GOOGLE_CLOUD_PROJECT", "extra__google_cloud_platform__key_path": "$GOOGLE_CLOUD_KEY_PATH"}'
     # Note that you need to set these environment variables.
+  - conn_id: bigquery_conn_with_fallback
+    conn_type: gcpbigquery
+    # Note that you need to set GOOGLE_APPLICATION_CREDENTIALS environment variable.
 
 ## Example of Postgres connection
-#  - conn_id: postgres_conn
-#    conn_type: postgres
-#    host: localhost
-#    schema:
-#    login: postgres
-#    password: postgres
-#    port: 5432
-#    extra:
+## To use this, either set the corresponding environment variables or
+## replace the values started by $ inline
+  - conn_id: postgres_conn
+    conn_type: postgres
+    host: $POSTGRES_HOST
+    schema: $POSTGRES_DATABASE
+    login: $POSTGRES_USERNAME
+    password: $POSTGRES_PASSWORD
+    port: $POSTGRES_PORT
+    # Note that you need to set these environment variables.
 
 ## Example of Redshift connection
 ## To use this, either set the corresponding environment variables or
 ## replace the values started by $ inline
-#  - conn_id: redshift_conn
-#    conn_type: redshift
-#    schema: $REDSHIFT_DATABASE
-#    host: $REDSHIFT_HOST
-#    port: 5439
-#    login: $REDSHIFT_USERNAME
-#    password: $REDSHIFT_PASSWORD
+  - conn_id: redshift_conn
+    conn_type: redshift
+    schema: $REDSHIFT_DATABASE
+    host: $REDSHIFT_HOST
+    port: $REDSHIFT_PORT
+    login: $REDSHIFT_USERNAME
+    password: $REDSHIFT_PASSWORD
+    # Note that you need to set these environment variables.
 
 ## Example of Snowflake connection
 ## To use this, either set the corresponding environment variables or
 ## replace the values started by $ inline
-#  - conn_id: snowflake_conn
-#    conn_type: snowflake
-#    host: https://gp00000.us-east-1.snowflakecomputing.com
-#    port: 443
-#    login: $SNOWFLAKE_ACCOUNT_NAME
-#    password: $SNOWFLAKE_PASSWORD
-#    schema: $SNOWFLAKE_SCHEMA
-#    extra:
-#      account: "gp00000"
-#      region: "us-east-1"
-#      role: $SNOWFLAKE_ROLE
-#      warehouse: $SNOWFLAKE_WAREHOUSE
-#      database: $SNOWFLAKE_DATABASE
+  - conn_id: snowflake_conn
+    conn_type: snowflake
+    host: $SNOWFLAKE_HOST
+    port: $SNOWFLAKE_PORT
+    login: $SNOWFLAKE_ACCOUNT_NAME
+    password: $SNOWFLAKE_PASSWORD
+    schema: $SNOWFLAKE_SCHEMA
+    extra:
+      account: $SNOWFLAKE_ACCOUNT
+      region: $SNOWFLAKE_REGION
+      role: $SNOWFLAKE_ROLE
+      warehouse: $SNOWFLAKE_WAREHOUSE
+      database: $SNOWFLAKE_DATABASE

--- a/sql-cli/include/base/config/dev/configuration.yml
+++ b/sql-cli/include/base/config/dev/configuration.yml
@@ -1,59 +1,11 @@
+# IMPORTANT:
+# Please use environment variables to define secrets in connections.
+# You can set those in a .env file in the root directory of your project.
 connections:
 
 ## Example of SQLite connection
+## This shows how you can use a different connection with the same id.
+## Instead of connecting to data/imdb.db it connects to data/retail.db on dev.
   - conn_id: sqlite_conn
     conn_type: sqlite
     host: data/retail.db
-    schema:
-    login:
-    password:
-
-## Example of Bigquery connection
-#  - conn_id: bigquery_conn
-#    conn_type: bigquery
-#    description: null
-#    extra:
-#      project: "my-gcp-project"
-#    host: null
-#    login: null
-#    password: null
-#    port: null
-#    schema: null
-
-## Example of Postgres connection
-#  - conn_id: postgres_conn
-#    conn_type: postgres
-#    host: localhost
-#    schema:
-#    login: postgres
-#    password: postgres
-#    port: 5432
-#    extra:
-
-## Example of Redshift connection
-## To use this, either set the corresponding environment variables or
-## replace the values started by $ inline
-#  - conn_id: redshift_conn
-#    conn_type: redshift
-#    schema: $REDSHIFT_DATABASE
-#    host: $REDSHIFT_HOST
-#    port: 5439
-#    login: $REDSHIFT_USERNAME
-#    password: $REDSHIFT_PASSWORD
-
-## Example of Snowflake connection
-## To use this, either set the corresponding environment variables or
-## replace the values started by $ inline
-#  - conn_id: snowflake_conn
-#    conn_type: snowflake
-#    host: https://gp00000.us-east-1.snowflakecomputing.com
-#    port: 443
-#    login: $SNOWFLAKE_ACCOUNT_NAME
-#    password: $SNOWFLAKE_PASSWORD
-#    schema: $SNOWFLAKE_SCHEMA
-#    extra:
-#      account: "gp00000"
-#      region: "us-east-1"
-#      role: $SNOWFLAKE_ROLE
-#      warehouse: $SNOWFLAKE_WAREHOUSE
-#      database: $SNOWFLAKE_DATABASE

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -1,22 +1,12 @@
-# IMPORTANT:
-# Please use environment variables to define secrets in connections.
-# You can set those in a .env file in the root directory of your project.
 connections:
-
-## Examples of Bigquery connections
-## To use this, either set the corresponding environment variables or
-## replace the values started by $ inline
   - conn_id: bigquery_conn
     conn_type: gcpbigquery
     extra: '{"extra__google_cloud_platform__project": "$GOOGLE_CLOUD_PROJECT", "extra__google_cloud_platform__key_path": "$GOOGLE_CLOUD_KEY_PATH"}'
-    # Note that you need to set these environment variables.
+
   - conn_id: bigquery_conn_with_fallback
     conn_type: gcpbigquery
-    # Note that you need to set GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    # Falls back to GOOGLE_APPLICATION_CREDENTIALS environment variable.
 
-## Example of Postgres connection
-## To use this, either set the corresponding environment variables or
-## replace the values started by $ inline
   - conn_id: postgres_conn
     conn_type: postgres
     host: $POSTGRES_HOST
@@ -24,11 +14,7 @@ connections:
     login: $POSTGRES_USERNAME
     password: $POSTGRES_PASSWORD
     port: $POSTGRES_PORT
-    # Note that you need to set these environment variables.
 
-## Example of Redshift connection
-## To use this, either set the corresponding environment variables or
-## replace the values started by $ inline
   - conn_id: redshift_conn
     conn_type: redshift
     schema: $REDSHIFT_DATABASE
@@ -36,11 +22,7 @@ connections:
     port: $REDSHIFT_PORT
     login: $REDSHIFT_USERNAME
     password: $REDSHIFT_PASSWORD
-    # Note that you need to set these environment variables.
 
-## Example of Snowflake connection
-## To use this, either set the corresponding environment variables or
-## replace the values started by $ inline
   - conn_id: snowflake_conn
     conn_type: snowflake
     host: $SNOWFLAKE_HOST

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -1,4 +1,13 @@
 connections:
+  - conn_id: aws_conn
+    conn_type: aws
+    login: $AWS_ACCESS_KEY_ID
+    password: $AWS_SECRET_ACCESS_KEY
+
+  - conn_id: aws_conn_with_fallback
+    conn_type: aws
+    # Falls back to AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variable.
+
   - conn_id: bigquery_conn
     conn_type: gcpbigquery
     extra: '{"extra__google_cloud_platform__project": "$GOOGLE_CLOUD_PROJECT", "extra__google_cloud_platform__key_path": "$GOOGLE_CLOUD_KEY_PATH"}'

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -1,0 +1,56 @@
+# IMPORTANT:
+# Please use environment variables to define secrets in connections.
+# You can set those in a .env file in the root directory of your project.
+connections:
+
+## Examples of Bigquery connections
+## To use this, either set the corresponding environment variables or
+## replace the values started by $ inline
+  - conn_id: bigquery_conn
+    conn_type: gcpbigquery
+    extra: '{"extra__google_cloud_platform__project": "$GOOGLE_CLOUD_PROJECT", "extra__google_cloud_platform__key_path": "$GOOGLE_CLOUD_KEY_PATH"}'
+    # Note that you need to set these environment variables.
+  - conn_id: bigquery_conn_with_fallback
+    conn_type: gcpbigquery
+    # Note that you need to set GOOGLE_APPLICATION_CREDENTIALS environment variable.
+
+## Example of Postgres connection
+## To use this, either set the corresponding environment variables or
+## replace the values started by $ inline
+  - conn_id: postgres_conn
+    conn_type: postgres
+    host: $POSTGRES_HOST
+    schema: $POSTGRES_DATABASE
+    login: $POSTGRES_USERNAME
+    password: $POSTGRES_PASSWORD
+    port: $POSTGRES_PORT
+    # Note that you need to set these environment variables.
+
+## Example of Redshift connection
+## To use this, either set the corresponding environment variables or
+## replace the values started by $ inline
+  - conn_id: redshift_conn
+    conn_type: redshift
+    schema: $REDSHIFT_DATABASE
+    host: $REDSHIFT_HOST
+    port: $REDSHIFT_PORT
+    login: $REDSHIFT_USERNAME
+    password: $REDSHIFT_PASSWORD
+    # Note that you need to set these environment variables.
+
+## Example of Snowflake connection
+## To use this, either set the corresponding environment variables or
+## replace the values started by $ inline
+  - conn_id: snowflake_conn
+    conn_type: snowflake
+    host: $SNOWFLAKE_HOST
+    port: $SNOWFLAKE_PORT
+    login: $SNOWFLAKE_ACCOUNT_NAME
+    password: $SNOWFLAKE_PASSWORD
+    schema: $SNOWFLAKE_SCHEMA
+    extra:
+      account: $SNOWFLAKE_ACCOUNT
+      region: $SNOWFLAKE_REGION
+      role: $SNOWFLAKE_ROLE
+      warehouse: $SNOWFLAKE_WAREHOUSE
+      database: $SNOWFLAKE_DATABASE

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -1,9 +1,0 @@
-connections:
-  - conn_id: bigquery_conn_invalid
-    conn_type: bigquery
-    description: null
-    host: null
-    login: null
-    password: null
-    port: null
-    schema: null

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -30,9 +30,4 @@ connections:
     login: $SNOWFLAKE_ACCOUNT_NAME
     password: $SNOWFLAKE_PASSWORD
     schema: $SNOWFLAKE_SCHEMA
-    extra:
-      account: $SNOWFLAKE_ACCOUNT
-      region: $SNOWFLAKE_REGION
-      role: $SNOWFLAKE_ROLE
-      warehouse: $SNOWFLAKE_WAREHOUSE
-      database: $SNOWFLAKE_DATABASE
+    extra: '{"account": "$SNOWFLAKE_ACCOUNT", "region": "$SNOWFLAKE_REGION", "role": "$SNOWFLAKE_ROLE", "warehouse": "$SNOWFLAKE_WAREHOUSE", "database": "$SNOWFLAKE_DATABASE"}'

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -10,8 +10,8 @@ connections:
   - conn_id: postgres_conn
     conn_type: postgres
     host: $POSTGRES_HOST
-    schema: $POSTGRES_DATABASE
-    login: $POSTGRES_USERNAME
+    schema: pagila
+    login: postgres
     password: $POSTGRES_PASSWORD
     port: $POSTGRES_PORT
 
@@ -19,14 +19,14 @@ connections:
     conn_type: redshift
     schema: $REDSHIFT_DATABASE
     host: $REDSHIFT_HOST
-    port: $REDSHIFT_PORT
+    port: 5439
     login: $REDSHIFT_USERNAME
     password: $REDSHIFT_PASSWORD
 
   - conn_id: snowflake_conn
     conn_type: snowflake
     host: $SNOWFLAKE_HOST
-    port: $SNOWFLAKE_PORT
+    port: 443
     login: $SNOWFLAKE_ACCOUNT_NAME
     password: $SNOWFLAKE_PASSWORD
     schema: $SNOWFLAKE_SCHEMA

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -227,15 +227,20 @@ def test_generate_invalid(workflow_name, message, initialised_project_with_tests
     "env,connection,status",
     [
         ("default", "sqlite_conn", "PASSED"),
-        ("test", "bigquery_conn_invalid", "FAILED"),
+        (
+            "default",
+            "bigquery_conn_with_fallback",
+            "PASSED",
+        ),  # requires GOOGLE_APPLICATION_CREDENTIALS env var to be set
+        ("default", "bigquery_conn_with_env_expand", "FAILED"),  # expects the env vars to not be set
     ],
 )
-def test_validate(env, connection, status, initialised_project_with_test_config):
+def test_validate(env, connection, status, initialised_project):
     result = runner.invoke(
         app,
         [
             "validate",
-            initialised_project_with_test_config.directory.as_posix(),
+            initialised_project.directory.as_posix(),
             "--env",
             env,
             "--connection",
@@ -265,12 +270,12 @@ def test_validate_sqlite_non_existent_host_path(
     assert isinstance(result.exception, FileNotFoundError)
 
 
-def test_validate_all(initialised_project_with_test_config):
+def test_validate_all(initialised_project):
     result = runner.invoke(
         app,
         [
             "validate",
-            initialised_project_with_test_config.directory.as_posix(),
+            initialised_project.directory.as_posix(),
         ],
     )
     assert result.exit_code == 0

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -227,12 +227,7 @@ def test_generate_invalid(workflow_name, message, initialised_project_with_tests
     "env,connection,status",
     [
         ("default", "sqlite_conn", "PASSED"),
-        (
-            "default",
-            "bigquery_conn_with_fallback",
-            "PASSED",
-        ),  # requires GOOGLE_APPLICATION_CREDENTIALS env var to be set
-        ("default", "bigquery_conn_with_env_expand", "FAILED"),  # expects the env vars to not be set
+        ("dev", "sqlite_conn", "PASSED"),
     ],
 )
 def test_validate(env, connection, status, initialised_project):
@@ -270,12 +265,21 @@ def test_validate_sqlite_non_existent_host_path(
     assert isinstance(result.exception, FileNotFoundError)
 
 
-def test_validate_all(initialised_project):
+@pytest.mark.parametrize(
+    "env",
+    [
+        "default",
+        "test",
+    ],
+)
+def test_validate_all(env, initialised_project_with_test_config):
     result = runner.invoke(
         app,
         [
             "validate",
-            initialised_project.directory.as_posix(),
+            initialised_project_with_test_config.directory.as_posix(),
+            "--env",
+            env,
         ],
     )
     assert result.exit_code == 0


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we don't have any working example(s) of bigquery connections, because we thought the `extra` is broken. But apparently we did not configure it right.

**Prior to Airflow 2.3**, the `extra` has to be of type string and also in case of bigquery all of the extras needed to be prefixed with `extra__google_cloud_platform__`. Another example is snowflake where the `extra` needed to be a json as well to work for airflow 2.2.5 which we support.

closes: #1277

## What is the new behavior?

We add examples and tests for all currently supported connection types. Moreover configure the ci pipeline to be able to test them.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
