### PR TITLE
Deprecate `export_file` before renaming it `export_table_to_file`

### DIFF
--- a/python-sdk/docs/astro/sql/operators/export.rst
+++ b/python-sdk/docs/astro/sql/operators/export.rst
@@ -1,16 +1,16 @@
-.. _export_file:
+.. _export_table_to_file:
 
-================================================================
-:py:mod:`export_file operator <astro.sql.operators.export_file>`
-================================================================
+==================================================================================
+:py:mod:`export_table_to_file operator <astro.sql.operators.export_table_to_file>`
+==================================================================================
 
-.. _export_file_operator:
+.. _export_table_to_file_operator:
 
-When to use the ``export_file`` operator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When to use the ``export_table_to_file`` operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``export_file`` operator allows you to write SQL tables to CSV or parquet files and store them locally, on S3, or on GCS. The ``export_file`` function can export data from :ref:`supported_databases` or a Pandas dataframe.
 
-There are two main uses for the ``export_file`` operator.
+There are two main uses for the ``export_table_to_file`` operator.
 
 Case 1: Export data from a table.
 

--- a/python-sdk/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/python-sdk/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -30,7 +30,7 @@ def example_amazon_s3_postgres_load_and_save():
         # [END named_table_example]  skipcq: PY-W0069
     )
 
