### PR TITLE
Add github action:labeler that labels SQL CLI PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
-label1:
+product/sql-cli:
 - sql-cli/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+label1:
+- sql-cli/**/*

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+- pull_request
 
 jobs:
   triage:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,3 +12,4 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,10 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
+  pull_request:
+    branches: [ 'main', 'release-**' ]
+  # Run on PRs from forks
+  pull_request_target:
+    branches: [ 'main' ]
 
 jobs:
   triage:

--- a/sql-cli/sql_cli/connections.py
+++ b/sql-cli/sql_cli/connections.py
@@ -28,6 +28,7 @@ def validate_connections(connections: list[Connection], connection_id: str | Non
 
 
 # dummy comment
+
 def _is_valid(connection: Connection) -> bool:
     # Sqlite automatically creates the file if it does not exist,
     # but our users might not expect that. They are referencing a database they expect to exist.

--- a/sql-cli/sql_cli/connections.py
+++ b/sql-cli/sql_cli/connections.py
@@ -27,8 +27,6 @@ def validate_connections(connections: list[Connection], connection_id: str | Non
             rprint(f"Validating connection {connection.conn_id:{CONNECTION_ID_OUTPUT_STRING_WIDTH}}", status)
 
 
-# dummy comment
-
 def _is_valid(connection: Connection) -> bool:
     # Sqlite automatically creates the file if it does not exist,
     # but our users might not expect that. They are referencing a database they expect to exist.

--- a/sql-cli/sql_cli/connections.py
+++ b/sql-cli/sql_cli/connections.py
@@ -27,6 +27,7 @@ def validate_connections(connections: list[Connection], connection_id: str | Non
             rprint(f"Validating connection {connection.conn_id:{CONNECTION_ID_OUTPUT_STRING_WIDTH}}", status)
 
 
+# dummy comment
 def _is_valid(connection: Connection) -> bool:
     # Sqlite automatically creates the file if it does not exist,
     # but our users might not expect that. They are referencing a database they expect to exist.


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
We need to manually label SQL CLI PRs that help us for tracking the releases for SQL CLI

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
We are exploring the Github action `labeler` to label Github PR including files affected in the
SQL CLI directory.
https://github.com/actions/labeler

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
