### PR TITLE
Add load to spark gcs

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -210,7 +210,7 @@ jobs:
           key: ${{ runner.os }}-2.5-${{ hashFiles('python-sdk/pyproject.toml') }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.5.0')" -- tests/
+      - run: nox -s "test-3.8(airflow='2.5.0')" -- tests/ --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:
@@ -277,7 +277,7 @@ jobs:
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:
-          name: coverage${{ matrix.group }}
+          name: coverage-${{ matrix.group }}-integration-tests
           path: ./python-sdk/.coverage
     env:
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}

--- a/python-sdk/docs/guides/databricks.rst
+++ b/python-sdk/docs/guides/databricks.rst
@@ -95,12 +95,36 @@ The first option is to pass in an s3 conn_id to the aql.load_file function, as s
     )
 
 The second option is to pre-load your s3 secrets into the databricks cluster before setting up.
-Instructions for this can be found here. This approach has the benefit of not passing any sensitive information to databricks,
+Instructions for this can be found `here <https://docs.databricks.com/external-data/amazon-s3.html>`_. This approach has the benefit of not passing any sensitive information to databricks,
 but at the expense of the ability to load arbitrary datasets into your databricks cluster.
 
-If you want to go with this option, set the environment variable ``AIRLFOW__ASTRO_SDK__LOAD_STORAGE_CONFIGS_TO_DATABRICKS`` to false.
+If you want to go with this option, set the environment variable ``AIRLFOW__ASTRO_SDK__LOAD_STORAGE_CONFIGS_TO_DATABRICKS`` to False.
 This will ensure that the Astro SDK does not attempt to load any information to databricks.
 You can also set this value on a per-job basis using the ``astro.databricks.DeltaLoadOptions`` class.
+
+Loading files from GCS
+======================
+
+GCS support works very similar to how S3 support is mentioned above. Users who want to manage their databricks loading manually
+can follow `This guide <https://docs.gcp.databricks.com/external-data/gcs.html>`_ and set ``AIRLFOW__ASTRO_SDK__LOAD_STORAGE_CONFIGS_TO_DATABRICKS`` to False.
+For those who want Airflow to handle access management, simply offer a gcs_conn in their file and all necessary credentials
+will be loaded to databricks using the secrets API.
+
+.. code-block:: python
+
+    file = File("gs://tmp9/databricks-test/", conn_id="gcp_conn", filetype=FileType.CSV)
+    aql.load_file(
+        input_file=file,
+        output_table=Table(conn_id="my_databricks_conn"),
+    )
+
+
+NOTE:
+-----
+In order to use the GCS -> Databricks automatic connection, we require one of these to be true:
+1. You set ``key_path`` to your auth file in the ``extras`` section of your GCS connection
+2. You set ``keyfile_dict`` to a dictionary of credentials in the ``extras`` section of your GCS connection
+3. You set the environment variable ``GOOGLE_APPLICATION_CREDENTIALS``
 
 Querying Data
 =============

--- a/python-sdk/src/astro/databricks/load_file/jinja_templates/load_secrets.py.jinja2
+++ b/python-sdk/src/astro/databricks/load_file/jinja_templates/load_secrets.py.jinja2
@@ -3,6 +3,7 @@ secret_key_list = dbutils.secrets.list("{{ secret_scope }}")
 for secret_key in secret_key_list:
     if 'astro_sdk_' in secret_key.key:
         key_name = secret_key.key.replace("astro_sdk_","")
-        logger.info(f"setting {key_name}")
+        # We are using print here as we have yet to find a way to make logs surface in the databricks UI
+        print(f"setting {key_name}")
         sc._jsc.hadoopConfiguration().set(key_name, dbutils.secrets.get("{{ secret_scope }}", secret_key.key))
 {%- endmacro -%}

--- a/python-sdk/src/astro/databricks/load_file/load_file_job.py
+++ b/python-sdk/src/astro/databricks/load_file/load_file_job.py
@@ -21,7 +21,7 @@ from astro.table import BaseTable
 
 cwd = pathlib.Path(__file__).parent
 
