### PR TITLE
Fix fetch_all test to reflect change to -1 vs. 0 as default

### DIFF
--- a/python-sdk/tests_integration/databases/test_all_databases.py
+++ b/python-sdk/tests_integration/databases/test_all_databases.py
@@ -142,7 +142,7 @@ def test_fetch_all_rows(mock_run_sql, database_table_fixture, row_count):
     db.fetch_all_rows(table, row_count)
     select_statements = [m.args[0] for m in mock_run_sql.mock_calls if m.args and "SELECT" in m.args[0]]
     assert len(select_statements) == 1
-    if row_count > 0:
+    if row_count > -1:
         assert f"LIMIT {row_count}" in select_statements[0]
     else:
         assert f"LIMIT {row_count}" not in select_statements[0]


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently the test_fetch_all test is broken due to a last minute change to make the default -1 and not 0. This PR fixes that minor bug

-
-
-

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
