### PR TITLE
Expose get/set deployment config in SQL CLI

### DIFF
--- a/sql-cli/Makefile
+++ b/sql-cli/Makefile
@@ -31,7 +31,7 @@ pre-commit:  # Run pre-commit
 flow:  # Build and run the latest version of flow
 
 test:  # Run tests
-	@TERMINAL_WIDTH=3000 _TYPER_FORCE_DISABLE_TERMINAL=1 PYTHONWARNINGS="ignore" poetry run pytest -k "test_config"
+	@TERMINAL_WIDTH=3000 _TYPER_FORCE_DISABLE_TERMINAL=1 PYTHONWARNINGS="ignore" poetry run pytest -vv
 
 release:  # Build a package
 	@echo -e "If this is your first time, please, manually follow these two steps: \n" \

--- a/sql-cli/Makefile
+++ b/sql-cli/Makefile
@@ -31,7 +31,7 @@ pre-commit:  # Run pre-commit
 flow:  # Build and run the latest version of flow
 
 test:  # Run tests
-	@TERMINAL_WIDTH=3000 _TYPER_FORCE_DISABLE_TERMINAL=1 PYTHONWARNINGS="ignore" poetry run pytest
+	@TERMINAL_WIDTH=3000 _TYPER_FORCE_DISABLE_TERMINAL=1 PYTHONWARNINGS="ignore" poetry run pytest -k "test_config"
 
 release:  # Build a package
 	@echo -e "If this is your first time, please, manually follow these two steps: \n" \

--- a/sql-cli/include/base/config/default/configuration.yml
+++ b/sql-cli/include/base/config/default/configuration.yml
@@ -62,3 +62,7 @@ connections:
   #   password: $SNOWFLAKE_PASSWORD
   #   schema: $SNOWFLAKE_SCHEMA
   #   extra: '{"account": "$SNOWFLAKE_ACCOUNT", "region": "$SNOWFLAKE_REGION", "role": "$SNOWFLAKE_ROLE", "warehouse": "$SNOWFLAKE_WAREHOUSE", "database": "$SNOWFLAKE_DATABASE"}'
+
+# Apache Airflow optional settings
+airflow:
+  home:

--- a/sql-cli/include/base/config/dev/configuration.yml
+++ b/sql-cli/include/base/config/dev/configuration.yml
@@ -9,3 +9,7 @@ connections:
   - conn_id: sqlite_conn
     conn_type: sqlite
     host: retail.db
+
+# Apache Airflow optional settings
+airflow:
+  home:

--- a/sql-cli/include/base/config/global.yml
+++ b/sql-cli/include/base/config/global.yml
@@ -1,5 +1,4 @@
 airflow:
   dags_folder:
-  home:
 general:
   data_dir:

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -13,7 +13,7 @@ from sql_cli.astro.command import AstroCommand
 from sql_cli.astro.group import AstroGroup
 from sql_cli.cli import config as cli_config
 from sql_cli.cli.utils import resolve_project_dir
-from sql_cli.constants import DEFAULT_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR
+from sql_cli.constants import DEFAULT_BASE_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR
 from sql_cli.exceptions import ConnectionFailed, DagCycle, EmptyDag, WorkflowFilesDirectoryNotFound
 from sql_cli.utils.rich import rprint
 
@@ -28,7 +28,7 @@ app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
     rich_markup_mode="rich",
 )
-app.add_typer(cli_config.app, name="config")
+app.add_typer(cli_config.app, name="config", hidden=True)
 
 airflow_logger = logging.getLogger("airflow")
 airflow_logger.setLevel(logging.CRITICAL)
