### PR TITLE
Generate constraints on releases and pushes (not PRs)

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -364,6 +364,7 @@ jobs:
       AZURE_WASB_CONN_STRING: ${{ secrets.AZURE_WASB_CONN_STRING }}
 
   Generate-Constraints:
+    if: (github.event_name == 'release' || github.event_name == 'push')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This will limit generating constraints on releases and pushes (not PRs). I don't think we need to generate constraints on every PR
