### PR TITLE
Disable Custom serialization for Back-compat

### DIFF
--- a/python-sdk/src/astro/dataframes/pandas.py
+++ b/python-sdk/src/astro/dataframes/pandas.py
@@ -49,5 +49,7 @@ class PandasDataframe(DataFrame):
         return PandasDataframe.from_pandas_df(read_json(data["data"]))
 
     @classmethod
-    def from_pandas_df(cls, df: DataFrame) -> PandasDataframe:
+    def from_pandas_df(cls, df: DataFrame) -> DataFrame | PandasDataframe:
+        if not settings.NEED_CUSTOM_SERIALIZATION:
+            return df
         return cls(df)

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -1,6 +1,8 @@
 import tempfile
 
 from airflow.configuration import conf
+from airflow.version import version as airflow_version
+from packaging.version import Version
 
 from astro.constants import DEFAULT_SCHEMA
 
@@ -34,6 +36,13 @@ OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.getboolean(
     SECTION_KEY, "openlineage_emit_temp_table_event", fallback=True
 )
 XCOM_BACKEND = conf.get("core", "xcom_backend")
+IS_BASE_XCOM_BACKEND = conf.get("core", "xcom_backend") == "airflow.models.xcom.BaseXCom"
+ENABLE_XCOM_PICKLING = conf.getboolean("core", "enable_xcom_pickling")
+AIRFLOW_25_PLUS = Version(airflow_version) >= Version("2.5.0")
+# We only need AstroPandasDataframe and other custom serialization and deserialization
+# if Airflow >= 2.5 and Pickling is not enabled and neither Custom XCom backend is used
+NEED_CUSTOM_SERIALIZATION = AIRFLOW_25_PLUS and IS_BASE_XCOM_BACKEND and not ENABLE_XCOM_PICKLING
+
 IS_CUSTOM_XCOM_BACKEND = XCOM_BACKEND not in [
     "airflow.models.xcom.BaseXCom",
     "astro.custom_backend.astro_custom_backend.AstroCustomXcomBackend",

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -63,6 +63,8 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
         """
         Convert rows to a serializable format
         """
+        if not settings.NEED_CUSTOM_SERIALIZATION:
+            return rows
         if isinstance(rows, Iterable):
             return [SdkLegacyRow.from_legacy_row(r) if isinstance(r, SQLAlcRow) else r for r in rows]
         return rows

--- a/python-sdk/tests/dataframes/test_pandas.py
+++ b/python-sdk/tests/dataframes/test_pandas.py
@@ -13,6 +13,19 @@ def test_from_pandas_df():
     assert df.equals(astro_df)
 
 
+@mock.patch("astro.utils.dataframe.settings.NEED_CUSTOM_SERIALIZATION", False)
+def test_from_pandas_df_returns_pandas_type():
+    """
+    Test that PandasDataframe is unchanged when a Custom XCom backend is used or XCom pickling is enabled
+    or Airflow version is <2.5
+    """
+    df = pd.DataFrame([{"id": 1, "name": "xyz"}, {"id": 2, "name": "abc"}])
+    astro_df = PandasDataframe.from_pandas_df(df)
+    assert not isinstance(astro_df, PandasDataframe)
+    assert isinstance(astro_df, pd.DataFrame)
+    assert df.equals(astro_df)
+
+
 def test_serialize_deserialize_with_larger_df(tmp_path):
     """
     Test that we do not store the entire dataframe in DB if it is greater and we can correctly


### PR DESCRIPTION
We only need AstroPandasDataframe and other custom serialization and deserialization if Airflow >= 2.5 and Pickling is not enabled and neither Custom XCom backend is used.

For others, we should leave it untouched.


(This PR is not strictly needed, I need it right now for internal purposes for Cloud IDE)