### PR TITLE
Use the latest name of export op in doc

### DIFF
--- a/python-sdk/docs/astro/sql/operators/export.rst
+++ b/python-sdk/docs/astro/sql/operators/export.rst
@@ -8,7 +8,7 @@
 
 When to use the ``export_table_to_file`` operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``export_file`` operator allows you to write SQL tables to CSV or parquet files and store them locally, on S3, or on GCS. The ``export_file`` function can export data from :ref:`supported_databases` or a Pandas dataframe.
+The ``export_table_to_file`` operator allows you to write SQL tables to CSV or parquet files and store them locally, on S3, or on GCS. The ``export_table_to_file`` function can export data from :ref:`supported_databases` or a Pandas dataframe.
 
 There are two main uses for the ``export_table_to_file`` operator.
 


### PR DESCRIPTION
# Description
## What is the current behavior?
We were using the old name `export_file` in the doc


## What is the new behavior?
Replaced it with new name - `export_table_to_file`

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
