### PR TITLE
Use correct file in example_load_file DAG

### DIFF
--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -157,8 +157,8 @@ Refer to :ref:`load_file_working` for details on Native Path.
 
         .. literalinclude:: ../../../../example_dags/example_load_file.py
            :language: python
-           :start-after: [START load_file_example_9]
-           :end-before: [END load_file_example_9]
+           :start-after: [START load_file_example_17]
+           :end-before: [END load_file_example_17]
 
 .. _supported_native_path:
 

--- a/python-sdk/docs/configurations.rst
+++ b/python-sdk/docs/configurations.rst
@@ -124,8 +124,6 @@ or by updating Airflow's configuration
    [astro_sdk]
    auto_add_inlets_outlets = True
 
-.. _configure_native_fallback:
-
 Configuring to emit temp table event in openlineage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Astro SDK has ability to create temporary tables see: :ref:`table`.
@@ -145,6 +143,7 @@ or by updating Airflow's configuration
    [astro_sdk]
    openlineage_emit_temp_table_event = True
 
+.. _configure_native_fallback:
 
 Configuring the native fallback mechanism
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -159,7 +159,7 @@ with dag:
     # [START load_file_example_12]
     aql.load_file(
         input_file=File(
-            "s3://astro-sdk/python_sdk/example_dags/data/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),
@@ -183,7 +183,7 @@ with dag:
     # [START load_file_example_14]
     aql.load_file(
         input_file=File(
-            "s3://astro-sdk/python_sdk/example_dags/data/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),
@@ -217,7 +217,7 @@ with dag:
     # [START load_file_example_17]
     aql.load_file(
         input_file=File(
-            "s3://astro-sdk/python_sdk/example_dags/data/sample_pattern.csv",
+            "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id="bigquery",
             filetype=FileType.CSV,
         ),


### PR DESCRIPTION
https://github.com/astronomer/astro-sdk/pull/1297 changed all the files to use S3, even though from PR description it should have only changed HTTP path.

Due to this we were trying to use S3 files with Bigquery connection ID weirdly

