### PR TITLE
CI: Fix circular import error for Airflow 2.2.5

### DIFF
--- a/python-sdk/src/astro/files/__init__.py
+++ b/python-sdk/src/astro/files/__init__.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 from airflow.hooks.base import BaseHook
 
 from astro.files.base import File, resolve_file_path_pattern  # noqa: F401 # skipcq: PY-W2000
-from astro.files.operators.files import get_file_list_func  # noqa: F401 # skipcq: PY-W2000
 
 if TYPE_CHECKING:
     from airflow.models.xcom_arg import XComArg


### PR DESCRIPTION
This should fix the following in CI:

```
File "/home/runner/work/astro-sdk/astro-sdk/python-sdk/src/astro/custom_backend/astro_custom_backend.py", line 6, in <module>
    from astro.custom_backend.serializer import deserialize, serialize
  File "/home/runner/work/astro-sdk/astro-sdk/python-sdk/src/astro/custom_backend/serializer.py", line 17, in <module>
    from astro.files import File
  File "/home/runner/work/astro-sdk/astro-sdk/python-sdk/src/astro/files/__init__.py", line 6, in <module>
    from astro.files.operators.files import get_file_list_func  # noqa: F401 # skipcq: PY-W2000
  File "/home/runner/work/astro-sdk/astro-sdk/python-sdk/src/astro/files/operators/files.py", line 5, in <module>
    from airflow.decorators.base import get_unique_task_id
  File "/home/runner/work/astro-sdk/astro-sdk/python-sdk/.nox/test-3-8-airflow-2-2-5/lib/python3.8/site-packages/airflow/decorators/__init__.py", line 20, in <module>
    from airflow.decorators.python import PythonDecoratorMixin, python_task  # noqa
  File "/home/runner/work/astro-sdk/astro-sdk/python-sdk/.nox/test-3-8-airflow-2-2-5/lib/python3.8/site-packages/airflow/decorators/python.py", line 20, in <module>
    from airflow.decorators.base import DecoratedOperator, task_decorator_factory
  File "/home/runner/work/astro-sdk/astro-sdk/python-sdk/.nox/test-3-8-airflow-2-2-5/lib/python3.8/site-packages/airflow/decorators/base.py", line 26, in <module>
    from airflow.models import BaseOperator
ImportError: cannot import name 'BaseOperator' from partially initialized module 'airflow.models' (most likely due to a circular import)
```