-    aql.export_file(
+    aql.export_table_to_file(
         input_data=t1,
         output_file=File(path=f"{s3_bucket}/homes.csv"),
         if_exists="replace",

--- a/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
+++ b/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
@@ -52,7 +52,7 @@ with DAG(
     # [START export_example_1]
     gcs_bucket = os.getenv("GCS_BUCKET", "gs://dag-authoring")
 
-    aql.export_file(
+    aql.export_table_to_file(
         task_id="save_file_to_gcs",
         input_data=t1,
         output_file=File(

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -7,6 +7,7 @@ from astro.sql.operators.cleanup import CleanupOperator, cleanup
 from astro.sql.operators.dataframe import DataframeOperator, dataframe
 from astro.sql.operators.drop import DropTableOperator, drop_table
 from astro.sql.operators.export_file import ExportFileOperator, export_file
+from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
 from astro.sql.operators.load_file import LoadFileOperator, load_file
 from astro.sql.operators.merge import MergeOperator, merge
 from astro.sql.operators.raw_sql import RawSQLOperator, run_raw_sql
@@ -24,6 +25,8 @@ __all__ = [
     "drop_table",
     "ExportFileOperator",
     "export_file",
+    "ExportTableToFileOperator",
+    "export_table_to_file",
     "get_value_list",
     "LoadFileOperator",
     "load_file",

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import pandas as pd
-from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
-from astro.airflow.datasets import kwargs_with_datasets
 from astro.constants import ExportExistsStrategy
-from astro.databases import create_database
 from astro.files import File
-from astro.sql.operators.base_operator import AstroSQLBaseOperator
-from astro.table import BaseTable, Table
-from astro.utils.typing_compat import Context
+from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
+from astro.table import BaseTable
 
 
-class ExportFileOperator(AstroSQLBaseOperator):
+class ExportFileOperator(ExportTableToFileOperator):
     """Write SQL table to csv/parquet on local/S3/GCS.
 
     :param input_data: Table to convert to file
@@ -32,108 +29,13 @@ class ExportFileOperator(AstroSQLBaseOperator):
         if_exists: ExportExistsStrategy = "exception",
         **kwargs,
     ) -> None:
-        self.output_file = output_file
-        self.input_data = input_data
-        self.if_exists = if_exists
-        self.kwargs = kwargs
-        datasets = {"output_datasets": self.output_file}
-        if isinstance(input_data, Table):
-            datasets["input_datasets"] = input_data
-        super().__init__(**kwargs_with_datasets(kwargs=kwargs, **datasets))
-
-    def execute(self, context: Context) -> File:  # skipcq PYL-W0613
-        """Write SQL table to csv/parquet on local/S3/GCS.
-
-        Infers SQL database type based on connection.
-        """
-        # Infer db type from `input_conn_id`.
-        if isinstance(self.input_data, BaseTable):
-            database = create_database(self.input_data.conn_id, table=self.input_data)
-            self.input_data = database.populate_table_metadata(self.input_data)
-            df = database.export_table_to_pandas_dataframe(self.input_data)
-        elif isinstance(self.input_data, pd.DataFrame):
-            df = self.input_data
-        else:
-            raise ValueError(f"Expected input_table to be Table or dataframe. Got {type(self.input_data)}")
-        # Write file if overwrite == True or if file doesn't exist.
-        if self.if_exists == "replace" or not self.output_file.exists():
-            self.output_file.create_from_dataframe(df, store_as_dataframe=False)
-            return self.output_file
-        else:
-            raise FileExistsError(f"{self.output_file.path} file already exists.")
-
-    def get_openlineage_facets_on_complete(self, task_instance):  # skipcq: PYL-W0613
-        """
-        Collect the input, output, job and run facets for export file operator
-        """
-
-        from astro.lineage import (
-            BaseFacet,
-            DataQualityMetricsInputDatasetFacet,
-            DataSourceDatasetFacet,
-            OpenlineageDataset,
-            OperatorLineage,
-            OutputStatisticsOutputDatasetFacet,
-            SchemaDatasetFacet,
-            SchemaField,
-        )
-        from astro.lineage.facets import ExportFileFacet
-
-        input_dataset: list[OpenlineageDataset] = []
-        if isinstance(self.input_data, BaseTable) and self.input_data.openlineage_emit_temp_table_event():
-            input_dataset = [
-                OpenlineageDataset(
-                    namespace=self.input_data.openlineage_dataset_namespace(),
-                    name=self.input_data.openlineage_dataset_name(),
-                    facets={
-                        "dataSource": DataSourceDatasetFacet(
-                            name=self.input_data.openlineage_dataset_name(),
-                            uri=self.input_data.openlingeage_dataset_uri(),
-                        ),
-                        "schema": SchemaDatasetFacet(
-                            fields=[
-                                SchemaField(
-                                    name=self.input_data.metadata.schema,
-                                    type=self.input_data.metadata.database,
-                                )
-                            ]
-                        ),
-                        "dataQualityMetrics": DataQualityMetricsInputDatasetFacet(
-                            rowCount=self.input_data.row_count, columnMetrics={}
-                        ),
-                    },
-                )
-            ]
-        output_uri = (
-            f"{self.output_file.openlineage_dataset_namespace}" f"{self.output_file.openlineage_dataset_name}"
-        )
-        output_dataset = [
-            OpenlineageDataset(
-                namespace=self.output_file.openlineage_dataset_namespace,
-                name=self.output_file.openlineage_dataset_name,
-                facets={
-                    "output_file_facet": ExportFileFacet(
-                        filepath=self.output_file.path,
-                        file_size=self.output_file.size,
-                        file_type=self.output_file.type.name,
-                        if_exists=self.if_exists,
-                    ),
-                    "dataSource": DataSourceDatasetFacet(name=self.output_file.path, uri=output_uri),
-                    "outputStatistics": OutputStatisticsOutputDatasetFacet(
-                        rowCount=self.input_data.row_count
-                        if isinstance(self.input_data, BaseTable)
-                        else len(self.input_data),
-                        size=self.output_file.size,
-                    ),
-                },
-            )
-        ]
-
-        run_facets: dict[str, BaseFacet] = {}
-        job_facets: dict[str, BaseFacet] = {}
-
-        return OperatorLineage(
-            inputs=input_dataset, outputs=output_dataset, run_facets=run_facets, job_facets=job_facets
+        super().__init__(input_data=input_data, output_file=output_file, if_exists=if_exists, **kwargs)
+        warnings.warn(
+            """This class is deprecated.
+            Please use `astro.sql.operators.export_table_to_file.ExportTableToFileOperator`.
+            And, will be removed in astro-sdk-python>=1.4.0.""",
+            DeprecationWarning,
+            stacklevel=2,
         )
 
 
@@ -170,12 +72,14 @@ def export_file(
     :param task_id: task id, optional
     """
 
-    task_id = task_id or get_unique_task_id("export_file")
+    warnings.warn(
+        """This decorator is deprecated.
+        Please use `astro.sql.operators.export_table_to_file.export_table_to_file`.
+        And, will be removed in astro-sdk-python>=1.4.0.""",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    return ExportFileOperator(
-        task_id=task_id,
-        output_file=output_file,
-        input_data=input_data,
-        if_exists=if_exists,
-        **kwargs,
-    ).output
+    return export_table_to_file(
+        input_data=input_data, output_file=output_file, if_exists=if_exists, task_id=task_id, **kwargs
+    )

--- a/python-sdk/src/astro/sql/operators/export_table_to_file.py
+++ b/python-sdk/src/astro/sql/operators/export_table_to_file.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+from airflow.decorators.base import get_unique_task_id
+from airflow.models.xcom_arg import XComArg
+
+from astro.airflow.datasets import kwargs_with_datasets
+from astro.constants import ExportExistsStrategy
+from astro.databases import create_database
+from astro.files import File
+from astro.sql.operators.base_operator import AstroSQLBaseOperator
+from astro.table import BaseTable, Table
+from astro.utils.typing_compat import Context
+
+
+class ExportTableToFileOperator(AstroSQLBaseOperator):
+    """Write SQL table to csv/parquet on local/S3/GCS.
+
+    :param input_data: Table to convert to file
+    :param output_file: File object containing the path to the file and connection id.
+    :param if_exists: Overwrite file if exists. Default False.
+    """
+
+    template_fields = ("input_data", "output_file")
+
+    def __init__(
+        self,
+        input_data: BaseTable | pd.DataFrame,
+        output_file: File,
+        if_exists: ExportExistsStrategy = "exception",
+        **kwargs,
+    ) -> None:
+        self.output_file = output_file
+        self.input_data = input_data
+        self.if_exists = if_exists
+        self.kwargs = kwargs
+        datasets = {"output_datasets": self.output_file}
+        if isinstance(input_data, Table):
+            datasets["input_datasets"] = input_data
+        super().__init__(**kwargs_with_datasets(kwargs=kwargs, **datasets))
+
+    def execute(self, context: Context) -> File:  # skipcq PYL-W0613
+        """Write SQL table to csv/parquet on local/S3/GCS.
+
+        Infers SQL database type based on connection.
+        """
+        # Infer db type from `input_conn_id`.
+        if isinstance(self.input_data, BaseTable):
+            database = create_database(self.input_data.conn_id, table=self.input_data)
+            self.input_data = database.populate_table_metadata(self.input_data)
+            df = database.export_table_to_pandas_dataframe(self.input_data)
+        elif isinstance(self.input_data, pd.DataFrame):
+            df = self.input_data
+        else:
+            raise ValueError(f"Expected input_table to be Table or dataframe. Got {type(self.input_data)}")
+        # Write file if overwrite == True or if file doesn't exist.
+        if self.if_exists == "replace" or not self.output_file.exists():
+            self.output_file.create_from_dataframe(df, store_as_dataframe=False)
+            return self.output_file
+        else:
+            raise FileExistsError(f"{self.output_file.path} file already exists.")
+
+    def get_openlineage_facets_on_complete(self, task_instance):  # skipcq: PYL-W0613
+        """
+        Collect the input, output, job and run facets for export file operator
+        """
+
+        from astro.lineage import (
+            BaseFacet,
+            DataQualityMetricsInputDatasetFacet,
+            DataSourceDatasetFacet,
+            OpenlineageDataset,
+            OperatorLineage,
+            OutputStatisticsOutputDatasetFacet,
+            SchemaDatasetFacet,
+            SchemaField,
+        )
+        from astro.lineage.facets import ExportFileFacet
+
+        input_dataset: list[OpenlineageDataset] = []
+        if isinstance(self.input_data, BaseTable) and self.input_data.openlineage_emit_temp_table_event():
+            input_dataset = [
+                OpenlineageDataset(
+                    namespace=self.input_data.openlineage_dataset_namespace(),
+                    name=self.input_data.openlineage_dataset_name(),
+                    facets={
+                        "dataSource": DataSourceDatasetFacet(
+                            name=self.input_data.openlineage_dataset_name(),
+                            uri=self.input_data.openlingeage_dataset_uri(),
+                        ),
+                        "schema": SchemaDatasetFacet(
+                            fields=[
+                                SchemaField(
+                                    name=self.input_data.metadata.schema,
+                                    type=self.input_data.metadata.database,
+                                )
+                            ]
+                        ),
+                        "dataQualityMetrics": DataQualityMetricsInputDatasetFacet(
+                            rowCount=self.input_data.row_count, columnMetrics={}
+                        ),
+                    },
+                )
+            ]
+        output_uri = (
+            f"{self.output_file.openlineage_dataset_namespace}" f"{self.output_file.openlineage_dataset_name}"
+        )
+        output_dataset = [
+            OpenlineageDataset(
+                namespace=self.output_file.openlineage_dataset_namespace,
+                name=self.output_file.openlineage_dataset_name,
+                facets={
+                    "output_file_facet": ExportFileFacet(
+                        filepath=self.output_file.path,
+                        file_size=self.output_file.size,
+                        file_type=self.output_file.type.name,
+                        if_exists=self.if_exists,
+                    ),
+                    "dataSource": DataSourceDatasetFacet(name=self.output_file.path, uri=output_uri),
+                    "outputStatistics": OutputStatisticsOutputDatasetFacet(
+                        rowCount=self.input_data.row_count
+                        if isinstance(self.input_data, BaseTable)
+                        else len(self.input_data),
+                        size=self.output_file.size,
+                    ),
+                },
+            )
+        ]
+
+        run_facets: dict[str, BaseFacet] = {}
+        job_facets: dict[str, BaseFacet] = {}
+
+        return OperatorLineage(
+            inputs=input_dataset, outputs=output_dataset, run_facets=run_facets, job_facets=job_facets
+        )
+
+
+def export_table_to_file(
+    input_data: BaseTable | pd.DataFrame,
+    output_file: File,
+    if_exists: ExportExistsStrategy = "exception",
+    task_id: str | None = None,
+    **kwargs: Any,
+) -> XComArg:
+    """Convert ExportTableToFileOperator into a function. Returns XComArg.
+
+    Returns an XComArg object of type File which matches the output_file parameter.
+
+    This will allow users to perform further actions with the exported file.
+
+    e.g.:
+
+    .. code-block:: python
+
+      with sample_dag:
+          table = aql.load_file(input_file=File(path=data_path), output_table=test_table)
+          exported_file = aql.export_file(
+              input_data=table,
+              output_file=File(path="/tmp/saved_df.csv"),
+              if_exists="replace",
+          )
+          res_df = aql.load_file(input_file=exported_file)
+
+
+    :param output_file: Path and conn_id
+    :param input_data: Input table / dataframe
+    :param if_exists: Overwrite file if exists. Default "exception"
+    :param task_id: task id, optional
+    """
+
+    task_id = task_id or get_unique_task_id("export_table_to_file")
+
+    return ExportTableToFileOperator(
+        task_id=task_id,
+        output_file=output_file,
+        input_data=input_data,
+        if_exists=if_exists,
+        **kwargs,
+    ).output

--- a/python-sdk/tests/benchmark/README.md
+++ b/python-sdk/tests/benchmark/README.md
@@ -110,7 +110,7 @@ If you're interested in running each test case more times, this is an example of
 ./run.sh 5
 ```
 
-It is also possible to specify the chunk size, if the `load_file` or `export_file` operators are being used, by setting an integer value in the environment variable `ASTRO_CHUNKSIZE`.
+It is also possible to specify the chunk size, if the `load_file` or `export_table_to_file` operators are being used, by setting an integer value in the environment variable `ASTRO_CHUNKSIZE`.
 
 The command outputs something similar to:
 ```

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -52,6 +52,37 @@ def test_raise_exception_for_invalid_input_type():
     assert exc_info.value.args[0] == expected_msg
 
 
+def test_warnings_message():
+    from astro.sql.operators.export_file import (
+        ExportFileOperator,
+        export_file,
+    )
+    with pytest.warns(expected_warning=DeprecationWarning,
+                      match="""This class is deprecated.
+            Please use `astro.sql.operators.export_table_to_file.ExportTableToFileOperator`.
+            And, will be removed in astro-sdk-python>=1.4.0."""):
+        ExportFileOperator(
+            task_id="task_id",
+            input_data=123,
+            output_file=File(
+                path="gs://astro-sdk/workspace/openlineage_export_file.csv",
+                conn_id="bigquery",
+                filetype=FileType.CSV,
+            ),
+            if_exists="replace",
+        )
+
+    with pytest.warns(expected_warning=DeprecationWarning,
+                      match="""This decorator is deprecated.
+        Please use `astro.sql.operators.export_table_to_file.export_table_to_file`.
+        And, will be removed in astro-sdk-python>=1.4.0."""):
+        export_file(
+            input_data=Table(),
+            output_file=File(path="/tmp/saved_df.csv"),
+            if_exists="replace"
+        )
+
+
 @pytest.mark.parametrize("database_table_fixture", [{"database": Database.SQLITE}], indirect=True)
 def test_save_temp_table_to_local(sample_dag, database_table_fixture):
     _, test_table = database_table_fixture
@@ -106,8 +137,8 @@ def test_save_returns_output_file(sample_dag, database_table_fixture):
     indirect=True,
 )
 def test_unique_task_id_for_same_path(
-    sample_dag,
-    database_table_fixture,
+        sample_dag,
+        database_table_fixture,
 ):
     _, test_table = database_table_fixture
     file_name = f"{test_utils.get_table_name('output')}.csv"

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -6,11 +6,11 @@ import pytest
 
 import astro.sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
-from astro.constants import Database, FileType
+from astro.constants import Database
 from astro.files import File
 
 # Import Operator
-from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
+from astro.sql.operators.export_table_to_file import export_table_to_file
 from astro.table import Table
 
 from ..operators import utils as test_utils

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -53,14 +53,14 @@ def test_raise_exception_for_invalid_input_type():
 
 
 def test_warnings_message():
-    from astro.sql.operators.export_file import (
-        ExportFileOperator,
-        export_file,
-    )
-    with pytest.warns(expected_warning=DeprecationWarning,
-                      match="""This class is deprecated.
+    from astro.sql.operators.export_file import ExportFileOperator, export_file
+
+    with pytest.warns(
+        expected_warning=DeprecationWarning,
+        match="""This class is deprecated.
             Please use `astro.sql.operators.export_table_to_file.ExportTableToFileOperator`.
-            And, will be removed in astro-sdk-python>=1.4.0."""):
+            And, will be removed in astro-sdk-python>=1.4.0.""",
+    ):
         ExportFileOperator(
             task_id="task_id",
             input_data=123,
@@ -72,15 +72,13 @@ def test_warnings_message():
             if_exists="replace",
         )
 
-    with pytest.warns(expected_warning=DeprecationWarning,
-                      match="""This decorator is deprecated.
+    with pytest.warns(
+        expected_warning=DeprecationWarning,
+        match="""This decorator is deprecated.
         Please use `astro.sql.operators.export_table_to_file.export_table_to_file`.
-        And, will be removed in astro-sdk-python>=1.4.0."""):
-        export_file(
-            input_data=Table(),
-            output_file=File(path="/tmp/saved_df.csv"),
-            if_exists="replace"
-        )
+        And, will be removed in astro-sdk-python>=1.4.0.""",
+    ):
+        export_file(input_data=Table(), output_file=File(path="/tmp/saved_df.csv"), if_exists="replace")
 
 
 @pytest.mark.parametrize("database_table_fixture", [{"database": Database.SQLITE}], indirect=True)
@@ -137,8 +135,8 @@ def test_save_returns_output_file(sample_dag, database_table_fixture):
     indirect=True,
 )
 def test_unique_task_id_for_same_path(
-        sample_dag,
-        database_table_fixture,
+    sample_dag,
+    database_table_fixture,
 ):
     _, test_table = database_table_fixture
     file_name = f"{test_utils.get_table_name('output')}.csv"

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -36,51 +36,6 @@ def test_save_dataframe_to_local(sample_dag):
     assert df.equals(pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]}))
 
 
-def test_raise_exception_for_invalid_input_type():
-    with pytest.raises(ValueError) as exc_info:
-        ExportTableToFileOperator(
-            task_id="task_id",
-            input_data=123,
-            output_file=File(
-                path="gs://astro-sdk/workspace/openlineage_export_file.csv",
-                conn_id="bigquery",
-                filetype=FileType.CSV,
-            ),
-            if_exists="replace",
-        ).execute(context=None)
-    expected_msg = "Expected input_table to be Table or dataframe. Got <class 'int'>"
-    assert exc_info.value.args[0] == expected_msg
-
-
-def test_warnings_message():
-    from astro.sql.operators.export_file import ExportFileOperator, export_file
-
-    with pytest.warns(
-        expected_warning=DeprecationWarning,
-        match="""This class is deprecated.
-            Please use `astro.sql.operators.export_table_to_file.ExportTableToFileOperator`.
-            And, will be removed in astro-sdk-python>=1.4.0.""",
-    ):
-        ExportFileOperator(
-            task_id="task_id",
-            input_data=123,
-            output_file=File(
-                path="gs://astro-sdk/workspace/openlineage_export_file.csv",
-                conn_id="bigquery",
-                filetype=FileType.CSV,
-            ),
-            if_exists="replace",
-        )
-
-    with pytest.warns(
-        expected_warning=DeprecationWarning,
-        match="""This decorator is deprecated.
-        Please use `astro.sql.operators.export_table_to_file.export_table_to_file`.
-        And, will be removed in astro-sdk-python>=1.4.0.""",
-    ):
-        export_file(input_data=Table(), output_file=File(path="/tmp/saved_df.csv"), if_exists="replace")
-
-
 @pytest.mark.parametrize("database_table_fixture", [{"database": Database.SQLITE}], indirect=True)
 def test_save_temp_table_to_local(sample_dag, database_table_fixture):
     _, test_table = database_table_fixture

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -6,11 +6,11 @@ import pytest
 
 import astro.sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
-from astro.constants import Database
+from astro.constants import Database, FileType
 from astro.files import File
 
 # Import Operator
-from astro.sql.operators.export_file import export_file
+from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
 from astro.table import Table
 
 from ..operators import utils as test_utils
@@ -25,7 +25,7 @@ def test_save_dataframe_to_local(sample_dag):
 
     with sample_dag:
         df = make_df()
-        aql.export_file(
+        aql.export_table_to_file(
             input_data=df,
             output_file=File(path="/tmp/saved_df.csv"),
             if_exists="replace",
@@ -34,6 +34,22 @@ def test_save_dataframe_to_local(sample_dag):
 
     df = pd.read_csv("/tmp/saved_df.csv")
     assert df.equals(pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]}))
+
+
+def test_raise_exception_for_invalid_input_type():
+    with pytest.raises(ValueError) as exc_info:
+        ExportTableToFileOperator(
+            task_id="task_id",
+            input_data=123,
+            output_file=File(
+                path="gs://astro-sdk/workspace/openlineage_export_file.csv",
+                conn_id="bigquery",
+                filetype=FileType.CSV,
+            ),
+            if_exists="replace",
+        ).execute(context=None)
+    expected_msg = "Expected input_table to be Table or dataframe. Got <class 'int'>"
+    assert exc_info.value.args[0] == expected_msg
 
 
 @pytest.mark.parametrize("database_table_fixture", [{"database": Database.SQLITE}], indirect=True)
@@ -65,7 +81,7 @@ def test_save_returns_output_file(sample_dag, database_table_fixture):
     data_path = str(CWD) + "/../../data/homes.csv"
     with sample_dag:
         table = aql.load_file(input_file=File(path=data_path), output_table=test_table)
-        file = aql.export_file(
+        file = aql.export_table_to_file(
             input_data=table,
             output_file=File(path="/tmp/saved_df.csv"),
             if_exists="replace",
@@ -108,14 +124,14 @@ def test_unique_task_id_for_same_path(
 
             if i == 3:
                 params["task_id"] = "task_id"
-            task = export_file(**params)
+            task = export_table_to_file(**params)
             tasks.append(task)
     test_utils.run_dag(sample_dag)
 
     assert tasks[0].operator.task_id != tasks[1].operator.task_id
-    assert tasks[0].operator.task_id == "export_file"
-    assert tasks[1].operator.task_id == "export_file__1"
-    assert tasks[2].operator.task_id == "export_file__2"
+    assert tasks[0].operator.task_id == "export_table_to_file"
+    assert tasks[1].operator.task_id == "export_table_to_file__1"
+    assert tasks[2].operator.task_id == "export_table_to_file__2"
     assert tasks[3].operator.task_id == "task_id"
 
     os.remove(OUTPUT_FILE_PATH)
@@ -126,7 +142,7 @@ def test_inlets_outlets_supported_ds():
     """Test Datasets are set as inlets and outlets"""
     input_data = Table("test_name")
     output_file = File("gs://bucket/object.csv")
-    task = aql.export_file(
+    task = aql.export_table_to_file(
         input_data=input_data,
         output_file=output_file,
     )
@@ -139,7 +155,7 @@ def test_inlets_outlets_non_supported_ds():
     """Test inlets and outlets are not set if Datasets are not supported"""
     input_data = Table("test_name")
     output_file = File("gs://bucket/object.csv")
-    task = aql.export_file(
+    task = aql.export_table_to_file(
         input_data=input_data,
         output_file=output_file,
     )

--- a/python-sdk/tests_integration/extractors/test_extractor.py
+++ b/python-sdk/tests_integration/extractors/test_extractor.py
@@ -16,7 +16,7 @@ from astro.files import File
 from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
 from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.sql import AppendOperator, DataframeOperator, MergeOperator
-from astro.sql.operators.export_file import ExportFileOperator
+from astro.sql.operators.export_table_to_file import ExportTableToFileOperator
 from astro.sql.operators.load_file import LoadFileOperator
 from astro.sql.operators.transform import TransformOperator
 from astro.table import Metadata, Table
@@ -132,7 +132,7 @@ def test_python_sdk_export_file_extract_on_complete():
     """
     Tests that  the custom PythonSDKExtractor is able to process the
     operator's metadata that needs to be extracted as per OpenLineage
-    for ExportFileOperator.
+    for ExportTableToFileOperator.
     """
     load_file = LoadFileOperator(
         task_id="load_file",
@@ -144,7 +144,7 @@ def test_python_sdk_export_file_extract_on_complete():
     load_file.execute(context=create_context(load_file))
 
     task_id = "export_file"
-    export_file_operator = ExportFileOperator(
+    export_file_operator = ExportTableToFileOperator(
         task_id=task_id,
         input_data=Table(conn_id="sqlite_conn", name="test_extractor"),
         output_file=File(
@@ -156,7 +156,7 @@ def test_python_sdk_export_file_extract_on_complete():
     )
 
     task_instance = TaskInstance(task=export_file_operator)
-    python_sdk_extractor = Extractors().get_extractor_class(ExportFileOperator)
+    python_sdk_extractor = Extractors().get_extractor_class(ExportTableToFileOperator)
     assert python_sdk_extractor is DefaultExtractor
     task_meta_extract = python_sdk_extractor(export_file_operator).extract()
     assert task_meta_extract is None

--- a/python-sdk/tests_integration/sql/operators/test_export_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_export_file.py
@@ -12,7 +12,7 @@ from astro import sql as aql
 from astro.constants import SUPPORTED_FILE_TYPES, Database, FileType
 from astro.files import File
 from astro.settings import SCHEMA
-from astro.sql import ExportTableToFileOperator, ExportFileOperator, export_file, export_table_to_file
+from astro.sql import ExportFileOperator, ExportTableToFileOperator, export_file, export_table_to_file
 from astro.table import Table
 
 from ..operators import utils as test_utils

--- a/python-sdk/tests_integration/sql/operators/test_export_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_export_file.py
@@ -12,7 +12,7 @@ from astro import sql as aql
 from astro.constants import SUPPORTED_FILE_TYPES, Database, FileType
 from astro.files import File
 from astro.settings import SCHEMA
-from astro.sql import ExportTableToFileOperator, export_file, export_table_to_file
+from astro.sql import ExportTableToFileOperator, ExportFileOperator, export_file, export_table_to_file
 from astro.table import Table
 
 from ..operators import utils as test_utils
@@ -333,8 +333,6 @@ def test_raise_exception_for_invalid_input_type():
 
 # TODO: Remove this test in astro-sdk 1.4
 def test_warnings_message():
-    from astro.sql.operators.export_file import ExportFileOperator, export_file
-
     with pytest.warns(
         expected_warning=DeprecationWarning,
         match="""This class is deprecated.

--- a/python-sdk/tests_integration/sql/operators/test_export_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_export_file.py
@@ -12,7 +12,7 @@ from astro import sql as aql
 from astro.constants import SUPPORTED_FILE_TYPES, Database, FileType
 from astro.files import File
 from astro.settings import SCHEMA
-from astro.sql import export_file, ExportTableToFileOperator, export_table_to_file
+from astro.sql import ExportTableToFileOperator, export_file, export_table_to_file
 from astro.table import Table
 
 from ..operators import utils as test_utils


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/1411

## What is the current behavior?
we have the `export_file` operator but we want to rename it to `export_table_to_file` operator since this is the last patch release before 1.4 so lets deprecate it in 1.3.1


## What is the new behavior?
Deprecate export_file before renaming it export_table_to_file



### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
