### PR TITLE
Support for FTP as file location

### DIFF
--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -113,8 +113,8 @@ connections:
     port: 2222
   - conn_id: ftp_conn
     conn_type: ftp
-    host: localhost
-    login: foo
-    password: pass
-    port: 21
+    host: $SFTP_HOSTNAME
+    login: $SFTP_USERNAME
+    password: $SFTP_PASSWORD
+    port: 2222
     extra:

--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -113,7 +113,8 @@ connections:
     port: 2222
   - conn_id: ftp_conn
     conn_type: ftp
-    host: 127.0.0.1
-    login: $REMOTE_USERNAME
-    password: $REMOTE_PASSWORD
+    host: localhost
+    login: foo
+    password: pass
     port: 21
+    extra:

--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -113,8 +113,8 @@ connections:
     port: 2222
   - conn_id: ftp_conn
     conn_type: ftp
-    host: $SFTP_HOSTNAME
-    login: $SFTP_USERNAME
-    password: $SFTP_PASSWORD
-    port: 2222
+    host: localhost
+    login: foo
+    password: pass
+    port: 21
     extra:

--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -111,3 +111,9 @@ connections:
     login: $SFTP_USERNAME
     password: $SFTP_PASSWORD
     port: 2222
+  - conn_id: ftp_conn
+    conn_type: ftp
+    host: 127.0.0.1
+    login: $REMOTE_USERNAME
+    password: $REMOTE_PASSWORD
+    port: 21

--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -113,8 +113,8 @@ connections:
     port: 2222
   - conn_id: ftp_conn
     conn_type: ftp
-    host: localhost
-    login: foo
-    password: pass
+    host: $SFTP_HOSTNAME
+    login: $SFTP_USERNAME
+    password: $SFTP_PASSWORD
     port: 21
     extra:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -49,9 +49,6 @@ env:
   SFTP_HOSTNAME: ${{ secrets.SFTP_HOSTNAME }}
   SFTP_USERNAME: ${{ secrets.SFTP_USERNAME }}
   SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
-  REMOTE_HOSTNAME: localhost
-  REMOTE_USERNAME: foo
-  REMOTE_PASSWORD: pass
   AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: True
   AIRFLOW__ASTRO_SDK__DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
   AZURE_WASB_CONN_STRING: ${{ secrets.AZURE_WASB_CONN_STRING }}
@@ -148,8 +145,8 @@ jobs:
           - 21:21
           - 30000-30009:30000-30009
         env:
-          FTP_USER_NAME: foo
-          FTP_USER_PASS: pass
+          FTP_USER_NAME: ${{ secrets.SFTP_USERNAME }}
+          FTP_USER_PASS: ${{ secrets.SFTP_PASSWORD }}
           FTP_USER_HOME: /home/foo
           PUBLICHOST: "localhost"
     steps:
@@ -173,7 +170,6 @@ jobs:
             .nox
           key: ${{ runner.os }}-${{ hashFiles('python-sdk/pyproject.toml') }}-${{ hashFiles('python-sdk/src/astro/__init__.py') }}
       - run: cat ../.github/ci-test-connections.yaml > test-connections.yaml
-      - run: docker inspect  $(docker ps -aq)
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
@@ -283,8 +279,8 @@ jobs:
           - 21:21
           - 30000-30009:30000-30009
         env:
-          FTP_USER_NAME: foo
-          FTP_USER_PASS: pass
+          FTP_USER_NAME: ${{ secrets.SFTP_USERNAME }}
+          FTP_USER_PASS: ${{ secrets.SFTP_PASSWORD }}
           FTP_USER_HOME: /home/foo
           PUBLICHOST: "localhost"
     steps:
@@ -369,8 +365,8 @@ jobs:
           - 21:21
           - 30000-30009:30000-30009
         env:
-          FTP_USER_NAME: foo
-          FTP_USER_PASS: pass
+          FTP_USER_NAME: ${{ secrets.SFTP_USERNAME }}
+          FTP_USER_PASS: ${{ secrets.SFTP_PASSWORD }}
           FTP_USER_HOME: /home/foo
           PUBLICHOST: "localhost"
     steps:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -143,7 +143,7 @@ jobs:
         ports:
           - 2222:22
       ftp:
