### PR TITLE
Change attrs to attr

### DIFF
--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -1,7 +1,7 @@
-from attrs import define
+import attr
 
 
-@define
+@attr.define
 class LoadOptions:
     def empty(self):
         return NotImplementedError()


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
CI on main is failing with following:
```
ImportError while loading conftest '/home/runner/work/astro-sdk/astro-sdk/python-sdk/conftest.py'.
conftest.py:17: in <module>
    from astro.databricks.load_options import default_delta_options
src/astro/databricks/load_options.py:6: in <module>
    from astro.options import LoadOptions
src/astro/options.py:1: in <module>
    from attrs import define
E   ModuleNotFoundError: No module named 'attrs'
nox > Command pytest tests/test_example_dags.py tests/integration_test_dag.py failed with exit code 4
```


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Import attr


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
