### PR TITLE
Create .env file on project initialisation + important refactorings (read desc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .git
 coverage.xml
-.env
 **/.coverage*
 **/.python-version
 python-sdk/integration-tests/test_data*
@@ -58,6 +57,7 @@ sql-cli/tests/.airflow/dags/*
 sql-cli/include/base/.airflow/dags/*
 !sql-cli/include/base/.airflow/dags/include/.gitkeep
 !sql-cli/include/base/.airflow/dags/.gitkeep
+!/sql-cli/include/base/.env
 
 # Airflow
 **/.airflowignore

--- a/sql-cli/pyproject.toml
+++ b/sql-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astro-sql-cli"
-version = "0.2.3a0"
+version = "0.2.3a2"
 description = "Empower analysts to build workflows to transform data using SQL"
 authors = [
     "Astronomer <humans@astronomer.io>",

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -142,7 +142,6 @@ def validate(
 
     project_dir_absolute = _resolve_project_dir(project_dir)
     project = Project(project_dir_absolute)
-    project.transform_env_config(environment=env)
     project.load_config(environment=env)
 
     rprint(f"Validating connection(s) for environment '{env}'")
@@ -185,7 +184,6 @@ def run(
 
     project_dir_absolute = _resolve_project_dir(project_dir)
     project = Project(project_dir_absolute)
-    project.transform_env_config(environment=env)
     project.load_config(env)
 
     dag_file = _generate_dag(project=project, workflow_name=workflow_name, generate_tasks=generate_tasks)

--- a/sql-cli/sql_cli/configuration.py
+++ b/sql-cli/sql_cli/configuration.py
@@ -50,7 +50,7 @@ class Config:
         :returns: Content of the YAML configuration file as a python dictionary.
         """
         load_dotenv(self.project_dir / ".env")
-        with open(filepath) as fp:
+        with filepath.open() as fp:
             yaml_with_env = os.path.expandvars(fp.read())
             yaml_config = yaml.safe_load(yaml_with_env)
         return yaml_config or {}

--- a/sql-cli/sql_cli/configuration.py
+++ b/sql-cli/sql_cli/configuration.py
@@ -7,23 +7,9 @@ from typing import Any
 
 import yaml
 from airflow.models.connection import Connection
+from dotenv import load_dotenv
 
 from sql_cli.constants import CONFIG_DIR, CONFIG_FILENAME, GLOBAL_CONFIG
-
-
-def convert_to_connection(conn: dict[str, Any]) -> Connection:
-    """
-    Convert the SQL CLI connection dictionary into an Airflow Connection instance.
-
-    :param conn: SQL CLI connection dictionary
-    :returns: Connection object
-    """
-    from airflow.api_connexion.schemas.connection_schema import connection_schema
-
-    c = conn.copy()
-    c["connection_id"] = c["conn_id"]
-    c.pop("conn_id")
-    return Connection(**connection_schema.load(c))
 
 
 @dataclass
@@ -55,8 +41,7 @@ class Config:
         """
         return self.project_dir / CONFIG_DIR / GLOBAL_CONFIG / CONFIG_FILENAME
 
-    @staticmethod
-    def from_yaml_to_dict(filepath: Path) -> dict[str, Any]:
+    def from_yaml_to_dict(self, filepath: Path) -> dict[str, Any]:
         """
         Return a dict with the contents of the given configuration.yaml
 
@@ -64,6 +49,7 @@ class Config:
 
         :returns: Content of the YAML configuration file as a python dictionary.
         """
+        load_dotenv(self.project_dir / ".env")
         with open(filepath) as fp:
             yaml_with_env = os.path.expandvars(fp.read())
             yaml_config = yaml.safe_load(yaml_with_env)
@@ -102,32 +88,3 @@ class Config:
 
         with filepath.open(mode="w") as fp:
             yaml.dump(yaml_config, fp)
-
-    def write_config_to_yaml(self) -> None:
-        """
-        Write Config instance's key-values to respective environment specific and global configuration.yml.
-
-        It may happen that some method wishes to transform the config instance's values and wants to persist them back
-        to the configuration files. This method serves as a utility method that can be used to write back the Config
-        instances' environment specific keys to the environment configuration.yml and global keys to the global
-        configuration.yml file.
-
-        E.g. When a project is initialised, the example workflow containing SQLite connection refer to the database
-        using relative paths. However, for the connection to be established successfully, it needs absolute path, so the
-        project initialisation flow reads the default yaml into config instance, transforms the config instance to
-        expand those relative paths to absolute paths and then calls this utility to persists the transformed instance.
-        """
-        env_config_filepath = self.get_env_config_filepath()
-        env_yaml_config = self.from_yaml_to_dict(env_config_filepath)
-        env_yaml_config["connections"] = self.connections
-        with env_config_filepath.open(mode="w") as fp:
-            yaml.dump(env_yaml_config, fp)
-
-        global_config_filepath = self.get_global_config_filepath()
-        global_yaml_config = self.from_yaml_to_dict(global_config_filepath)
-        if self.airflow_home:
-            global_yaml_config["airflow"]["home"] = self.airflow_home
-        if self.airflow_dags_folder:
-            global_yaml_config["airflow"]["dags_folder"] = self.airflow_dags_folder
-        with global_config_filepath.open(mode="w") as fp:
-            yaml.dump(global_yaml_config, fp)

--- a/sql-cli/sql_cli/connections.py
+++ b/sql-cli/sql_cli/connections.py
@@ -2,12 +2,43 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 
 from airflow.models import Connection
 
+from sql_cli.constants import SQLITE_CONN_TYPE
 from sql_cli.utils.rich import rprint
 
 CONNECTION_ID_OUTPUT_STRING_WIDTH = 25
+
+
+def convert_to_connection(conn: dict[str, Any], project_dir: Path | None) -> Connection:
+    """
+    Convert the SQL CLI connection dictionary into an Airflow Connection instance.
+
+    :param conn: SQL CLI connection dictionary
+    :param project_dir: Path to the initialised project
+    :returns: Connection object
+    """
+    from airflow.api_connexion.schemas.connection_schema import connection_schema
+
+    connection = conn.copy()
+    connection["connection_id"] = connection["conn_id"]
+    connection.pop("conn_id")
+    if connection["conn_type"] == SQLITE_CONN_TYPE:
+        host_path = connection["host"]
+        if not os.path.isabs(host_path):
+            # The example workflows have relative paths for the host URLs for SQLite connections. Additionally, the
+            # user might also sometimes set relative paths for the host from the initialised project directory. Such
+            # paths need to be converted to absolute paths so that the connections work successfully.
+            resolved_host_path = project_dir / host_path
+            if not resolved_host_path.exists():
+                raise FileNotFoundError(
+                    f"The relative file path {host_path} was resolved into {resolved_host_path} but it's a failed "
+                    f"resolution as the path does not exist."
+                )
+            connection["host"] = str(resolved_host_path)
+    return Connection(**connection_schema.load(connection))
 
 
 def validate_connections(connections: list[Connection], connection_id: str | None = None) -> None:

--- a/sql-cli/tests/test_configuration.py
+++ b/sql-cli/tests/test_configuration.py
@@ -1,9 +1,4 @@
 from pathlib import Path
-from tempfile import gettempdir
-from unittest.mock import patch
-from uuid import uuid4
-
-import yaml
 
 from sql_cli.configuration import Config
 
@@ -17,28 +12,3 @@ def test_from_yaml_to_config():
     assert config_from_file.project_dir == config_reference.project_dir
     assert config_from_file.environment == config_reference.environment
     assert config_from_file.connections
-
-
-@patch(
-    "sql_cli.configuration.Config.from_yaml_to_dict",
-    return_value={"airflow": {"home": "", "dags_folder": ""}},
-)
-@patch("sql_cli.configuration.Config.get_env_config_filepath")
-@patch("sql_cli.configuration.Config.get_global_config_filepath")
-def test_write_config_to_yaml(
-    get_global_config_filepath, get_env_config_filepath, mock_from_yaml_to_dict, tmp_path
-):
-    tmp_dir = gettempdir()
-    get_global_config_filepath.return_value = Path(f"{tmp_dir}/{uuid4().hex}")
-    get_env_config_filepath.return_value = Path(f"{tmp_dir}/{uuid4().hex}")
-    config = Config(
-        project_dir=tmp_path,
-        environment="neverland",
-        airflow_home=f"{tmp_dir}/home",
-        airflow_dags_folder=f"{tmp_dir}/dags",
-    )
-    config.write_config_to_yaml()
-    with open(get_global_config_filepath.return_value) as fp:
-        yaml_config = yaml.safe_load(fp.read())
-    assert yaml_config["airflow"]["home"] == f"{tmp_dir}/home"
-    assert yaml_config["airflow"]["dags_folder"] == f"{tmp_dir}/dags"

--- a/sql-cli/tests/test_project.py
+++ b/sql-cli/tests/test_project.py
@@ -12,6 +12,7 @@ BASE_PATHS = [
     Path(".airflow/default/airflow.db"),
     Path(".airflow/dev"),
     Path(".airflow/global"),
+    Path(".env"),
     Path("config"),
     Path("config/default"),
     Path("config/default/configuration.yml"),


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, there is no way for Astro CLI users to specify environment
variables that can be used for configuring connections as we launch
docker containers from Astro CLI commands which do not have access
to host environment variables

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
related: #1329 



## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
As part of project initialisation, we create a .env file in the initialised project and
ask the user to configure environment variables in this file. Astro CLI will mount
this .env file in the docker containers so that those environment variables are 
available in the docker container since we use `dotenv` library to load 
environment variables from .env file. Such environment variables can be used
to expand yaml files to create connections including secrets as environment variables.
e.g. https://legacy.docs.greatexpectations.io/en/latest/guides/how_to_guides/configuring_data_contexts/how_to_use_a_yaml_file_or_environment_variables_to_populate_credentials.html

Remove transform env specific config implementation and move the
needed relevant connection transformation into the convert_to_connection
method.

Remove the method to write config to yaml as it overwrites environment
vars placeholder with the expanded vars when read into config instance.

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
