### PR TITLE
Fix elapsed seconds for run command

### DIFF
--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -211,8 +211,8 @@ def run(
     elif dr.state == State.FAILED:
         final_state = "[bold red]FAILED 💥[/bold red]"
     rprint(f"Completed running the workflow {dr.dag_id}. Final state: {final_state}")
-    elapsed_seconds = (dr.end_date - dr.start_date).microseconds / 10**6
-    rprint(f"Total elapsed time: [bold blue]{elapsed_seconds:.2}s[/bold blue]")
+    elapsed_seconds = (dr.end_date - dr.start_date).total_seconds()
+    rprint(f"Total elapsed time: [bold blue]{elapsed_seconds:.2f}s[/bold blue]")
 
 
 @app.command(


### PR DESCRIPTION
The previous implementation just considers the microseconds and ignores all other attributes like seconds, minutes and hours. e.g if the difference is 00:00:05.7878, it only took 7878 and wrote in the output as 0.78 seconds, whereas the output should have been 5.79 seconds with rounding the output to 2 decimal places. The fix includes using the total_seconds() method of the timedelta object to calculate the dag run duration accurately for the output.