### PR TITLE
Add merge function to databricks delta

### DIFF
--- a/python-sdk/src/astro/databricks/delta.py
+++ b/python-sdk/src/astro/databricks/delta.py
@@ -374,7 +374,7 @@ class DeltaDatabase(BaseDatabase):
         )
         statement = (
             f"merge into {target_table_identifier} as `target_table` "
-            f"using {source_table_identifier}as `source_table`"
+            f"using {source_table_identifier} as `source_table`"
             f" on {merge_clauses}"
         )
 

--- a/python-sdk/tests/benchmark/dags/benchmark_gcs_to_big_query.py
+++ b/python-sdk/tests/benchmark/dags/benchmark_gcs_to_big_query.py
@@ -96,7 +96,7 @@ load_five_gb = GCSToBigQueryOperator(
 )
 
 delete_test_dataset = BigQueryDeleteDatasetOperator(
-    task_id="delete_airflow_test_dataset",
+    task_id="delete_airflow_dataset",
     dataset_id=DATASET_NAME,
     delete_contents=True,
     dag=dag,

--- a/python-sdk/tests/databricks_tests/test_databricks_api_util.py
+++ b/python-sdk/tests/databricks_tests/test_databricks_api_util.py
@@ -27,7 +27,7 @@ def raise_not_exist_error(unneeded_arg):
 
 
 @mock.patch("databricks_cli.secrets.api.SecretApi.delete_scope")
-@mock.patch("databricks_cli.sdk.api_client.ApiClient")
+@mock.patch("databricks_cli.sdk.api_client.ApiClient", autospec=True)
 def test_delete_scope_http_error_arbitary(mock_api_client, mock_delete_secret):
     """Raise error when delete_scope throw error"""
     mock_delete_secret.raiseError.side_effect = raise_arb_http_error
@@ -37,7 +37,7 @@ def test_delete_scope_http_error_arbitary(mock_api_client, mock_delete_secret):
 
 
 @mock.patch("databricks_cli.secrets.api.SecretApi.delete_scope")
-@mock.patch("databricks_cli.sdk.api_client.ApiClient")
+@mock.patch("databricks_cli.sdk.api_client.ApiClient", autospec=True)
 def test_delete_scope_http_error_non_existent(mock_api_client, mock_delete_secret):
     """Do not raise an error when trying to delete non-existent scope and the error code is RESOURCE_DOES_NOT_EXIST"""
     mock_delete_secret.side_effect = raise_not_exist_error

--- a/python-sdk/tests_integration/databricks_tests/test_databricks_api_util.py
+++ b/python-sdk/tests_integration/databricks_tests/test_databricks_api_util.py
@@ -1,24 +1,128 @@
 import pathlib
+from unittest import mock
+from unittest.mock import Mock, call
 
 import pytest
+from requests.exceptions import HTTPError
 
-from astro.constants import Database
-from astro.databricks.api_utils import delete_secret_scope
+from astro.databricks.api_utils import (
+    create_and_run_job,
+    create_secrets,
+    delete_secret_scope,
+    load_file_to_dbfs,
+)
 
 CWD = pathlib.Path(__file__).parent
 
 
-@pytest.mark.integration
-@pytest.mark.parametrize(
-    "database_table_fixture",
-    [
-        {
-            "database": Database.DELTA,
-        }
-    ],
-    indirect=True,
-    ids=["delta"],
-)
-def test_delete_scope_nonexistent(database_table_fixture):
-    db, _ = database_table_fixture
-    delete_secret_scope("non-existent-scope", api_client=db.api_client)
+def raise_arb_http_error(unneeded_arg):
+    arbitrary_http = HTTPError()
+    arbitrary_http.response = Mock(json=lambda: {"error_code": "FOOBAR"})
+    raise arbitrary_http
+
+
+def raise_not_exist_error(unneeded_arg):
+    non_existent_http = HTTPError()
+    non_existent_http.response = Mock(json=lambda: {"error_code": "RESOURCE_DOES_NOT_EXIST"})
+
+
+@mock.patch("databricks_cli.secrets.api.SecretApi.delete_scope")
+@mock.patch("databricks_cli.sdk.api_client.ApiClient")
+def test_delete_scope_http_error_arbitary(mock_api_client, mock_delete_secret):
+    """Raise error when delete_scope throw error"""
+    mock_delete_secret.raiseError.side_effect = raise_arb_http_error
+    mock_delete_secret.side_effect = raise_arb_http_error
+    with pytest.raises(HTTPError):
+        delete_secret_scope("non-existent-scope", api_client=mock_api_client)
+
+
+@mock.patch("databricks_cli.secrets.api.SecretApi.delete_scope")
+@mock.patch("databricks_cli.sdk.api_client.ApiClient")
+def test_delete_scope_http_error_non_existent(mock_api_client, mock_delete_secret):
+    """Do not raise an error when trying to delete non-existent scope and the error code is RESOURCE_DOES_NOT_EXIST"""
+    mock_delete_secret.side_effect = raise_not_exist_error
+    delete_secret_scope("non-existent-scope", api_client=mock_api_client)
+
+
+@mock.patch("databricks_cli.sdk.api_client.ApiClient", autospec=True)
+def test_create_and_run_job(mock_api_client):
+    create_and_run_job(
+        api_client=mock_api_client,
+        file_to_run="/foo/bar.py",
+        databricks_job_name="my-db-job",
+        existing_cluster_id="foobar",
+    )
+    mock_api_client.perform_query.return_value = {"job_id": 123}
+    calls = [
+        call.perform_query(
+            "POST",
+            "/jobs/create",
+            data={
+                "name": "my-db-job",
+                "spark_python_task": {"python_file": "/foo/bar.py"},
+                "existing_cluster_id": "foobar",
+            },
+            headers=None,
+            version=None,
+        ),
+    ]
+    mock_api_client.assert_has_calls(calls)
+
+
+@mock.patch("databricks_cli.sdk.api_client.ApiClient", autospec=True)
+def test_load_to_dbfs(mock_api_client):
+    load_file_to_dbfs(
+        local_file_path=CWD / "__init__.py", file_name="my_table.py", api_client=mock_api_client
+    )
+    calls = [
+        call.perform_query("POST", "/dbfs/mkdirs", data={"path": "dbfs:/mnt/pyscripts/"}, headers=None),
+        call.perform_query(
+            "POST",
+            "/dbfs/delete",
+            data={"path": "dbfs:/mnt/pyscripts/my_table.py", "recursive": False},
+            headers=None,
+        ),
+        call.perform_query(
+            "POST",
+            "/dbfs/put",
+            data={"path": "dbfs:/mnt/pyscripts/my_table.py", "overwrite": True},
+            headers={"Content-Type": None},
+            files={"file": mock.ANY},
+        ),
+    ]
+    mock_api_client.assert_has_calls(calls)
+
+
+@mock.patch("databricks_cli.sdk.api_client.ApiClient", autospec=True)
+def test_create_secrets(mock_api_client):
+    create_secrets(scope_name="my-scope", filesystem_secrets={"foo": "bar"}, api_client=mock_api_client)
+    calls = [
+        call.perform_query(
+            "POST",
+            "/secrets/scopes/create",
+            data={"scope": "my-scope"},
+            headers=None,
+        ),
+        call.perform_query(
+            "POST",
+            "/secrets/put",
+            data={"scope": "my-scope", "key": "astro_sdk_foo", "string_value": "bar"},
+            headers=None,
+        ),
+    ]
+    mock_api_client.assert_has_calls(calls)
+
+
+@mock.patch("databricks_cli.sdk.api_client.ApiClient", autospec=True)
+def test_delete_secret_scope(mock_api_client):
+    delete_secret_scope(scope_name="my-scope", api_client=mock_api_client)
+    mock_api_client.assert_has_calls(
+        [
+            call.perform_query(
+                "POST",
+                "/secrets/scopes/delete",
+                data={"scope": "my-scope"},
+                headers=None,
+            )
+        ]
+    )

--- a/python-sdk/tests_integration/sql/operators/test_merge.py
+++ b/python-sdk/tests_integration/sql/operators/test_merge.py
@@ -113,9 +113,10 @@ def validate_results(df: pd.DataFrame, mode):
         {"database": Database.REDSHIFT},
         {"database": Database.POSTGRES},
         {"database": Database.SQLITE},
+        {"database": Database.DELTA},
     ],
     indirect=True,
-    ids=["snowflake", "bigquery", "redshift", "postgres", "sqlite"],
+    ids=["snowflake", "bigquery", "redshift", "postgres", "sqlite", "delta"],
 )
 @pytest.mark.parametrize(
     "multiple_tables_fixture",
@@ -150,9 +151,10 @@ def test_merge(database_table_fixture, multiple_tables_fixture, sample_dag, merg
         {"database": Database.SNOWFLAKE},
         {"database": Database.BIGQUERY},
         {"database": Database.REDSHIFT},
+        {"database": Database.DELTA},
     ],
     indirect=True,
-    ids=["snowflake", "bigquery", "redshift"],
+    ids=["snowflake", "bigquery", "redshift", "delta"],
 )
 @pytest.mark.parametrize(
     "multiple_tables_fixture",


### PR DESCRIPTION
# Description
## What is the current behavior?

Currently, the merge function returns a `NotImplementedError` if a user attempts to merge two delta tables. This leaves the delta astro SDK experience incomplete and can create confusion for users.

Closes #1451 

## What is the new behavior?
The new behavior is to add a merge function in a similar fashion to how we generate a merge function in snowflake. We have found these two interaces to be fairly similar so it might be worth looking into whether the functions can be merged in a future ticket.

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