-        image: ghcr.io/astronomer/astro-sdk/ftp_docker
+        image: delfer/alpine-ftp-server
         ports:
           - 21:21
           - 21000-21010:21000-21010
@@ -276,7 +276,7 @@ jobs:
         ports:
           - 2222:22
       ftp:
-        image: ghcr.io/astronomer/astro-sdk/ftp_docker
+        image: delfer/alpine-ftp-server
         ports:
           - 21:21
           - 21000-21010:21000-21010
@@ -360,7 +360,7 @@ jobs:
         ports:
           - 2222:22
       ftp:
-        image: ghcr.io/astronomer/astro-sdk/ftp_docker
+        image: delfer/alpine-ftp-server
         ports:
           - 21:21
           - 21000-21010:21000-21010

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -146,10 +146,12 @@ jobs:
         image: ghcr.io/astronomer/astro-sdk/ftp_docker
         ports:
           - 21:21
-          - 21000-21010:21000-21010
+          - 30000-30009:30000-30009
         env:
-          USERS: "foo|pass|/home/foo"
-          ADDRESS: "localhost"
+          FTP_USER_NAME: foo
+          FTP_USER_PASS: pass
+          FTP_USER_HOME: /home/foo
+          PUBLICHOST: "localhost"
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
@@ -279,10 +281,12 @@ jobs:
         image: ghcr.io/astronomer/astro-sdk/ftp_docker
         ports:
           - 21:21
-          - 21000-21010:21000-21010
+          - 30000-30009:30000-30009
         env:
-          USERS: "foo|pass|/home/foo"
-          ADDRESS: "localhost"
+          FTP_USER_NAME: foo
+          FTP_USER_PASS: pass
+          FTP_USER_HOME: /home/foo
+          PUBLICHOST: "localhost"
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
@@ -363,10 +367,12 @@ jobs:
         image: ghcr.io/astronomer/astro-sdk/ftp_docker
         ports:
           - 21:21
-          - 21000-21010:21000-21010
+          - 30000-30009:30000-30009
         env:
-          USERS: "foo|pass|/home/foo"
-          ADDRESS: "localhost"
+          FTP_USER_NAME: foo
+          FTP_USER_PASS: pass
+          FTP_USER_HOME: /home/foo
+          PUBLICHOST: "localhost"
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -49,6 +49,9 @@ env:
   SFTP_HOSTNAME: ${{ secrets.SFTP_HOSTNAME }}
   SFTP_USERNAME: ${{ secrets.SFTP_USERNAME }}
   SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+  REMOTE_HOSTNAME: localhost
+  REMOTE_USERNAME: foo
+  REMOTE_PASSWORD: pass
   AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS: True
   AIRFLOW__ASTRO_SDK__DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
   AZURE_WASB_CONN_STRING: ${{ secrets.AZURE_WASB_CONN_STRING }}
@@ -139,6 +142,14 @@ jobs:
         image: ghcr.io/astronomer/astro-sdk/sftp_docker
         ports:
           - 2222:22
+      ftp:
+        image: ghcr.io/astronomer/astro-sdk/ftp_docker
+        ports:
+          - 21:21
+          - 21000-21010:21000-21010
+        env:
+          USERS: "foo|pass|/home/foo"
+          ADDRESS: localhost
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
@@ -263,6 +274,14 @@ jobs:
         image: ghcr.io/astronomer/astro-sdk/sftp_docker
         ports:
           - 2222:22
+      ftp:
+        image: ghcr.io/astronomer/astro-sdk/ftp_docker
+        ports:
+          - 21:21
+          - 21000-21010:21000-21010
+        env:
+          USERS: "foo|pass|/home/foo"
+          ADDRESS: localhost
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
@@ -339,6 +358,14 @@ jobs:
         image: ghcr.io/astronomer/astro-sdk/sftp_docker
         ports:
           - 2222:22
+      ftp:
+        image: ghcr.io/astronomer/astro-sdk/ftp_docker
+        ports:
+          - 21:21
+          - 21000-21010:21000-21010
+        env:
+          USERS: "foo|pass|/home/foo"
+          ADDRESS: 127.0.0.1
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -143,7 +143,7 @@ jobs:
         ports:
           - 2222:22
       ftp:
