### PR TITLE
Add a check to make sure the rows are iteratable and not none

### DIFF
--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -48,7 +48,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
             return result
         elif self.handler:
             response = self.handler(result)
-            response = [SdkLegacyRow.from_legacy_row(r) if isinstance(r, SQLAlcRow) else r for r in response]
+            response = self.make_row_serializable(response)
             if 0 <= self.response_limit < len(response):
                 raise IllegalLoadToDatabaseException()  # pragma: no cover
             if self.response_size >= 0:
@@ -57,6 +57,15 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
                 return response
         else:
             return None
+
+    @staticmethod
+    def make_row_serializable(rows):
+        """
+        Convert rows to a serializable format
+        """
+        if rows is not None and hasattr(rows, "__iter__"):
+            return [SdkLegacyRow.from_legacy_row(r) if isinstance(r, SQLAlcRow) else r for r in rows]
+        return rows
 
 
 class SdkLegacyRow(SQLAlcRow):

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -63,7 +63,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
         """
         Convert rows to a serializable format
         """
-        if isinstance(rows, Iterable) and not isinstance(rows, str):
+        if isinstance(rows, Iterable):
             return [SdkLegacyRow.from_legacy_row(r) if isinstance(r, SQLAlcRow) else r for r in rows]
         return rows
 

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -59,11 +59,11 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
             return None
 
     @staticmethod
-    def make_row_serializable(rows):
+    def make_row_serializable(rows: SQLAlcRow):
         """
         Convert rows to a serializable format
         """
-        if rows is not None and hasattr(rows, "__iter__"):
+        if isinstance(rows, Iterable):
             return [SdkLegacyRow.from_legacy_row(r) if isinstance(r, SQLAlcRow) else r for r in rows]
         return rows
 

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -59,11 +59,11 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
             return None
 
     @staticmethod
-    def make_row_serializable(rows: SQLAlcRow):
+    def make_row_serializable(rows: Any) -> Any:
         """
         Convert rows to a serializable format
         """
-        if isinstance(rows, Iterable):
+        if isinstance(rows, Iterable) and not isinstance(rows, str):
             return [SdkLegacyRow.from_legacy_row(r) if isinstance(r, SQLAlcRow) else r for r in rows]
         return rows
 

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -1,0 +1,18 @@
+import pathlib
+
+import pytest
+
+from astro import sql as aql
+
+CWD = pathlib.Path(__file__).parent
+DATA_FILEPATH = pathlib.Path(CWD.parent.parent, "data/sample.csv")
+
+
+@pytest.mark.parametrize("rows", [([], []), (["a", "b"], ["a", "b"]), ("a", "a"), (1, 1), (None, None)])
+def test_make_row_serializable(rows):
+    """
+    Test make_row_serializable() only modifies SQLAlcRow object
+    """
+    input_rows, expected_output = rows
+    result = aql.RawSQLOperator.make_row_serializable(input_rows)
+    assert result == expected_output

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -8,7 +8,7 @@ CWD = pathlib.Path(__file__).parent
 DATA_FILEPATH = pathlib.Path(CWD.parent.parent, "data/sample.csv")
 
 
-@pytest.mark.parametrize("rows", [([], []), (["a", "b"], ["a", "b"]), ("a", "a"), (1, 1), (None, None)])
+@pytest.mark.parametrize("rows", [([], []), (["a", "b"], ["a", "b"]), (1, 1), (None, None)])
 def test_make_row_serializable(rows):
     """
     Test make_row_serializable() only modifies SQLAlcRow object


### PR DESCRIPTION
# Description
## What is the current behavior?
Right now we don't have a check to make sure the rows returned by handler

related: #1232
related: #1351

## What is the new behavior?
Added a check to make sure the object returned by the handler is not None and is iterable.

## Does this introduce a breaking change?
Nope