@@ -169,7 +169,7 @@ def run(
     try:
         dr = dag_runner.run_dag(
             dag,
-            run_conf=project.airflow_config,
+            run_conf=project.get_env_airflow_config(env),
             connections={c.conn_id: c for c in project.connections},
             verbose=verbose,
         )
@@ -218,7 +218,7 @@ def init(
     airflow_home: Path = typer.Option(
         None,
         dir_okay=True,
-        help=f"(Optional) Set the Airflow Home. Default: {DEFAULT_AIRFLOW_HOME}",
+        help=f"(Optional) Set the Airflow Home. Default: {DEFAULT_BASE_AIRFLOW_HOME}/<env>/",
         show_default=False,
     ),
     airflow_dags_folder: Path = typer.Option(

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -11,6 +11,8 @@ from typer import Exit
 import sql_cli
 from sql_cli.astro.command import AstroCommand
 from sql_cli.astro.group import AstroGroup
+from sql_cli.cli import config as cli_config
+from sql_cli.cli.utils import resolve_project_dir
 from sql_cli.constants import DEFAULT_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR
 from sql_cli.exceptions import ConnectionFailed, DagCycle, EmptyDag, WorkflowFilesDirectoryNotFound
 from sql_cli.utils.rich import rprint
@@ -26,6 +28,7 @@ app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
     rich_markup_mode="rich",
 )
+app.add_typer(cli_config.app, name="config")
 
 airflow_logger = logging.getLogger("airflow")
 airflow_logger.setLevel(logging.CRITICAL)
@@ -56,33 +59,6 @@ def about() -> None:
 
 @app.command(
     cls=AstroCommand,
-    help="""
-    Gets the value of the configuration key set in the configuration file for the given environment.
-    """,
-)
-def config(
-    key: str = typer.Argument(
-        default=...,
-        show_default=False,
-        help="Key from the configuration whose value needs to be fetched.",
-    ),
-    project_dir: Path = typer.Option(
-        None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
-    ),
-    env: str = typer.Option(
-        default="default",
-        help="(Optional) Environment used to fetch the configuration key from.",
-    ),
-) -> None:
-    from sql_cli.configuration import Config
-
-    project_dir_absolute = _resolve_project_dir(project_dir)
-    project_config = Config(environment=env, project_dir=project_dir_absolute).from_yaml_to_config()
-    print(getattr(project_config, key))
-
-
-@app.command(
-    cls=AstroCommand,
     help="Generate the Airflow DAG from a directory of SQL files.",
 )
 def generate(
@@ -106,7 +82,7 @@ def generate(
 ) -> None:
     from sql_cli.project import Project
 
-    project_dir_absolute = _resolve_project_dir(project_dir)
+    project_dir_absolute = resolve_project_dir(project_dir)
     project = Project(project_dir_absolute)
     project.load_config(env)
 
@@ -140,7 +116,7 @@ def validate(
     from sql_cli.connections import validate_connections
     from sql_cli.project import Project
 
-    project_dir_absolute = _resolve_project_dir(project_dir)
+    project_dir_absolute = resolve_project_dir(project_dir)
     project = Project(project_dir_absolute)
     project.load_config(environment=env)
 
@@ -182,7 +158,7 @@ def run(
     from sql_cli.project import Project
     from sql_cli.utils.airflow import get_dag
 
-    project_dir_absolute = _resolve_project_dir(project_dir)
+    project_dir_absolute = resolve_project_dir(project_dir)
     project = Project(project_dir_absolute)
     project.load_config(env)
 
@@ -260,17 +236,10 @@ def init(
 ) -> None:
     from sql_cli.project import Project
 
-    project_dir_absolute = _resolve_project_dir(project_dir)
+    project_dir_absolute = resolve_project_dir(project_dir)
     project = Project(project_dir_absolute, airflow_home, airflow_dags_folder, data_dir)
     project.initialise()
     rprint("Initialized an Astro SQL project at", project.directory)
-
-
-def _resolve_project_dir(project_dir: Path | None) -> Path:
-    """Resolve project directory to be used by the corresponding command for its functionality."""
-    # If the caller has not supplied a `project_dir`, we assume that the user is calling the command from the project
-    # directory itself and hence we resolve the current working directory as the project directory.
-    return project_dir.resolve() if project_dir else Path.cwd()
 
 
 def _generate_dag(project: Project, workflow_name: str, generate_tasks: bool) -> Path:

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -1,26 +1,28 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import typer
 
 from sql_cli.astro.command import AstroCommand
 from sql_cli.cli.utils import resolve_project_dir
+from sql_cli.constants import DEFAULT_ENVIRONMENT
 
 app = typer.Typer()
 
 
-class InvalidGetConfigArg(Exception):
+class InvalidConfigException(Exception):
     pass
 
 
-def _get(key: str, project_dir: Path, env: str, as_json: bool) -> str | dict:
+def _get(key: str, project_dir: Path, env: str, as_json: bool) -> str:
     """
     Typer-agnostic implementation of the `config get` command.
 
-    :param key: (optional) Key to be fetched from the configuration file. If none is specified, return all.
-    :param project_dir: (optional) Path to the project directory
-    :param env: Environment configuration (default, dev)
+    :param key: Key to be fetched from the configuration file.
+    :param project_dir: Path to the project directory
+    :param env: SQL CLI environment (default, dev)
     :param as_json: If the output should be displayed as JSON.
     :returns: Either the string containing the key value or a JSON containing desired the key-value pair(s)
     """
@@ -31,17 +33,44 @@ def _get(key: str, project_dir: Path, env: str, as_json: bool) -> str | dict:
     if key:
         return getattr(project_config, key)
     elif as_json:
-        return project_config.as_json()
+        return json.dumps(project_config.to_dict())
     else:
-        raise InvalidGetConfigArg("Please, either define a key or use the --as-json flag")
+        raise InvalidConfigException("Please, either define a key or use the --as-json flag")
+
+
+def _set(key: str, project_dir: Path, env: str, astro_deployment: str, astro_workspace: str) -> None:
+    """
+    Set deployment configuration associated to a SQL CLI environment.
+
+    :param key: Configuration property (key) to be set. At the mmoment only "deploy" is accepted.
+    :param project_dir: Path to the project directory.
+    :param env: SQL CLI environment (default, dev).
+    :param astro_deployment: Astronomer Cloud deployment ID.
+    :param astro_workspace: Astronomer Cloud deployment workspace.
+    """
+    from sql_cli.configuration import Config
+
+    if key != "deploy":
+        raise InvalidConfigException(
+            f"The key {key} is not supported yet. Only deploy is currently supported."
+        )
+
+    project_dir_absolute = resolve_project_dir(project_dir)
+    project_config = Config(environment=env, project_dir=project_dir_absolute).from_yaml_to_config()
+    config_filepath = project_config.get_env_config_filepath()
+
+    project_config.write_value_to_yaml("deployment", "astro_deployment", astro_deployment, config_filepath)
+    project_config.write_value_to_yaml("deployment", "astro_workspace", astro_workspace, config_filepath)
 
 
 @app.command(
     cls=AstroCommand,
     help="""
-    Gets the project configuration. There are two was of using this:
-         1) astro config get airflow_home
-         2) astro config get --as-json
+    Get the project configuration.
+
+    Example of usages:
+    $ astro config get airflow_home
+    $ astro config get --as-json
 
     The first returns a key from the config whereas the second returns all the configuration as JSON.
     """,
@@ -50,16 +79,50 @@ def get(
     key: str = typer.Argument(
         default="",
         show_default=False,
-        help="Key from the configuration whose value needs to be fetched.",
+        help="Configuration key which value needs to be fetched.",
     ),
     project_dir: Path = typer.Option(
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
     env: str = typer.Option(
-        default="default",
+        default=DEFAULT_ENVIRONMENT,
         help="(Optional) Environment used to fetch the configuration key from.",
     ),
     as_json: bool = typer.Option(False, help="If the response should be in JSON format", show_default=True),
 ) -> None:
     value = _get(key, project_dir, env, as_json)
     print(value)
+
+
+@app.command(
+    cls=AstroCommand,
+    help="""
+   Set the project configuration.
+
+   Example:
+   $ astro config set deploy --env=dev --astro-workspace=cl123 --astro-deployment=cl345
+   """,
+)
+def set(  # noqa: A001
+    key: str = typer.Argument(
+        default="",
+        show_default=False,
+        help="Key from the configuration whose value needs to be fetched.",
+    ),
+    project_dir: Path = typer.Option(
+        None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
+    ),
+    astro_deployment: str = typer.Option(
+        ...,
+        help="Astro deployment deployment ID (e.g. cl8bqua474573873jwenjhb6bbo)",
+    ),
+    astro_workspace: str = typer.Option(
+        ...,
+        help="Astro deployment workspace ID (e.g. cl6geh889308371i01vscssm4q)",
+    ),
+    env: str = typer.Option(
+        default=DEFAULT_ENVIRONMENT,
+        help="(Optional) Environment used to fetch the configuration key from.",
+    ),
+) -> None:
+    _set(key, project_dir, env, astro_workspace=astro_workspace, astro_deployment=astro_deployment)

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -64,18 +64,19 @@ def _set(key: str, project_dir: Path, env: str, astro_deployment: str, astro_wor
 
 
 @app.command(
+    "get",
     cls=AstroCommand,
     help="""
     Get the project configuration.
 
     Example of usages:
     $ flow config get airflow_home
-    $ flow config get --as-json
+    $ flow config get --json
 
     The first returns a key from the config whereas the second returns all the configuration as JSON.
     """,
 )
-def get(
+def get_config(
     key: str = typer.Argument(
         default="",
         show_default=False,
@@ -88,23 +89,23 @@ def get(
         default=DEFAULT_ENVIRONMENT,
         help="(Optional) Environment used to fetch the configuration key from.",
     ),
-    as_json: bool = typer.Option(False, help="If the response should be in JSON format", show_default=True),
+    json: bool = typer.Option(False, help="If the response should be in JSON format", show_default=True),
 ) -> None:
-    value = _get(key, project_dir, env, as_json)
+    value = _get(key, project_dir, env, json)
     print(value)
 
 
 @app.command(
+    "set",
     cls=AstroCommand,
     help="""
-   Set the project configuration.
+    Set the project configuration.
 
-   Example:
-   $ flow config set deploy --env=dev --astro-workspace=cl123 --astro-deployment=cl345
-   """,
+    Example:
+    $ flow config set deploy --env=dev --astro-workspace=cl123 --astro-deployment=cl345
+    """,
 )
-# skipcq: PYL-W0622
-def set(  # noqa: A001
+def set_config(
     key: str = typer.Argument(
         default="",
         show_default=False,

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -103,7 +103,7 @@ def get(
    $ flow config set deploy --env=dev --astro-workspace=cl123 --astro-deployment=cl345
    """,
 )
-def set(  # noqa: A001
+def set(  # noqa: A001,  skipcq: PYL-W0622
     key: str = typer.Argument(
         default="",
         show_default=False,

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -42,15 +42,15 @@ def _get(key: str, project_dir: Path, env: str, as_json: bool) -> str:
         )
 
 
-def _set(key: str, project_dir: Path, env: str, astro_deployment: str, astro_workspace: str) -> None:
+def _set(key: str, project_dir: Path, env: str, astro_deployment_id: str, astro_workspace_id: str) -> None:
     """
     Set deployment configuration associated to a SQL CLI environment.
 
     :param key: Configuration property (key) to be set. At the mmoment only "deploy" is accepted.
     :param project_dir: Path to the project directory.
     :param env: SQL CLI environment (default, dev).
-    :param astro_deployment: Astronomer Cloud deployment ID.
-    :param astro_workspace: Astronomer Cloud deployment workspace.
+    :param astro_deployment_id: Astronomer Cloud deployment ID.
+    :param astro_workspace_id: Astronomer Cloud deployment workspace ID.
     """
     from sql_cli.configuration import Config
 
@@ -63,8 +63,12 @@ def _set(key: str, project_dir: Path, env: str, astro_deployment: str, astro_wor
     project_config = Config(environment=env, project_dir=project_dir_absolute).from_yaml_to_config()
     config_filepath = project_config.get_env_config_filepath()
 
-    project_config.write_value_to_yaml("deployment", "astro_deployment", astro_deployment, config_filepath)
-    project_config.write_value_to_yaml("deployment", "astro_workspace", astro_workspace, config_filepath)
+    project_config.write_value_to_yaml(
+        "deployment", "astro_deployment_id", astro_deployment_id, config_filepath
+    )
+    project_config.write_value_to_yaml(
+        "deployment", "astro_workspace_id", astro_workspace_id, config_filepath
+    )
 
 
 @app.command(
@@ -108,7 +112,7 @@ def get_config(
     Set the project configuration.
 
     Example:
-    $ flow config set deploy --env=dev --astro-workspace=cl123 --astro-deployment=cl345
+    $ flow config set deploy --env=dev --astro-workspace-id=cl123 --astro-deployment-id=cl345
     """,
 )
 def set_config(
@@ -120,11 +124,11 @@ def set_config(
     project_dir: Path = typer.Option(
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
-    astro_deployment: str = typer.Option(
+    astro_deployment_id: str = typer.Option(
         ...,
         help="Astro deployment deployment ID (e.g. cl8bqua474573873jwenjhb6bbo)",
     ),
-    astro_workspace: str = typer.Option(
+    astro_workspace_id: str = typer.Option(
         ...,
         help="Astro deployment workspace ID (e.g. cl6geh889308371i01vscssm4q)",
     ),
@@ -133,4 +137,6 @@ def set_config(
         help="(Optional) Environment used to fetch the configuration key from.",
     ),
 ) -> None:
-    _set(key, project_dir, env, astro_workspace=astro_workspace, astro_deployment=astro_deployment)
+    _set(
+        key, project_dir, env, astro_workspace_id=astro_workspace_id, astro_deployment_id=astro_deployment_id
+    )

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from sql_cli.astro.command import AstroCommand
+from sql_cli.cli.utils import resolve_project_dir
+
+app = typer.Typer()
+
+
+class InvalidGetConfigArg(Exception):
+    pass
+
+
+def _get(key: str, project_dir: Path, env: str, as_json: bool) -> str | dict:
+    """
+    Typer-agnostic implementation of the `config get` command.
+
+    :param key: (optional) Key to be fetched from the configuration file. If none is specified, return all.
+    :param project_dir: (optional) Path to the project directory
+    :param env: Environment configuration (default, dev)
+    :param as_json: If the output should be displayed as JSON.
+    :returns: Either the string containing the key value or a JSON containing desired the key-value pair(s)
+    """
+    from sql_cli.configuration import Config
+
+    project_dir_absolute = resolve_project_dir(project_dir)
+    project_config = Config(environment=env, project_dir=project_dir_absolute).from_yaml_to_config()
+    if key:
+        return getattr(project_config, key)
+    elif as_json:
+        return project_config.as_json()
+    else:
+        raise InvalidGetConfigArg("Please, either define a key or use the --as-json flag")
+
+
+@app.command(
+    cls=AstroCommand,
+    help="""
+    Gets the project configuration. There are two was of using this:
+         1) astro config get airflow_home
+         2) astro config get --as-json
+
+    The first returns a key from the config whereas the second returns all the configuration as JSON.
+    """,
+)
+def get(
+    key: str = typer.Argument(
+        default="",
+        show_default=False,
+        help="Key from the configuration whose value needs to be fetched.",
+    ),
+    project_dir: Path = typer.Option(
+        None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
+    ),
+    env: str = typer.Option(
+        default="default",
+        help="(Optional) Environment used to fetch the configuration key from.",
+    ),
+    as_json: bool = typer.Option(False, help="If the response should be in JSON format", show_default=True),
+) -> None:
+    value = _get(key, project_dir, env, as_json)
+    print(value)

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -30,12 +30,16 @@ def _get(key: str, project_dir: Path, env: str, as_json: bool) -> str:
 
     project_dir_absolute = resolve_project_dir(project_dir)
     project_config = Config(environment=env, project_dir=project_dir_absolute).from_yaml_to_config()
-    if key:
+    if key and as_json:
+        raise InvalidConfigException("Sorry, key and --json are mutually exclusive. Give only one of them.")
+    elif key:
         return getattr(project_config, key)
     elif as_json:
         return json.dumps(project_config.to_dict())
     else:
-        raise InvalidConfigException("Please, either define a key or use the --as-json flag")
+        raise InvalidConfigException(
+            "Please, either give a key or use the --json flag. It is mandatory to give one of them."
+        )
 
 
 def _set(key: str, project_dir: Path, env: str, astro_deployment: str, astro_workspace: str) -> None:

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -103,7 +103,8 @@ def get(
    $ flow config set deploy --env=dev --astro-workspace=cl123 --astro-deployment=cl345
    """,
 )
-def set(  # noqa: A001,  skipcq: PYL-W0622
+# skipcq: PYL-W0622
+def set(  # noqa: A001
     key: str = typer.Argument(
         default="",
         show_default=False,

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -69,8 +69,8 @@ def _set(key: str, project_dir: Path, env: str, astro_deployment: str, astro_wor
     Get the project configuration.
 
     Example of usages:
-    $ astro config get airflow_home
-    $ astro config get --as-json
+    $ flow config get airflow_home
+    $ flow config get --as-json
 
     The first returns a key from the config whereas the second returns all the configuration as JSON.
     """,
@@ -100,7 +100,7 @@ def get(
    Set the project configuration.
 
    Example:
-   $ astro config set deploy --env=dev --astro-workspace=cl123 --astro-deployment=cl345
+   $ flow config set deploy --env=dev --astro-workspace=cl123 --astro-deployment=cl345
    """,
 )
 def set(  # noqa: A001

--- a/sql-cli/sql_cli/cli/config.py
+++ b/sql-cli/sql_cli/cli/config.py
@@ -89,9 +89,11 @@ def get_config(
         default=DEFAULT_ENVIRONMENT,
         help="(Optional) Environment used to fetch the configuration key from.",
     ),
-    json: bool = typer.Option(False, help="If the response should be in JSON format", show_default=True),
+    as_json: bool = typer.Option(
+        False, "--json", help="If the response should be in JSON format", show_default=True
+    ),
 ) -> None:
-    value = _get(key, project_dir, env, json)
+    value = _get(key, project_dir, env, as_json)
     print(value)
 
 

--- a/sql-cli/sql_cli/cli/utils.py
+++ b/sql-cli/sql_cli/cli/utils.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_project_dir(project_dir: Path | None) -> Path:
+    """Resolve project directory to be used by the corresponding command for its functionality."""
+    # If the caller has not supplied a `project_dir`, we assume that the user is calling the command from the project
+    # directory itself and hence we resolve the current working directory as the project directory.
+    return project_dir.resolve() if project_dir else Path.cwd()

--- a/sql-cli/sql_cli/configuration.py
+++ b/sql-cli/sql_cli/configuration.py
@@ -67,7 +67,7 @@ class Config:
         return Config(
             project_dir=self.project_dir,
             environment=self.environment,
-            airflow_home=global_yaml_config.get("airflow", {}).get("home"),
+            airflow_home=env_yaml_config.get("airflow", {}).get("home"),
             airflow_dags_folder=global_yaml_config.get("airflow", {}).get("dags_folder"),
             data_dir=global_yaml_config.get("general", {}).get("data_dir"),
             connections=env_yaml_config.get("connections", []),
@@ -95,8 +95,13 @@ class Config:
         with filepath.open(mode="w") as fp:
             yaml.dump(yaml_config, fp)
 
-    def as_json(self):
+    def to_dict(self):
         """
         Return configuration represented as JSON string.
         """
-        return "{}"
+        config_as_dict = {"global": self.from_yaml_to_dict(self.get_global_config_filepath())}
+        if self.environment:
+            env_config = self.from_yaml_to_dict(self.get_env_config_filepath())
+            env_config.pop("connections", None)  # remove sensitive information
+            config_as_dict[self.environment] = env_config
+        return config_as_dict

--- a/sql-cli/sql_cli/configuration.py
+++ b/sql-cli/sql_cli/configuration.py
@@ -94,3 +94,9 @@ class Config:
 
         with filepath.open(mode="w") as fp:
             yaml.dump(yaml_config, fp)
+
+    def as_json(self):
+        """
+        Return configuration represented as JSON string.
+        """
+        return "{}"

--- a/sql-cli/sql_cli/configuration.py
+++ b/sql-cli/sql_cli/configuration.py
@@ -93,9 +93,11 @@ class Config:
         with filepath.open(mode="w") as fp:
             yaml.dump(yaml_config, fp)
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         """
         Return configuration represented as JSON string.
+
+        :returns: Dictionary containing non-sensitive global and per-environment configuration.
         """
         config_as_dict = {"global": self.from_yaml_to_dict(self.get_global_config_filepath())}
         if self.environment:

--- a/sql-cli/sql_cli/configuration.py
+++ b/sql-cli/sql_cli/configuration.py
@@ -9,7 +9,7 @@ import yaml
 from airflow.models.connection import Connection
 from dotenv import load_dotenv
 
-from sql_cli.constants import CONFIG_DIR, CONFIG_FILENAME, GLOBAL_CONFIG_FILENAME
+from sql_cli.constants import CONFIG_DIR, CONFIG_FILENAME, DEFAULT_ENVIRONMENT, GLOBAL_CONFIG_FILENAME
 
 
 @dataclass
@@ -19,21 +19,19 @@ class Config:
     """
 
     project_dir: Path
-    environment: str | None = None
+    environment: str = DEFAULT_ENVIRONMENT
 
     connections: list[dict[str, Connection]] = field(default_factory=list)
     airflow_home: str | None = None
     airflow_dags_folder: str | None = None
     data_dir: str | None = None
 
-    def get_env_config_filepath(self) -> Path | None:
+    def get_env_config_filepath(self) -> Path:
         """
         Return environment specific configuration.yaml filepath.
 
         :returns: The path to the desired YAML configuration file
         """
-        if not self.environment:
-            return None
         return self.project_dir / CONFIG_DIR / self.environment / CONFIG_FILENAME
 
     def get_global_config_filepath(self) -> Path:

--- a/sql-cli/sql_cli/constants.py
+++ b/sql-cli/sql_cli/constants.py
@@ -3,7 +3,7 @@ GLOBAL_CONFIG_FILENAME = "global.yml"
 CONFIG_FILENAME = "configuration.yml"
 
 DEFAULT_ENVIRONMENT = "default"
-DEFAULT_BASE_AIRFLOW_HOME = ".airflow/"
+DEFAULT_BASE_AIRFLOW_HOME = ".airflow"
 DEFAULT_DAGS_FOLDER = ".airflow/dags"
 DEFAULT_DATA_DIR = "data"
 

--- a/sql-cli/sql_cli/constants.py
+++ b/sql-cli/sql_cli/constants.py
@@ -3,7 +3,7 @@ GLOBAL_CONFIG_FILENAME = "global.yml"
 CONFIG_FILENAME = "configuration.yml"
 
 DEFAULT_ENVIRONMENT = "default"
-DEFAULT_AIRFLOW_HOME = f".airflow/{DEFAULT_ENVIRONMENT}"
+DEFAULT_BASE_AIRFLOW_HOME = ".airflow/"
 DEFAULT_DAGS_FOLDER = ".airflow/dags"
 DEFAULT_DATA_DIR = "data"
 

--- a/sql-cli/sql_cli/project.py
+++ b/sql-cli/sql_cli/project.py
@@ -113,7 +113,7 @@ class Project:
         Initialises global config YAML file that includes configuration to be shared across environments including the
         airflow config.
         """
-        config = Config(environment=DEFAULT_ENVIRONMENT, project_dir=self.directory)
+        config = Config(project_dir=self.directory)
         global_config_filepath = config.get_global_config_filepath()
         config.write_value_to_yaml(
             "general", "data_dir", self._data_dir.resolve().as_posix(), global_config_filepath

--- a/sql-cli/sql_cli/project.py
+++ b/sql-cli/sql_cli/project.py
@@ -10,7 +10,7 @@ from airflow.models.connection import Connection
 
 from sql_cli.configuration import Config
 from sql_cli.connections import convert_to_connection
-from sql_cli.constants import DEFAULT_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR, DEFAULT_ENVIRONMENT
+from sql_cli.constants import DEFAULT_BASE_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR, DEFAULT_ENVIRONMENT
 from sql_cli.exceptions import InvalidProject
 from sql_cli.utils.airflow import initialise as initialise_airflow, reload as reload_airflow
 
@@ -38,22 +38,20 @@ class Project:
         data_dir: Path | None = None,
     ) -> None:
         self.directory = directory
-        self._airflow_home = airflow_home or Path(self.directory, DEFAULT_AIRFLOW_HOME)
+        self._airflow_home = airflow_home
         self._airflow_dags_folder = airflow_dags_folder or Path(self.directory, DEFAULT_DAGS_FOLDER)
         self._data_dir = data_dir or Path(self.directory, DEFAULT_DATA_DIR)
         self.connections: list[Connection] = []
 
-    @property
-    def airflow_home(self) -> Path:
+    def get_env_airflow_home(self, env: str = DEFAULT_ENVIRONMENT) -> Path:
         """
-        Folder which contains the Airflow database and configuration.
-        Can be either user-defined, during initialisation, or the default one.
+        Return Airflow home for desired environment.
 
-        This is used by flow validate and flow run.
-
-        :returns: The path to the Airflow home directory.
+        :param env: SQL CLI environment
+        :returns: Path to environment-specific Airflow home
         """
-        return self._airflow_home
+        default_path = self.directory / DEFAULT_BASE_AIRFLOW_HOME / env
+        return self._airflow_home or default_path
 
     @property
     def airflow_dags_folder(self) -> Path:
@@ -68,6 +66,7 @@ class Project:
         return self._airflow_dags_folder
 
     @property
+<<<<<<< HEAD
     def data_dir(self) -> Path:
         """
         Folder which contains additional data files.
@@ -81,21 +80,35 @@ class Project:
 
     @property
     def airflow_config(self) -> dict[str, Any]:
+=======
+    def environments_list(self) -> list:
+        """
+        Return list with the names of the existing environments in the current project.
+
+        :returns: A list with strings representing the existing environments.
+        """
+        config_dir = self.directory / "config"
+        return [subpath.name for subpath in config_dir.iterdir() if subpath.is_dir()]
+
+    def get_env_airflow_config(self, env: str) -> dict[str, Any]:
+>>>>>>> Add flow config get --as-json option
         """
         Retrieve the Airflow configuration for the currently set environment.
 
         :returns: A Python dictionary containing the Airflow configuration.
         """
-        filename = self.airflow_home / "airflow.cfg"
+        airflow_home = self.get_env_airflow_home(env)
+        filename = airflow_home / "airflow.cfg"
         parser = ConfigParser()
         parser.read(filename)
         return {section: dict(parser.items(section)) for section in parser.sections()}
 
     def _initialise_global_config(self) -> None:
         """
-        Initialises global config file that includes configuration to be shared across environments including the
+        Initialises global config YAML file that includes configuration to be shared across environments including the
         airflow config.
         """
+<<<<<<< HEAD
         config = Config(project_dir=self.directory)
         global_env_filepath = config.get_global_config_filepath()
         config.write_value_to_yaml(
@@ -113,17 +126,55 @@ class Project:
             )
         config.write_value_to_yaml(
             "airflow", "dags_folder", self._airflow_dags_folder.resolve().as_posix(), global_env_filepath
+=======
+        config = Config(environment=DEFAULT_ENVIRONMENT, project_dir=self.directory)
+        global_config_filepath = config.get_global_config_filepath()
+        # If the `Airflow Home` directory does not exist, Airflow initialisation flow takes care of creating the
+        # directory. We rely on this behaviour and hence do not raise an exception if the path specified as
+        # `Airflow Home` does not exist.
+        if not Path.exists(self._airflow_dags_folder):
+            raise FileNotFoundError(f"Specified DAGs directory {self._airflow_dags_folder} does not exist.")
+        config.write_value_to_yaml(
+            "airflow", "dags_folder", str(self._airflow_dags_folder.resolve()), global_config_filepath
         )
 
-    def _remove_unnecessary_airflow_files(self) -> None:
+    def _initialise_env_config(self, environment: str) -> None:
         """
-        Delete Airflow generated paths which are not necessary for the SQL CLI (scheduler & webserver-related).
+        Initialises the environment YAML config file that includes environment-specific values.
+
+        :param environment: Environment to set the configuration
         """
-        logs_folder = self.airflow_home / "logs"
+        config = Config(environment=environment, project_dir=self.directory)
+        config_filepath = config.get_env_config_filepath()
+        # If the `Airflow Home` directory does not exist, Airflow initialisation flow takes care of creating the
+        # directory. We rely on this behaviour and hence do not raise an exception if the path specified as
+        # `Airflow Home` does not exist.
+        config.write_value_to_yaml(
+            "airflow", "home", str(self.get_env_airflow_home(environment)), config_filepath
+>>>>>>> Add flow config get --as-json option
+        )
+
+    def _remove_unnecessary_airflow_files(self, airflow_home: Path) -> None:
+        """
+        Delete Airflow generated paths which are not necessary for the desired Airflow home.
+
+        :param airflow_home: Path to Airflow home we want to clean up.
+        """
+        logs_folder = airflow_home / "logs"
         shutil.rmtree(logs_folder)
 
-        webserver_config = self.airflow_home / "webserver_config.py"
+        webserver_config = airflow_home / "webserver_config.py"
         webserver_config.unlink()
+
+    def _initialise_airflow_for_environment(self, env: str) -> None:
+        """
+        Initialise Airflow home for given environment.
+
+        :param env: SQL CLI environment
+        """
+        airflow_home = self.get_env_airflow_home(env)
+        initialise_airflow(airflow_home, self.airflow_dags_folder)
+        self._remove_unnecessary_airflow_files(airflow_home)
 
     def initialise(self) -> None:
         """
@@ -145,8 +196,9 @@ class Project:
             dirs_exist_ok=True,
         )
         self._initialise_global_config()
-        initialise_airflow(self.airflow_home, self.airflow_dags_folder)
-        self._remove_unnecessary_airflow_files()
+        for env in self.environments_list:
+            self._initialise_env_config(env)
+            self._initialise_airflow_for_environment(env)
 
     def is_valid_project(self) -> bool:
         """
@@ -168,11 +220,22 @@ class Project:
         config = Config(environment=environment, project_dir=self.directory).from_yaml_to_config()
         if config.airflow_home:
             self._airflow_home = Path(config.airflow_home).resolve()
+        else:
+            self._initialise_env_config(environment)
+            config = Config(environment=environment, project_dir=self.directory).from_yaml_to_config()
+
+        if not self.get_env_airflow_home(environment).exists():
+            self._initialise_airflow_for_environment(environment)
+
         if config.airflow_dags_folder:
             self._airflow_dags_folder = Path(config.airflow_dags_folder).resolve()
+<<<<<<< HEAD
         if config.data_dir:
             self._data_dir = Path(config.data_dir).resolve()
         reload_airflow(self.airflow_home)
+=======
+        reload_airflow(self.get_env_airflow_home(environment))
+>>>>>>> Add flow config get --as-json option
         self.connections = [
             convert_to_connection(connection, self._data_dir) for connection in config.connections
         ]

--- a/sql-cli/sql_cli/project.py
+++ b/sql-cli/sql_cli/project.py
@@ -83,7 +83,7 @@ class Project:
         return self._data_dir
 
     @property
-    def environments_list(self) -> list:
+    def environments_list(self) -> list[str]:
         """
         Return list with the names of the existing environments in the current project.
 

--- a/sql-cli/sql_cli/project.py
+++ b/sql-cli/sql_cli/project.py
@@ -10,7 +10,12 @@ from airflow.models.connection import Connection
 
 from sql_cli.configuration import Config
 from sql_cli.connections import convert_to_connection
-from sql_cli.constants import DEFAULT_BASE_AIRFLOW_HOME, DEFAULT_DAGS_FOLDER, DEFAULT_DATA_DIR, DEFAULT_ENVIRONMENT
+from sql_cli.constants import (
+    DEFAULT_BASE_AIRFLOW_HOME,
+    DEFAULT_DAGS_FOLDER,
+    DEFAULT_DATA_DIR,
+    DEFAULT_ENVIRONMENT,
+)
 from sql_cli.exceptions import InvalidProject
 from sql_cli.utils.airflow import initialise as initialise_airflow, reload as reload_airflow
 
@@ -66,7 +71,6 @@ class Project:
         return self._airflow_dags_folder
 
     @property
-<<<<<<< HEAD
     def data_dir(self) -> Path:
         """
         Folder which contains additional data files.
@@ -79,8 +83,6 @@ class Project:
         return self._data_dir
 
     @property
-    def airflow_config(self) -> dict[str, Any]:
-=======
     def environments_list(self) -> list:
         """
         Return list with the names of the existing environments in the current project.
@@ -91,7 +93,6 @@ class Project:
         return [subpath.name for subpath in config_dir.iterdir() if subpath.is_dir()]
 
     def get_env_airflow_config(self, env: str) -> dict[str, Any]:
->>>>>>> Add flow config get --as-json option
         """
         Retrieve the Airflow configuration for the currently set environment.
 
@@ -108,27 +109,12 @@ class Project:
         Initialises global config YAML file that includes configuration to be shared across environments including the
         airflow config.
         """
-<<<<<<< HEAD
-        config = Config(project_dir=self.directory)
-        global_env_filepath = config.get_global_config_filepath()
-        config.write_value_to_yaml(
-            "general", "data_dir", self._data_dir.resolve().as_posix(), global_env_filepath
-        )
-        # If the `Airflow Home` directory does not exist, Airflow initialisation flow takes care of creating the
-        # directory. We rely on this behaviour and hence do not raise an exception if the path specified as
-        # `Airflow Home` does not exist.
-        config.write_value_to_yaml(
-            "airflow", "home", self._airflow_home.resolve().as_posix(), global_env_filepath
-        )
-        if not self._airflow_dags_folder.exists():
-            raise FileNotFoundError(
-                f"Specified DAGs directory {self._airflow_dags_folder.as_posix()} does not exist."
-            )
-        config.write_value_to_yaml(
-            "airflow", "dags_folder", self._airflow_dags_folder.resolve().as_posix(), global_env_filepath
-=======
         config = Config(environment=DEFAULT_ENVIRONMENT, project_dir=self.directory)
         global_config_filepath = config.get_global_config_filepath()
+        config.write_value_to_yaml(
+            "general", "data_dir", self._data_dir.resolve().as_posix(), global_config_filepath
+        )
+
         # If the `Airflow Home` directory does not exist, Airflow initialisation flow takes care of creating the
         # directory. We rely on this behaviour and hence do not raise an exception if the path specified as
         # `Airflow Home` does not exist.
@@ -151,7 +137,6 @@ class Project:
         # `Airflow Home` does not exist.
         config.write_value_to_yaml(
             "airflow", "home", str(self.get_env_airflow_home(environment)), config_filepath
->>>>>>> Add flow config get --as-json option
         )
 
     def _remove_unnecessary_airflow_files(self, airflow_home: Path) -> None:
@@ -229,13 +214,9 @@ class Project:
 
         if config.airflow_dags_folder:
             self._airflow_dags_folder = Path(config.airflow_dags_folder).resolve()
-<<<<<<< HEAD
         if config.data_dir:
             self._data_dir = Path(config.data_dir).resolve()
-        reload_airflow(self.airflow_home)
-=======
         reload_airflow(self.get_env_airflow_home(environment))
->>>>>>> Add flow config get --as-json option
         self.connections = [
             convert_to_connection(connection, self._data_dir) for connection in config.connections
         ]

--- a/sql-cli/sql_cli/project.py
+++ b/sql-cli/sql_cli/project.py
@@ -139,7 +139,8 @@ class Project:
             "airflow", "home", str(self.get_env_airflow_home(environment)), config_filepath
         )
 
-    def _remove_unnecessary_airflow_files(self, airflow_home: Path) -> None:
+    @staticmethod
+    def _remove_unnecessary_airflow_files(airflow_home: Path) -> None:
         """
         Delete Airflow generated paths which are not necessary for the desired Airflow home.
 

--- a/sql-cli/sql_cli/utils/airflow.py
+++ b/sql-cli/sql_cli/utils/airflow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
+import shutil
 from configparser import ConfigParser
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -146,3 +147,16 @@ def check_for_dag_import_errors(dag_file: Path) -> dict[str, str]:
     dag_folder = process_subdir(str(dag_file))
     dagbag = DagBag(dag_folder, include_examples=False)
     return dagbag.import_errors
+
+
+def remove_unnecessary_files(airflow_home: Path) -> None:
+    """
+    Delete Airflow generated paths which are not necessary during the SQL CLI project initialisation.
+
+    :param airflow_home: Path to Airflow home we want to clean up.
+    """
+    logs_folder = airflow_home / "logs"
+    shutil.rmtree(logs_folder)
+
+    webserver_config = airflow_home / "webserver_config.py"
+    webserver_config.unlink()

--- a/sql-cli/tests/cli/test_config.py
+++ b/sql-cli/tests/cli/test_config.py
@@ -17,7 +17,8 @@ def test__get_as_json(initialised_project):
         "global": {
             "airflow": {
                 "dags_folder": str(initialised_project.directory / ".airflow/dags"),
-            }
+            },
+            "general": {"data_dir": str(initialised_project.directory / "data")},
         },
         "dev": {
             "airflow": {

--- a/sql-cli/tests/cli/test_config.py
+++ b/sql-cli/tests/cli/test_config.py
@@ -29,10 +29,19 @@ def test__get_as_json(initialised_project):
     assert computed == json.dumps(expected)
 
 
-def test__get_invalid(initialised_project):
+def test__get_invalid_missing_mandatory(initialised_project):
     with pytest.raises(InvalidConfigException) as err:
         _get("", initialised_project.directory, env="default", as_json=False)
-    assert str(err.value) == "Please, either define a key or use the --as-json flag"
+    assert (
+        str(err.value)
+        == "Please, either give a key or use the --json flag. It is mandatory to give one of them."
+    )
+
+
+def test__get_invalid_mutually_exclusive(initialised_project):
+    with pytest.raises(InvalidConfigException) as err:
+        _get("some-key", initialised_project.directory, env="default", as_json=True)
+    assert str(err.value) == "Sorry, key and --json are mutually exclusive. Give only one of them."
 
 
 def test__set_invalid(initialised_project):

--- a/sql-cli/tests/cli/test_config.py
+++ b/sql-cli/tests/cli/test_config.py
@@ -1,0 +1,40 @@
+import json
+
+import pytest
+
+from sql_cli.cli.config import InvalidConfigException, _get, _set
+
+
+def test__get_with_key(initialised_project):
+    computed = _get("airflow_home", initialised_project.directory, env="default", as_json=False)
+    expected = (initialised_project.directory / ".airflow/default").as_posix()
+    assert computed == expected
+
+
+def test__get_as_json(initialised_project):
+    computed = _get("", initialised_project.directory, env="dev", as_json=True)
+    expected = {
+        "global": {
+            "airflow": {
+                "dags_folder": str(initialised_project.directory / ".airflow/dags"),
+            }
+        },
+        "dev": {
+            "airflow": {
+                "home": str(initialised_project.directory / ".airflow/dev"),
+            }
+        },
+    }
+    assert computed == json.dumps(expected)
+
+
+def test__get_invalid(initialised_project):
+    with pytest.raises(InvalidConfigException) as err:
+        _get("", initialised_project.directory, env="default", as_json=False)
+    assert str(err.value) == "Please, either define a key or use the --as-json flag"
+
+
+def test__set_invalid(initialised_project):
+    with pytest.raises(InvalidConfigException) as err:
+        _set("not-deploy", "", "", "", "")
+    assert str(err.value) == "The key not-deploy is not supported yet. Only deploy is currently supported."

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -22,7 +22,7 @@ connections:
     schema: pagila
     login: postgres
     password: $POSTGRES_PASSWORD
-    port: 5432
+    port: $POSTGRES_PORT
 
   - conn_id: redshift_conn
     conn_type: redshift

--- a/sql-cli/tests/config/test/configuration.yml
+++ b/sql-cli/tests/config/test/configuration.yml
@@ -22,7 +22,7 @@ connections:
     schema: pagila
     login: postgres
     password: $POSTGRES_PASSWORD
-    port: $POSTGRES_PORT
+    port: 5432
 
   - conn_id: redshift_conn
     conn_type: redshift

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -119,11 +119,12 @@ def test_version():
         ("airflow_dags_folder", "airflow_home/dags"),
     ],
 )
-def test_config(key, value, initialised_project_with_custom_airflow_config):
+def test_config_get(key, value, initialised_project_with_custom_airflow_config):
     result = runner.invoke(
         app,
         [
             "config",
+            "get",
             "--project-dir",
             initialised_project_with_custom_airflow_config.directory.as_posix(),
             key,

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from sql_cli import __version__
 from sql_cli.__main__ import app
+from sql_cli.configuration import Config
 from sql_cli.connections import CONNECTION_ID_OUTPUT_STRING_WIDTH
 from tests.utils import list_dir
 
@@ -130,8 +131,29 @@ def test_config_get(key, value, initialised_project_with_custom_airflow_config):
             key,
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert value in result.stdout
+
+
+def test_config_set_deploy(initialised_project):
+    result = runner.invoke(
+        app,
+        [
+            "config",
+            "set",
+            "deploy",
+            "--project-dir",
+            initialised_project.directory.as_posix(),
+            "--astro-deployment",
+            "some-deployment",
+            "--astro-workspace",
+            "some-workspace",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    project_config = Config(environment="default", project_dir=initialised_project.directory).to_dict()
+    assert project_config["default"]["deployment"]["astro_workspace"] == "some-workspace"
+    assert project_config["default"]["deployment"]["astro_deployment"] == "some-deployment"
 
 
 @pytest.mark.parametrize(
@@ -282,8 +304,8 @@ def test_validate_all(env, initialised_project_with_test_config):
             env,
         ],
     )
-    assert result.exit_code == 0
     assert "Validating connection(s)" in result.stdout
+    assert result.exit_code == 0, result.stdout
 
 
 @pytest.mark.parametrize(

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -144,16 +144,16 @@ def test_config_set_deploy(initialised_project):
             "deploy",
             "--project-dir",
             initialised_project.directory.as_posix(),
-            "--astro-deployment",
+            "--astro-deployment-id",
             "some-deployment",
-            "--astro-workspace",
+            "--astro-workspace-id",
             "some-workspace",
         ],
     )
     assert result.exit_code == 0, result.output
     project_config = Config(environment="default", project_dir=initialised_project.directory).to_dict()
-    assert project_config["default"]["deployment"]["astro_workspace"] == "some-workspace"
-    assert project_config["default"]["deployment"]["astro_deployment"] == "some-deployment"
+    assert project_config["default"]["deployment"]["astro_workspace_id"] == "some-workspace"
+    assert project_config["default"]["deployment"]["astro_deployment_id"] == "some-deployment"
 
 
 @pytest.mark.parametrize(

--- a/sql-cli/tests/test_configuration.py
+++ b/sql-cli/tests/test_configuration.py
@@ -19,5 +19,4 @@ def test_from_yaml_to_config_without_env():
     config_from_file = config_reference.from_yaml_to_config()
     assert isinstance(config_from_file, Config)
     assert config_from_file.project_dir == config_reference.project_dir
-    assert config_from_file.environment is None
-    assert config_from_file.connections == []
+    assert config_from_file.environment == "default"

--- a/sql-cli/tests/test_project.py
+++ b/sql-cli/tests/test_project.py
@@ -11,6 +11,8 @@ BASE_PATHS = [
     Path(".airflow/default/airflow.cfg"),
     Path(".airflow/default/airflow.db"),
     Path(".airflow/dev"),
+    Path(".airflow/dev/airflow.cfg"),
+    Path(".airflow/dev/airflow.db"),
     Path(".airflow/global"),
     Path(".env"),
     Path("config"),


### PR DESCRIPTION
Refactor the retrieval of configuration to allow retrieving most of the settings by exposing them as JSON.
```
$ flow config get airflow_home
$ flow config get --as-json
```

Add command to set deployment configuration per environment, using:
```
$ flow config set deploy --env=dev --astro-workspace=cl123 --astro-deplyment-cl345
```

As part of this PR, I also refactored the Airflow home to be environment-specific.

Disclaimers:
1. The command config is hidden from end-users and is meant to be used to integrate with the Astro CLI.
2. We'll need a follow up ticket on the the Astro CLI side, changing the current call from ` flow config airflow_home` to  flow config get airflow_home`

Related: #1166