-        image: delfer/alpine-ftp-server
+        image: ghcr.io/astronomer/astro-sdk/ftp_docker
         ports:
           - 21:21
           - 21000-21010:21000-21010
@@ -276,7 +276,7 @@ jobs:
         ports:
           - 2222:22
       ftp:
-        image: delfer/alpine-ftp-server
+        image: ghcr.io/astronomer/astro-sdk/ftp_docker
         ports:
           - 21:21
           - 21000-21010:21000-21010
@@ -360,7 +360,7 @@ jobs:
         ports:
           - 2222:22
       ftp:
-        image: delfer/alpine-ftp-server
+        image: ghcr.io/astronomer/astro-sdk/ftp_docker
         ports:
           - 21:21
           - 21000-21010:21000-21010

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -149,7 +149,7 @@ jobs:
           - 21000-21010:21000-21010
         env:
           USERS: "foo|pass|/home/foo"
-          ADDRESS: localhost
+          ADDRESS: "localhost"
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
@@ -281,7 +281,7 @@ jobs:
           - 21000-21010:21000-21010
         env:
           USERS: "foo|pass|/home/foo"
-          ADDRESS: localhost
+          ADDRESS: "localhost"
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
@@ -365,7 +365,7 @@ jobs:
           - 21000-21010:21000-21010
         env:
           USERS: "foo|pass|/home/foo"
-          ADDRESS: 127.0.0.1
+          ADDRESS: "localhost"
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -144,7 +144,7 @@ jobs:
           - 2222:22
       ftp:
         image: ghcr.io/astronomer/astro-sdk/ftp_docker
-        container_name: ftp_docker
+        name: ftp_docker
         ports:
           - 21:21
           - 21000-21010:21000-21010

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -144,7 +144,6 @@ jobs:
           - 2222:22
       ftp:
         image: ghcr.io/astronomer/astro-sdk/ftp_docker
-        name: ftp_docker
         ports:
           - 21:21
           - 21000-21010:21000-21010
@@ -172,7 +171,7 @@ jobs:
             .nox
           key: ${{ runner.os }}-${{ hashFiles('python-sdk/pyproject.toml') }}-${{ hashFiles('python-sdk/src/astro/__init__.py') }}
       - run: cat ../.github/ci-test-connections.yaml > test-connections.yaml
-      - run: docker inspect ftp_docker
+      - run: docker inspect  $(docker ps -aq)
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -144,6 +144,7 @@ jobs:
           - 2222:22
       ftp:
         image: ghcr.io/astronomer/astro-sdk/ftp_docker
+        container_name: ftp_docker
         ports:
           - 21:21
           - 21000-21010:21000-21010
@@ -171,6 +172,7 @@ jobs:
             .nox
           key: ${{ runner.os }}-${{ hashFiles('python-sdk/pyproject.toml') }}-${{ hashFiles('python-sdk/src/astro/__init__.py') }}
       - run: cat ../.github/ci-test-connections.yaml > test-connections.yaml
+      - run: docker inspect ftp_docker
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
 | Google GCS  |
 | Google Drive|
 | SFTP        |
+| FTP         |
 
 ## Available operations
 

--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -120,6 +120,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
 | Google GCS  |
 | Google Drive|
 | SFTP        |
+| FTP         |
 
 ## Available operations
 

--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -273,6 +273,15 @@ Users can also load data from an SFTP:
    :start-after: [START load_file_example_20]
    :end-before: [END load_file_example_20]
 
