### PR TITLE
Install poetry in nox sessions using session.run using pip instead of session.install

### DIFF
--- a/sql-cli/noxfile.py
+++ b/sql-cli/noxfile.py
@@ -33,7 +33,7 @@ def test(session: nox.Session, airflow: str) -> None:
         }
     )
 
-    session.install("poetry")
+    session.run("pip", "install", "poetry")
 
     if airflow.startswith("2.2."):
         # To install some versions of Airflow, we need constraints, due to issues like:


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
We're seeing intermittently the following issue in our CI runs:
```
Run nox -s "test-3.9(airflow='2.4')"
nox > Running session test-3.9(airflow='2.4')
nox > Re-using existing virtual environment at .nox/test-3-9-airflow-2-4.
nox > python -m pip install poetry
nox > Error: python is not installed into the virtualenv, it is located at /opt/hostedtoolcache/Python/3.9.16/x64/bin/python. Pass external=True into run() to explicitly allow this.
nox > Session test-3.9(airflow='2.4') failed.
Error: Process completed with exit code 1.
```

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->

related: #1444 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The nox documentation [here](https://nox.thea.codes/en/stable/config.html#configuring-a-session-s-virtualenv) says the following:
```
Use of session.install() is deprecated without a virtualenv since it modifies the global Python environment. If this is what you really want, use session.run() and pip instead.
```

So, try `session.run` with `pip install` instead of `session.install` to install `poetry`
## Does this introduce a breaking change?
No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