-supported_file_locations = [FileLocation.LOCAL, FileLocation.S3]
+supported_file_locations = [FileLocation.LOCAL, FileLocation.S3, FileLocation.GS]
 
 
 def load_file_to_delta(
@@ -119,7 +119,7 @@ def _load_secrets_to_databricks(api_client: ApiClient, input_file: File, secret_
     """
     create_secrets(
         scope_name=secret_scope_name,
-        filesystem_secrets=input_file.location.databricks_settings(),
+        filesystem_secrets=input_file.location.databricks_auth_settings(),
         api_client=api_client,
     )
 

--- a/python-sdk/src/astro/files/locations/amazon/s3.py
+++ b/python-sdk/src/astro/files/locations/amazon/s3.py
@@ -67,7 +67,7 @@ class S3Location(BaseFileLocation):
         """
         return urlparse(self.path).path
 
-    def databricks_settings(self) -> dict:
+    def databricks_auth_settings(self) -> dict:
         """
         Required settings to upload this file into databricks. Only needed for cloud storage systems
         like S3

--- a/python-sdk/src/astro/files/locations/base.py
+++ b/python-sdk/src/astro/files/locations/base.py
@@ -132,7 +132,7 @@ class BaseFileLocation(ABC):
         except OSError:
             return False
 
-    def databricks_settings(self) -> dict:
+    def databricks_auth_settings(self) -> dict:
         """
         Required settings to upload this file into databricks. Only needed for cloud storage systems
         like S3

--- a/python-sdk/src/astro/files/locations/google/gcs.py
+++ b/python-sdk/src/astro/files/locations/google/gcs.py
@@ -1,11 +1,32 @@
 from __future__ import annotations
 
+import json
+import os
 from urllib.parse import urlparse, urlunparse
 
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
 from astro.constants import FileLocation
 from astro.files.locations.base import BaseFileLocation
+
+
+def _pull_credentials_from_json_dict(creds_json: dict) -> dict:
+    expected_values = {"client_email", "project_id", "private_key", "private_key_id"}
+    missing_values = expected_values - set(creds_json.keys())
+    if missing_values:
+        raise ValueError(f"Error retrieving GCP credentials. missing key(s): {','.join(missing_values)}")
+    return {
+        "spark.hadoop.google.cloud.auth.service.account.enable": "true",
+        "spark.hadoop.fs.gs.auth.service.account.email": creds_json["client_email"],
+        "spark.hadoop.fs.gs.project.id": creds_json["project_id"],
+        "spark.hadoop.fs.gs.auth.service.account.private.key": creds_json["private_key"],
+        "spark.hadoop.fs.gs.auth.service.account.private.key.id": creds_json["private_key_id"],
+    }
+
+
+def _pull_credentials_from_keypath(creds_dict: dict) -> dict:
+    with open(creds_dict["key_path"]) as f:
+        return _pull_credentials_from_json_dict(json.loads(f.read()))
 
 
 class GCSLocation(BaseFileLocation):
@@ -42,6 +63,27 @@ class GCSLocation(BaseFileLocation):
         if object_name.startswith("/"):
             object_name = object_name[1:]
         return int(self.hook.get_size(bucket_name=bucket_name, object_name=object_name))
+
+    def databricks_auth_settings(self) -> dict:
+        """
+        Required settings to upload this file into databricks. Only needed for cloud storage systems
+        like S3
+        :return: A dictionary of settings keys to settings values
+        """
+        creds_dict = self.hook.get_connection(self.conn_id).extra_dejson
+        if creds_dict.get("key_path"):
+            return _pull_credentials_from_keypath(creds_dict=creds_dict)
+        elif creds_dict.get("keyfile_dict"):
+            return _pull_credentials_from_json_dict(creds_dict.get("keyfile_dict"))
+        elif os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+            return _pull_credentials_from_json_dict(
+                {"key_path": os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")}
+            )
+        else:
+            raise ValueError(
+                "Error: to pull credentials from GCP We either need a keyfile or a keyfile_dict "
+                "to retrieve credentials"
+            )
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/python-sdk/tests/databricks/load_file/test_load_python_code_generator.py
+++ b/python-sdk/tests/databricks/load_file/test_load_python_code_generator.py
@@ -46,7 +46,8 @@ secret_gen_string = """secret_key_list = dbutils.secrets.list("astro-sdk-secrets
 for secret_key in secret_key_list:
     if 'astro_sdk_' in secret_key.key:
         key_name = secret_key.key.replace("astro_sdk_","")
-        logger.info(f"setting {key_name}")
+        # We are using print here as we have yet to find a way to make logs surface in the databricks UI
+        print(f"setting {key_name}")
         sc._jsc.hadoopConfiguration().set(key_name, dbutils.secrets.get("astro-sdk-secrets", secret_key.key))"""
 
 

--- a/python-sdk/tests/files/locations/test_gcs.py
+++ b/python-sdk/tests/files/locations/test_gcs.py
@@ -1,6 +1,10 @@
-from unittest.mock import patch
+from unittest import mock
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
 
 from astro.files.locations import create_file_location
+from astro.files.locations.google.gcs import GCSLocation, _pull_credentials_from_json_dict
 
 
 @patch(
@@ -11,3 +15,54 @@ def test_remote_object_store_prefix(remote_file):
     """with remote filepath having prefix"""
     location = create_file_location("gs://tmp/house")
     assert sorted(location.paths) == sorted(["gs://tmp/house1.csv", "gs://tmp/house2.csv"])
+
+
+mock_creds = {"client_email": "foo", "project_id": "bar", "private_key": "baz", "private_key_id": "fizz"}
+
+
+def test_pull_from_json_dict():
+    with pytest.raises(ValueError) as exc_info:
+        _pull_credentials_from_json_dict({"client_email": "foo", "project_id": "bar", "private_key": "baz"})
+    assert exc_info.value.args[0] == "Error retrieving GCP credentials. missing key(s): private_key_id"
+    working_json = _pull_credentials_from_json_dict(mock_creds)
+    assert working_json == {
+        "spark.hadoop.fs.gs.auth.service.account.email": "foo",
+        "spark.hadoop.fs.gs.auth.service.account.private.key": "baz",
+        "spark.hadoop.fs.gs.auth.service.account.private.key.id": "fizz",
+        "spark.hadoop.fs.gs.project.id": "bar",
+        "spark.hadoop.google.cloud.auth.service.account.enable": "true",
+    }
+
+
+@pytest.mark.parametrize("input_dict", [{}], ids=["empty_dict"])
+def test_databricks_auth_no_value(input_dict):
+    with mock.patch(
+        "astro.files.locations.google.gcs.GCSLocation.hook", new_callable=PropertyMock
+    ), pytest.raises(ValueError) as exc_info:
+        mock_conn = MagicMock()
+        mock_conn.extra_dejson = input_dict
+        location = GCSLocation(path="gs://foo/bar", conn_id="mock_gcs_conn")
+        location.hook.get_connection.return_value.extra_dejson = {}
+        location.databricks_auth_settings()
+    assert (
+        exc_info.value.args[0]
+        == "Error: to pull credentials from GCP We either need a keyfile or a keyfile_dict to retrieve credentials"
+    )
+
+
+@pytest.mark.parametrize(
+    "input_dict", [{"key_path": "foo/bar"}, {"keyfile_dict": mock_creds}], ids=["key_path", "key_dict"]
+)
+def test_databricks_auth(input_dict):
+    with mock.patch(
+        "astro.files.locations.google.gcs.GCSLocation.hook", new_callable=PropertyMock
+    ), mock.patch("astro.files.locations.google.gcs._pull_credentials_from_keypath") as mock_keypath:
+        mock_conn = MagicMock()
+        mock_conn.extra_dejson = input_dict
+        location = GCSLocation(path="gs://foo/bar", conn_id="mock_gcs_conn")
+        location.hook.get_connection.return_value.extra_dejson = input_dict
+        location.databricks_auth_settings()
+        if input_dict.get("key_path"):
+            mock_keypath.assert_called_once()
+        else:
+            mock_keypath.assert_not_called()

--- a/python-sdk/tests_integration/databricks/test_load.py
+++ b/python-sdk/tests_integration/databricks/test_load.py
@@ -53,3 +53,61 @@ def test_autoloader_load_file_s3(database_table_fixture):
         input_file=file,
         output_table=table,
     )
+    assert database.table_exists(table)
+    database.drop_table(table)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.DELTA,
+        }
+    ],
+    indirect=True,
+    ids=["delta"],
+)
+def test_delta_load_file_gcs(database_table_fixture):
+    from astro.constants import FileType
+
+    file = File(
+        "gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.csv",
+        conn_id="databricks_gcs",
+        filetype=FileType.CSV,
+    )
+    database, table = database_table_fixture
+    database.load_file_to_table(
+        input_file=file,
+        output_table=table,
+    )
+    assert database.table_exists(table)
+    database.drop_table(table)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.DELTA,
+        }
+    ],
+    indirect=True,
+    ids=["delta"],
+)
+def test_delta_load_file_gcs_default_connection(database_table_fixture):
+    from astro.constants import FileType
+
+    file = File(
+        "gs://astro-sdk/benchmark/trimmed/covid_overview/covid_overview_10kb.csv",
+        conn_id="google_cloud_default",
+        filetype=FileType.CSV,
+    )
+    database, table = database_table_fixture
+    database.load_file_to_table(
+        input_file=file,
+        output_table=table,
+    )
+    assert database.table_exists(table)
+    database.drop_table(table)


### PR DESCRIPTION
# Description

## What is the new behavior?
This PR adds the ability for GCP users to load GCS files to delta for processing in databricks automatically. It is worth noting that this is optional, as users can turn off secret loading and manually add GCS settings to their databricks cluster using [this guide](https://docs.gcp.databricks.com/external-data/gcs.html) if they prefer. The main benefit here is that users do not need to set these settings ahead of time.

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
