### PR TITLE
Make environment optional for Config instance

### DIFF
--- a/sql-cli/sql_cli/project.py
+++ b/sql-cli/sql_cli/project.py
@@ -82,7 +82,7 @@ class Project:
         Initialises global config file that includes configuration to be shared across environments including the
         airflow config.
         """
-        config = Config(environment=DEFAULT_ENVIRONMENT, project_dir=self.directory)
+        config = Config(project_dir=self.directory)
         global_env_filepath = config.get_global_config_filepath()
         # If the `Airflow Home` directory does not exist, Airflow initialisation flow takes care of creating the
         # directory. We rely on this behaviour and hence do not raise an exception if the path specified as

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -22,7 +22,7 @@ connections:
     schema: pagila
     login: postgres
     password: $POSTGRES_PASSWORD
-    port: 5432
+    port: $POSTGRES_PORT
 
   - conn_id: redshift_conn
     conn_type: redshift

--- a/sql-cli/tests/test_configuration.py
+++ b/sql-cli/tests/test_configuration.py
@@ -12,3 +12,12 @@ def test_from_yaml_to_config():
     assert config_from_file.project_dir == config_reference.project_dir
     assert config_from_file.environment == config_reference.environment
     assert config_from_file.connections
+
+
+def test_from_yaml_to_config_without_env():
+    config_reference = Config(project_dir=Path(__file__).parent.parent / "include/base")
+    config_from_file = config_reference.from_yaml_to_config()
+    assert isinstance(config_from_file, Config)
+    assert config_from_file.project_dir == config_reference.project_dir
+    assert config_from_file.environment is None
+    assert config_from_file.connections == []


### PR DESCRIPTION
The Config instance has environment as a required param. However, for generating a config instance just to retrieve global config keys, we had a need to pass some environment key and if we need to set a random value like `global` it creates a problem if someone calls the method `get_env_config_filepath` because the directory `global` no longer exists. Hence, allow the creation of Config instance by making environment key optional.

Also, re-add env var for postgres password in test configuration.yml