+Loading data from FTP
+~~~~~~~~~~~~~~~~~~~~~~
+Users can also load data from an FTP:
+
+.. literalinclude:: ../../../../example_dags/example_load_file.py
+   :language: python
+   :start-after: [START load_file_example_21]
+   :end-before: [END load_file_example_21]
+
 
 Default Datasets
 ~~~~~~~~~~~~~~~~

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -270,7 +270,11 @@ with dag:
 
     # [START load_file_example_21]
     aql.load_file(
-        input_file=File(path="ftp://home/foo/upload/", conn_id="ftp_conn", filetype=FileType.CSV),
+        input_file=File(
+            path="ftp://home/foo/upload/ADOPTION_CENTER_1_unquoted.csv",
+            conn_id="ftp_conn",
+            filetype=FileType.CSV,
+        ),
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
             metadata=Metadata(

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -271,7 +271,7 @@ with dag:
     # [START load_file_example_21]
     aql.load_file(
         input_file=File(
-            path="ftp://home/foo/upload/ADOPTION_CENTER_1_unquoted.csv",
+            path="ftp://upload/ADOPTION_CENTER_1_unquoted.csv",
             conn_id="ftp_conn",
             filetype=FileType.CSV,
         ),

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -268,4 +268,17 @@ with dag:
     )
     # [END load_file_example_20]
 
+    # [START load_file_example_21]
+    aql.load_file(
+        input_file=File(path="ftp://home/foo/upload/", conn_id="ftp_conn", filetype=FileType.CSV),
+        output_table=Table(
+            conn_id=SNOWFLAKE_CONN_ID,
+            metadata=Metadata(
+                database=os.environ["SNOWFLAKE_DATABASE"],
+                schema=os.environ["SNOWFLAKE_SCHEMA"],
+            ),
+        ),
+    )
+    # [END load_file_example_21]
+
     aql.cleanup()

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -45,6 +45,8 @@ def test(session: nox.Session, airflow) -> None:
         # install apache-airflow-providers-sftp==4.0.0 since it is the compatible version
         # to run sftp example dag to load file with airflow 2.2.5
         session.install("apache-airflow-providers-sftp==4.0.0")
+        # install smart-open 6.3.0 since it has FTP implementation
+        session.install("smart-open>=6.3.0")
     else:
         env["AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES"] = "airflow.* astro.*"
 

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -96,7 +96,7 @@ all = [
     "apache-airflow-providers-postgres",
     "apache-airflow-providers-snowflake",
     "apache-airflow-providers-sftp",
-    "smart-open[all]>=5.2.1",
+    "smart-open>=6.3.0",
     "snowflake-connector-python[pandas]",
     "snowflake-sqlalchemy>=1.2.0",
     "sqlalchemy-bigquery>=1.3.0",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -82,7 +82,7 @@ sftp = [
 ]
 ftp = [
     "apache-airflow-providers-ftp>=3.0.0",
-    "smart-open[ssh]>=5.2.1",
+    "smart-open[all]>=6.3.0",
 ]
 openlineage = ["openlineage-airflow>=0.17.0"]
 
@@ -96,7 +96,7 @@ all = [
     "apache-airflow-providers-postgres",
     "apache-airflow-providers-snowflake",
     "apache-airflow-providers-sftp",
-    "smart-open[all]>=5.2.1",
+    "smart-open[all]>=6.3.0",
     "snowflake-connector-python[pandas]",
     "snowflake-sqlalchemy>=1.2.0",
     "sqlalchemy-bigquery>=1.3.0",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -80,6 +80,10 @@ sftp = [
     "apache-airflow-providers-sftp>=4.0.0",
     "smart-open[ssh]>=5.2.1",
 ]
+ftp = [
+    "apache-airflow-providers-ftp>=3.0.0",
+    "smart-open[ssh]>=5.2.1",
+]
 openlineage = ["openlineage-airflow>=0.17.0"]
 
 databricks = ["databricks-cli",
@@ -88,6 +92,7 @@ databricks = ["databricks-cli",
 all = [
     "apache-airflow-providers-amazon",
     "apache-airflow-providers-google>=6.4.0",
+    "apache-airflow-providers-ftp",
     "apache-airflow-providers-postgres",
     "apache-airflow-providers-snowflake",
     "apache-airflow-providers-sftp",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -82,7 +82,7 @@ sftp = [
 ]
 ftp = [
     "apache-airflow-providers-ftp>=3.0.0",
-    "smart-open[ssh]>=5.2.1",
+    "smart-open>=5.2.1",
 ]
 openlineage = ["openlineage-airflow>=0.17.0"]
 
@@ -96,7 +96,7 @@ all = [
     "apache-airflow-providers-postgres",
     "apache-airflow-providers-snowflake",
     "apache-airflow-providers-sftp",
-    "smart-open>=6.3.0",
+    "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]",
     "snowflake-sqlalchemy>=1.2.0",
     "sqlalchemy-bigquery>=1.3.0",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -82,7 +82,7 @@ sftp = [
 ]
 ftp = [
     "apache-airflow-providers-ftp>=3.0.0",
-    "smart-open[all]>=6.3.0",
+    "smart-open[ssh]>=5.2.1",
 ]
 openlineage = ["openlineage-airflow>=0.17.0"]
 
@@ -96,7 +96,7 @@ all = [
     "apache-airflow-providers-postgres",
     "apache-airflow-providers-snowflake",
     "apache-airflow-providers-sftp",
-    "smart-open[all]>=6.3.0",
+    "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]",
     "snowflake-sqlalchemy>=1.2.0",
     "sqlalchemy-bigquery>=1.3.0",

--- a/python-sdk/src/astro/constants.py
+++ b/python-sdk/src/astro/constants.py
@@ -25,6 +25,7 @@ class FileLocation(Enum):
     WASB = "wasb"  # Azure Blob Storage
     WASBS = "wasbs"  # Azure Blob Storage
     SFTP = "sftp"  # Remote file location
+    FTP = "ftp"  # Remote file location
     # [END filelocation]
 
     def __str__(self) -> str:

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -95,6 +95,7 @@ class File(LoggingMixin, Dataset):
             delimited data (e.g. csv, parquet, etc.).
         :param df: pandas dataframe
         """
+
         self.is_dataframe = store_as_dataframe
 
         with self.location.get_stream() as stream:

--- a/python-sdk/src/astro/files/locations/ftp.py
+++ b/python-sdk/src/astro/files/locations/ftp.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from airflow.providers.ftp.hooks.ftp import FTPHook
+
+from astro.constants import FileLocation
+from astro.files.locations.base import BaseFileLocation
+
+
+class FTPLocation(BaseFileLocation):
+    """Handler FTP object store operations"""
+
+    location_type = FileLocation.FTP
+
+    @property
+    def hook(self) -> FTPHook:
+        return FTPHook(ftp_conn_id=self.conn_id) if self.conn_id else FTPHook()
+
+    @property
+    def transport_params(self) -> dict:
+        """get FTP credentials for remote file system"""
+        return {}
+
+    @property
+    def paths(self) -> list[str]:
+        """Resolve FTP file paths with prefix"""
+        url = urlparse(self.path)
+        conn = self.hook.get_connection(self.conn_id)
+        uri = conn.get_uri()
+        client = self.hook.get_conn()
+        files = client.nlst("/" + url.netloc + url.path)
+        if len(files) > 0:
+            paths = [uri + file for file in files]
+        else:
+            paths = [uri + "/" + url.netloc + url.path]
+        return paths
+
+    @property
+    def size(self) -> int:
+        """Return file size for FTP location"""
+        url = urlparse(self.path)
+        stat = self.hook.get_size(url.path)
+        return int(stat) or -1
+
+    @property
+    def openlineage_dataset_namespace(self) -> str:
+        """
+        Returns the open lineage dataset namespace as per
+        https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
+        """
+        parsed_url = urlparse(self.path)
+        return f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    @property
+    def openlineage_dataset_name(self) -> str:
+        """
+        Returns the open lineage dataset name as per
+        https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
+        """
+        return urlparse(self.path).path
+
+    def get_uri(self):
+        """Gets the URI of the connection"""
+        conn = self.hook.get_connection(self.conn_id)
+        return conn.get_uri()

--- a/python-sdk/src/astro/files/locations/ftp.py
+++ b/python-sdk/src/astro/files/locations/ftp.py
@@ -32,6 +32,7 @@ class FTPLocation(BaseFileLocation):
         uri = conn.get_uri()
         client = self.hook.get_conn()
         files = client.nlst("/" + url.netloc + url.path)
+        # the above command checks if the path is a file or directory
         if len(files) > 0:
             paths = [uri + file for file in files]
         else:

--- a/python-sdk/src/astro/files/locations/ftp.py
+++ b/python-sdk/src/astro/files/locations/ftp.py
@@ -69,5 +69,5 @@ class FTPLocation(BaseFileLocation):
 
     def get_stream(self):
         parsed_url = urlparse(self.path)
-        self.path = f"{self.get_uri()}/{parsed_url.netloc}{parsed_url.path}"
-        return smart_open.open(self.path, mode="wb", transport_params=self.transport_params)
+        path = f"{self.get_uri()}/{parsed_url.netloc}{parsed_url.path}"
+        return smart_open.open(path, mode="wb", transport_params=self.transport_params)

--- a/python-sdk/src/astro/files/locations/ftp.py
+++ b/python-sdk/src/astro/files/locations/ftp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 
+import smart_open
 from airflow.providers.ftp.hooks.ftp import FTPHook
 
 from astro.constants import FileLocation
@@ -12,6 +13,7 @@ class FTPLocation(BaseFileLocation):
     """Handler FTP object store operations"""
 
     location_type = FileLocation.FTP
+    supported_conn_type = {FTPHook.conn_type}
 
     @property
     def hook(self) -> FTPHook:
@@ -64,3 +66,8 @@ class FTPLocation(BaseFileLocation):
         """Gets the URI of the connection"""
         conn = self.hook.get_connection(self.conn_id)
         return conn.get_uri()
+
+    def get_stream(self):
+        parsed_url = urlparse(self.path)
+        self.path = f"{self.get_uri()}/{parsed_url.netloc}{parsed_url.path}"
+        return smart_open.open(self.path, mode="wb", transport_params=self.transport_params)

--- a/python-sdk/tests/files/locations/test_ftp.py
+++ b/python-sdk/tests/files/locations/test_ftp.py
@@ -1,0 +1,51 @@
+import ftplib
+from unittest.mock import Mock, patch
+
+import pytest
+from airflow.providers.ftp.hooks.ftp import FTPHook
+
+from astro.files.locations import create_file_location
+
+
+def test_get_transport_params_for_ftp():
+    """test get_transport_params() whether empty dict is been sent or not"""
+    path = "ftp://bucket/some-file"
+    location = create_file_location(path)
+    credentials = location.transport_params
+    assert credentials == {}
+
+
+@patch("airflow.providers.ftp.hooks.ftp.FTPHook.get_size")
+def test_size(mock_get_conn):
+    """Test whether get_size() will return the file size correctly"""
+
+    mock_get_conn.return_value = 110
+    location = create_file_location("ftp://user@host/some/sample.csv")
+    assert location.size == 110
+    mock_get_conn.assert_called_once_with("/some/sample.csv")
+
+
+def test_hook():
+    """Test whether FTP hook is being called or not."""
+    location = create_file_location("ftp://user@host/some")
+    hook = location.hook
+    assert isinstance(hook, FTPHook)
+
+
+@pytest.mark.parametrize(
+    "response, file_location",
+    [
+        (["/some/sample.csv"], "ftp://user@host/some"),
+        ([], "ftp://some/sample.csv"),
+    ],
+)
+@patch("airflow.providers.ftp.hooks.ftp.FTPHook.get_connection")
+@patch("airflow.providers.ftp.hooks.ftp.FTPHook.get_conn")
+def test_get_paths_from_ftp(mock_ftp_conn, mock_ftp_connection, response, file_location):
+    """Get the list of files from the ftp path"""
+    mock_ftp_client = Mock(ftplib.FTP)
+    mock_ftp_conn.return_value = mock_ftp_client
+    mock_ftp_client.nlst.return_value = response
+    mock_ftp_connection.return_value.get_uri.return_value = "ftp://user@host:1234"
+    location = create_file_location(file_location)
+    assert sorted(location.paths) == sorted(["ftp://user@host:1234/some/sample.csv"])

--- a/python-sdk/tests/files/locations/test_location_base.py
+++ b/python-sdk/tests/files/locations/test_location_base.py
@@ -58,6 +58,7 @@ def test_get_class_name_method_valid_name():
         (FileLocation.GS, "gs://bucket/some-file", "gs://bucket"),
         (FileLocation.GOOGLE_DRIVE, "gdrive://bucket/some-file", "gdrive://bucket"),
         (FileLocation.SFTP, "sftp://user@host/some", "sftp://user@host"),
+        (FileLocation.FTP, "ftp://user@host/some", "ftp://user@host"),
     ],
 )
 def test_openlineage_file_dataset_namespace(file_location, filepath, namespace):
@@ -79,6 +80,7 @@ def test_openlineage_file_dataset_namespace(file_location, filepath, namespace):
         (FileLocation.GS, "gs://bucket/some-file", "/some-file"),
         (FileLocation.GOOGLE_DRIVE, "gdrive://bucket/some-file", "/some-file"),
         (FileLocation.SFTP, "sftp://user@host/some", "/some"),
+        (FileLocation.FTP, "ftp://user@host/some", "/some"),
     ],
 )
 def test_openlineage_file_dataset_name(file_location, filepath, dataset_name):

--- a/python-sdk/tests/test_constants.py
+++ b/python-sdk/tests/test_constants.py
@@ -2,7 +2,7 @@ from astro.constants import SUPPORTED_DATABASES, SUPPORTED_FILE_LOCATIONS, SUPPO
 
 
 def test_supported_file_locations():
-    expected = ["gdrive", "gs", "http", "https", "local", "s3", "sftp", "wasb", "wasbs"]
+    expected = ["ftp", "gdrive", "gs", "http", "https", "local", "s3", "sftp", "wasb", "wasbs"]
     assert sorted(SUPPORTED_FILE_LOCATIONS) == expected
 
 

--- a/python-sdk/tests_integration/files/locations/test_ftp.py
+++ b/python-sdk/tests_integration/files/locations/test_ftp.py
@@ -52,8 +52,8 @@ CWD = pathlib.Path(__file__).parent
 )
 def test_export_table_to_file_in_the_ftp(database_table_fixture):
     """Test export_table_to_file_file() where end file location is in FTP"""
-    object_path = "ftp://home/foo/upload/test.csv"
-    final_path = "ftp://foo:pass@localhost:21/home/foo/upload/test.csv"
+    object_path = "ftp://home/foo/upload/test_ftp.csv"
+    final_path = "ftp://foo:pass@localhost:21/home/foo/upload/test_ftp.csv"
     database, populated_table = database_table_fixture
     database.export_table_to_file(
         populated_table,

--- a/python-sdk/tests_integration/files/locations/test_ftp.py
+++ b/python-sdk/tests_integration/files/locations/test_ftp.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 
+import airflow
 import pandas as pd
 import pytest
 
@@ -16,6 +17,7 @@ CWD = pathlib.Path(__file__).parent
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(airflow.__version__ < "2.3.0", reason="Require Airflow version >= 2.3.0")
 @pytest.mark.parametrize(
     "database_table_fixture",
     [

--- a/python-sdk/tests_integration/files/locations/test_ftp.py
+++ b/python-sdk/tests_integration/files/locations/test_ftp.py
@@ -1,7 +1,6 @@
 import os
 import pathlib
 
-import airflow
 import pandas as pd
 import pytest
 
@@ -17,7 +16,6 @@ CWD = pathlib.Path(__file__).parent
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(airflow.__version__ < "2.3.0", reason="Require Airflow version >= 2.3.0")
 @pytest.mark.parametrize(
     "database_table_fixture",
     [

--- a/python-sdk/tests_integration/files/locations/test_ftp.py
+++ b/python-sdk/tests_integration/files/locations/test_ftp.py
@@ -52,8 +52,8 @@ CWD = pathlib.Path(__file__).parent
 )
 def test_export_table_to_file_in_the_ftp(database_table_fixture):
     """Test export_table_to_file() where end file location is in FTP"""
-    object_path = "ftp://home/foo/upload/test_ftp.csv"
-    final_path = "ftp://foo:pass@localhost:21/home/foo/upload/test_ftp.csv"
+    object_path = "ftp://upload/test_ftp.csv"
+    final_path = "ftp://foo:pass@localhost:21/upload/test_ftp.csv"
     database, populated_table = database_table_fixture
     database.export_table_to_file(
         populated_table,

--- a/python-sdk/tests_integration/files/locations/test_ftp.py
+++ b/python-sdk/tests_integration/files/locations/test_ftp.py
@@ -1,0 +1,75 @@
+import os
+import pathlib
+
+import pandas as pd
+import pytest
+
+from astro.constants import Database
+from astro.files import File
+from astro.settings import SCHEMA
+from astro.table import Metadata, Table
+from astro.utils.load import copy_remote_file_to_local
+from tests.sql.operators import utils as test_utils
+
+DEFAULT_CONN_ID = "ftp_conn"
+CWD = pathlib.Path(__file__).parent
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.POSTGRES,
+            "file": File(str(pathlib.Path(CWD.parent.parent, "data/sample.csv"))),
+        },
+        {
+            "database": Database.SNOWFLAKE,
+            "file": File(str(pathlib.Path(CWD.parent.parent, "data/sample.csv"))),
+            "table": Table(
+                metadata=Metadata(
+                    schema=os.getenv("SNOWFLAKE_SCHEMA", SCHEMA),
+                    database=os.getenv("SNOWFLAKE_DATABASE", "snowflake"),
+                )
+            ),
+        },
+        {
+            "database": Database.SQLITE,
+            "file": File(str(pathlib.Path(CWD.parent.parent, "data/sample.csv"))),
+        },
+        {
+            "database": Database.BIGQUERY,
+            "file": File(str(pathlib.Path(CWD.parent.parent, "data/sample.csv"))),
+            "table": Table(metadata=Metadata(schema=SCHEMA)),
+        },
+        {
+            "database": Database.REDSHIFT,
+            "file": File(str(pathlib.Path(CWD.parent.parent, "data/sample.csv"))),
+        },
+    ],
+    indirect=True,
+    ids=["postgres", "snowflake", "sqlite", "bigquery", "redshift"],
+)
+def test_export_table_to_file_in_the_ftp(database_table_fixture):
+    """Test export_table_to_file_file() where end file location is in FTP"""
+    object_path = "ftp://home/foo/upload/test.csv"
+    final_path = "ftp://foo:pass@localhost:21/home/foo/upload/test.csv"
+    database, populated_table = database_table_fixture
+    database.export_table_to_file(
+        populated_table,
+        File(object_path, conn_id=DEFAULT_CONN_ID),
+        if_exists="replace",
+    )
+
+    filepath = copy_remote_file_to_local(source_filepath=final_path, transport_params={})
+    df = pd.read_csv(filepath)
+    assert len(df) == 3
+    expected = pd.DataFrame(
+        [
+            {"id": 1, "name": "First"},
+            {"id": 2, "name": "Second"},
+            {"id": 3, "name": "Third with unicode पांचाल"},
+        ]
+    )
+    test_utils.assert_dataframes_are_equal(df, expected)
+    os.remove(filepath)

--- a/python-sdk/tests_integration/files/locations/test_ftp.py
+++ b/python-sdk/tests_integration/files/locations/test_ftp.py
@@ -51,7 +51,7 @@ CWD = pathlib.Path(__file__).parent
     ids=["postgres", "snowflake", "sqlite", "bigquery", "redshift"],
 )
 def test_export_table_to_file_in_the_ftp(database_table_fixture):
-    """Test export_table_to_file_file() where end file location is in FTP"""
+    """Test export_table_to_file() where end file location is in FTP"""
     object_path = "ftp://home/foo/upload/test_ftp.csv"
     final_path = "ftp://foo:pass@localhost:21/home/foo/upload/test_ftp.csv"
     database, populated_table = database_table_fixture


### PR DESCRIPTION
relates-to #969 
**Please describe the feature you'd like to see**
It is a very common ETL operation to either push data to or load data from FTP sources

**Describe the solution you'd like**
FTP should be valid location types in `File`

**Are there any alternatives to this feature?**
Implementors otherwise need to use workarounds like `S3toSFTPOperator`

**Acceptance Criteria**

- [x] All checks and tests in the CI should pass
- [x] Unit tests (90% code coverage or more, [once available](https://github.com/astronomer/astro-sdk/issues/191))
- [x] Integration tests (if the feature relates to a new database or external service)
- [x] Example DAG
- [x] Docstrings in [reStructuredText](https://peps.python.org/pep-0287/) for each of  methods, classes, functions and module-level attributes (including Example DAG on how it should be used)
- [x] Exception handling in case of errors
- [x] Logging (are we exposing useful information to the user? e.g. source and destination)
- [x] Improve the documentation (README, Sphinx, and any other relevant)
- [x] How to use Guide for the feature ([example](https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/operators/postgres_operator_howto_guide.html))
