### PR TITLE
Add the ability to interact between local dataframes and Delta tables…

### DIFF
--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -389,6 +389,21 @@ class BaseDatabase(ABC):
                 columns_names_capitalization=columns_names_capitalization,
             )
 
+    def fetch_all_rows(self, table: BaseTable, row_limit: int = -1) -> list:
+        """
+        Fetches all rows for a table and returns as a list. This is needed because some
+        databases have different cursors that require different methods to fetch rows
+
+        :param row_limit: Limit the number of rows returned, by default return all rows.
+        :param table: The table metadata needed to fetch the rows
+        :return: a list of rows
+        """
+        statement = f"SELECT * FROM {self.get_table_qualified_name(table)}"
+        if row_limit > 0:
+            statement = statement + f" LIMIT {row_limit}"
+        response = self.run_sql(statement)
+        return response.fetchall()  # type: ignore
+
     def load_file_to_table(
         self,
         input_file: File,

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -399,7 +399,7 @@ class BaseDatabase(ABC):
         :return: a list of rows
         """
         statement = f"SELECT * FROM {self.get_table_qualified_name(table)}"
-        if row_limit > 0:
+        if row_limit > -1:
             statement = statement + f" LIMIT {row_limit}"
         response = self.run_sql(statement)
         return response.fetchall()  # type: ignore

--- a/python-sdk/src/astro/databricks/api_utils.py
+++ b/python-sdk/src/astro/databricks/api_utils.py
@@ -94,6 +94,7 @@ def generate_file(
             "load_options": load_options,
             "input_path": data_source_path,
             "file_type": file_type.upper(),
+            "if_exists": load_options.if_exists,
         },
         output_file_path,
     )

--- a/python-sdk/src/astro/databricks/delta.py
+++ b/python-sdk/src/astro/databricks/delta.py
@@ -115,7 +115,7 @@ class DeltaDatabase(BaseDatabase):
         :return: a list of rows
         """
         statement = f"SELECT * FROM {self.get_table_qualified_name(table)};"
-        if row_limit > 0:
+        if row_limit > -1:
             statement = statement + f" LIMIT {row_limit}"
         return self.run_sql(statement, handler=lambda x: x.fetchall())  # type: ignore
 

--- a/python-sdk/src/astro/databricks/load_file/jinja_templates/copy_into.py.jinja2
+++ b/python-sdk/src/astro/databricks/load_file/jinja_templates/copy_into.py.jinja2
@@ -1,5 +1,7 @@
-{% macro copy_into_command(file_format, load_options) -%}
+{%- macro copy_into_command(file_format, load_options, if_exists) -%}
+{%- if if_exists == "replace" %}
 spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+{%- endif %}
 spark.sql(f"CREATE TABLE IF NOT EXISTS {table_name}")
 spark.sql(
     f"""COPY INTO {table_name} FROM '{src_data_path}' FILEFORMAT={{ file_format }}

--- a/python-sdk/src/astro/databricks/load_file/jinja_templates/load_file_to_delta.py.jinja2
+++ b/python-sdk/src/astro/databricks/load_file/jinja_templates/load_file_to_delta.py.jinja2
@@ -10,8 +10,8 @@ username = spark.sql("SELECT regexp_replace(current_user(), '[^a-zA-Z0-9]', '_')
 table_name = f"{{ table_name }}" # This can be generated based on task ID and dag ID or just entirely random
 checkpoint_path = f"/tmp/{username}/_checkpoint/etl_3_quickstart"
 
-{% if load_options.load_secrets %}
+{%- if load_options.load_secrets %}
 {{ load_secrets_command(load_options.secret_scope) }}
-{% endif %}
+{%- endif %}
 
-{{ copy_into_command(file_type, load_options) }}
+{{ copy_into_command(file_type, load_options, load_options.if_exists) }}

--- a/python-sdk/src/astro/databricks/load_options.py
+++ b/python-sdk/src/astro/databricks/load_options.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from airflow.configuration import conf
 from attr import define, field
 
+from astro.constants import LoadExistStrategy
 from astro.options import LoadOptions
 
 
@@ -14,6 +15,7 @@ class DeltaLoadOptions(LoadOptions):
     copy_into_copy_options: dict = field(init=True, factory=dict)
     existing_cluster_id: str = field()
     new_cluster_spec: dict = field(init=True, factory=dict)
+    if_exists: LoadExistStrategy = "replace"
     secret_scope: str = "astro-sdk-secrets"
     load_secrets: bool = False
 

--- a/python-sdk/tests/databricks/load_file/test_load_python_code_generator.py
+++ b/python-sdk/tests/databricks/load_file/test_load_python_code_generator.py
@@ -14,7 +14,6 @@ table_name = f"baz" # This can be generated based on task ID and dag ID or just 
 checkpoint_path = f"/tmp/{username}/_checkpoint/etl_3_quickstart"
 
 
-
 spark.sql(f"DROP TABLE IF EXISTS {table_name}")
 spark.sql(f"CREATE TABLE IF NOT EXISTS {table_name}")
 spark.sql(
@@ -80,3 +79,20 @@ def test_generate_file_without_secrets():
         with open(output_file) as file:
             file_string = file.read()
             assert secret_gen_string not in file_string
+
+
+def test_generate_file_append():
+    with tempfile.NamedTemporaryFile() as tfile:
+        options = DeltaLoadOptions.get_default_delta_options()
+        options.load_secrets = False
+        options.if_exists = "append"
+        output_file = generate_file(
+            data_source_path="foobar",
+            table_name="baz",
+            source_type="s3",
+            output_file_path=Path(tfile.name),
+            load_options=options,
+        )
+        with open(output_file) as file:
+            file_string = file.read()
+            assert "DROP TABLE" not in file_string

--- a/python-sdk/tests_integration/databases/test_all_databases.py
+++ b/python-sdk/tests_integration/databases/test_all_databases.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from astro.constants import Database
+from astro.databases.base import BaseDatabase
 from astro.dataframes.pandas import PandasDataframe
 from astro.files import File
 from astro.settings import SCHEMA
@@ -43,9 +44,14 @@ CWD = pathlib.Path(__file__).parent
             "file": File(str(pathlib.Path(CWD.parent, "data/sample.csv"))),
             "table": Table(),
         },
+        {
+            "database": Database.DELTA,
+            "file": File(str(pathlib.Path(CWD.parent, "data/sample.csv"))),
+            "table": Table(),
+        },
     ],
     indirect=True,
-    ids=["bigquery", "postgres", "redshift", "snowflake", "sqlite"],
+    ids=["bigquery", "postgres", "redshift", "snowflake", "sqlite", "delta"],
 )
 def test_export_table_to_pandas_dataframe(
     database_table_fixture,
@@ -62,7 +68,9 @@ def test_export_table_to_pandas_dataframe(
             {"id": 3, "name": "Third with unicode पांचाल"},
         ]
     )
-    assert df.rename(columns=str.lower).equals(expected)
+    # Due to a weird minor difference with how databricks creates dataframes, this is a workaround
+    # to ensure equality when the actual data inside the DF is equal.
+    assert df.rename(columns=str.lower).to_dict() == expected.to_dict()
     assert isinstance(df, PandasDataframe)
 
 
@@ -75,9 +83,10 @@ def test_export_table_to_pandas_dataframe(
         {"database": Database.REDSHIFT},
         {"database": Database.SNOWFLAKE},
         {"database": Database.SQLITE},
+        {"database": Database.DELTA},
     ],
     indirect=True,
-    ids=["bigquery", "postgres", "redshift", "snowflake", "sqlite"],
+    ids=["bigquery", "postgres", "redshift", "snowflake", "sqlite", "delta"],
 )
 def test_load_pandas_dataframe_to_table_with_append(database_table_fixture):
     """Load Pandas Dataframe to a SQL table with append strategy"""
@@ -90,10 +99,7 @@ def test_load_pandas_dataframe_to_table_with_append(database_table_fixture):
         if_exists="append",
     )
 
-    statement = f"SELECT * FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement)
-
-    rows = response.fetchall()
+    rows = database.fetch_all_rows(table)
     assert len(rows) == 2
     assert rows[0] == (1,)
     assert rows[1] == (2,)
@@ -104,9 +110,7 @@ def test_load_pandas_dataframe_to_table_with_append(database_table_fixture):
         if_exists="append",
     )
 
-    statement = f"SELECT * FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement)
-    rows = response.fetchall()
+    rows = database.fetch_all_rows(table)
     assert len(rows) == 4
     assert rows[0] == (1,)
     assert rows[1] == (2,)
@@ -114,6 +118,34 @@ def test_load_pandas_dataframe_to_table_with_append(database_table_fixture):
     assert rows[3] == (2,)
 
     database.drop_table(table)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {"database": Database.BIGQUERY},
+        {"database": Database.POSTGRES},
+        {"database": Database.REDSHIFT},
+        {"database": Database.SNOWFLAKE},
+        {"database": Database.SQLITE},
+        {"database": Database.DELTA},
+    ],
+    indirect=True,
+    ids=["bigquery", "postgres", "redshift", "snowflake", "sqlite", "delta"],
+)
+@pytest.mark.parametrize("row_count", [0, 100])
+@mock.patch.object(BaseDatabase, "run_sql")
+def test_fetch_all_rows(mock_run_sql, database_table_fixture, row_count):
+    db, table = database_table_fixture
+    db.run_sql = mock_run_sql
+    db.fetch_all_rows(table, row_count)
+    select_statements = [m.args[0] for m in mock_run_sql.mock_calls if m.args and "SELECT" in m.args[0]]
+    assert len(select_statements) == 1
+    if row_count > 0:
+        assert f"LIMIT {row_count}" in select_statements[0]
+    else:
+        assert f"LIMIT {row_count}" not in select_statements[0]
 
 
 @pytest.mark.integration
@@ -139,10 +171,7 @@ def test_load_pandas_dataframe_to_table_with_replace(database_table_fixture):
         target_table=table,
     )
 
-    statement = f"SELECT * FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement)
-
-    rows = response.fetchall()
+    rows = database.fetch_all_rows(table)
     assert len(rows) == 3
     assert rows[0] == (1,)
     assert rows[1] == (2,)
@@ -153,9 +182,7 @@ def test_load_pandas_dataframe_to_table_with_replace(database_table_fixture):
         target_table=table,
     )
 
-    statement = f"SELECT * FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement)
-    rows = response.fetchall()
+    rows = database.fetch_all_rows(table)
     assert len(rows) == 2
     assert rows[0] == (3,)
     assert rows[1] == (4,)
@@ -163,7 +190,6 @@ def test_load_pandas_dataframe_to_table_with_replace(database_table_fixture):
     database.drop_table(table)
 
 
-@pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",
     [
@@ -180,13 +206,14 @@ def test_load_pandas_dataframe_to_table_with_replace(database_table_fixture):
             "table": Table(metadata=Metadata(schema=SCHEMA)),
         },
         {"database": Database.SQLITE, "table": Table()},
+        {"database": Database.DELTA, "table": Table()},
     ],
     indirect=True,
-    ids=["bigquery", "postgres", "snowflake", "sqlite"],
+    ids=["bigquery", "postgres", "snowflake", "sqlite", "delta"],
 )
 @mock.patch("astro.files.base.File.export_to_dataframe")
 @mock.patch("astro.files.base.File.export_to_dataframe_via_byte_stream")
-def test_export_to_dataframe_via_byte_stream_is_called_for_postgres(
+def test_export_to_dataframe_via_byte_stream_is_called_for(
     export_to_dataframe_via_byte_stream,
     export_to_dataframe,
     database_table_fixture,


### PR DESCRIPTION
… in databricks

# Description
Currently there is no established path for moving a dataframe into a databricks delta table except to manually save that dataframe as a local file and then push that file into delta using aql.load_file. 

## What is the new behavior?
This PR allows users to pass local dataframes into delta files using all of the existing methods withing the astro SDK (e.g. passing it into a transform function). Users should not need to learn any new functionality as all of this will work out of the box with existing aql based DAGs.

## Does this introduce a breaking change?
No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
