### PR TITLE
Add Xcom req as per 1.3.3 and airflow 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,25 +47,14 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
     airflow db init
     ```
 
-   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from astro-sdk-python release 1.2 and above.
-   >
-   > .. list-table::
-        :widths: 25 25 50
-        :header-rows: 1
-        * - Heading row 1, column 1
-          - Heading row 1, column 2
-          - Heading row 1, column 3
-        * - Row 1, column 1
-          -
-          - Row 1, column 3
-        * - Row 2, column 1
-          - Row 2, column 2
-          - Row 2, column 3
-
+   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from astro-sdk-python release 1.2 and above. This functionality is now deprecated.
+   > - For airflow version < 2.5 and astro-sdk-python release < 1.2 Users can either use a custom XCom backend [AstroCustomXcomBackend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html) with Xcom pickling disabled (or) enable Xcom pickling. Currently, custom XCom backends are limited to data types that are json serializable. Since Dataframes are not json serializable, we need to enable XCom pickling to store dataframes.
+   > - For airflow version >= 2.5 and astro-sdk-python release >= 1.3.3 Users can either use [Airflow's Xcom backend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#airflow_xcom_backend) with Xcom pickling disabled (or) enable Xcom pickling.
 
     The data format used by pickle is Python-specific. This has the advantage that there are no restrictions imposed by external standards such as JSON or XDR (which can’t represent pointer sharing); however it means that non-Python programs may not be able to reconstruct pickled Python objects.
 
     Read more: [enable_xcom_pickling](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#enable-xcom-pickling) and [pickle](https://docs.python.org/3/library/pickle.html#comparison-with-json):
+
 
 
 2. Create a SQLite database for the example to run with:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
     airflow db init
     ```
 
-   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from `astro-sdk-python` with airflow >= 2.5 and release 1.3.3 and above. This functionality is now deprecated as Airflow xcom backend handles serialization.
+   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from `astro-sdk-python` release 1.3.3 with airflow >= 2.5 and above. This functionality is now deprecated as Airflow xcom backend handles serialization.
     Users have to add a few configs as suggested in the [doc](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#airflow_xcom_backend) to enable it.
 
     The data format used by pickle is Python-specific. This has the advantage that there are no restrictions imposed by external standards such as JSON or XDR (which can’t represent pointer sharing); however it means that non-Python programs may not be able to reconstruct pickled Python objects.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
     airflow db init
     ```
 
-   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from `astro-sdk-python` release 1.2 and above. This functionality is now deprecated as our custom xcom backend handles serialization.
-    Users can either use a custom XCom backend [`AstroCustomXcomBackend`](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html) with Xcom pickling disabled (or) enable Xcom pickling.
-    Currently, custom XCom backends are limited to data types that are json serializable. Since Dataframes are not json serializable, we need to enable XCom pickling to store dataframes.
+   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from `astro-sdk-python` with airflow >= 2.5 and release 1.3.3 and above. This functionality is now deprecated as Airflow xcom backend handles serialization.
+    Users have to add a few configs as suggested in the [doc](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#airflow_xcom_backend) to enable it.
 
     The data format used by pickle is Python-specific. This has the advantage that there are no restrictions imposed by external standards such as JSON or XDR (which can’t represent pointer sharing); however it means that non-Python programs may not be able to reconstruct pickled Python objects.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
     ```
 
    > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from astro-sdk-python release 1.2 and above. This functionality is now deprecated.
-   > - For airflow version < 2.5 and astro-sdk-python release < 1.2 Users can either use a custom XCom backend [AstroCustomXcomBackend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html) with Xcom pickling disabled (or) enable Xcom pickling. Currently, custom XCom backends are limited to data types that are json serializable. Since Dataframes are not json serializable, we need to enable XCom pickling to store dataframes.
+   > - For airflow version < 2.5 and astro-sdk-python release < 1.2 Users can either use a custom XCom backend [AstroCustomXcomBackend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#xcom-backend) with Xcom pickling disabled (or) enable Xcom pickling. Currently, custom XCom backends are limited to data types that are json serializable. Since Dataframes are not json serializable, we need to enable XCom pickling to store dataframes.
    > - For airflow version >= 2.5 and astro-sdk-python release >= 1.3.3 Users can either use [Airflow's Xcom backend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#airflow_xcom_backend) with Xcom pickling disabled (or) enable Xcom pickling.
 
     The data format used by pickle is Python-specific. This has the advantage that there are no restrictions imposed by external standards such as JSON or XDR (which can’t represent pointer sharing); however it means that non-Python programs may not be able to reconstruct pickled Python objects.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,21 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
     airflow db init
     ```
 
-   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from `astro-sdk-python` release 1.3.3 with airflow >= 2.5 and above. This functionality is now deprecated as Airflow xcom backend handles serialization.
-    Users have to add a few configs as suggested in the [doc](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#airflow_xcom_backend) to enable it.
+   > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from astro-sdk-python release 1.2 and above.
+   >
+   > .. list-table::
+        :widths: 25 25 50
+        :header-rows: 1
+        * - Heading row 1, column 1
+          - Heading row 1, column 2
+          - Heading row 1, column 3
+        * - Row 1, column 1
+          -
+          - Row 1, column 3
+        * - Row 2, column 1
+          - Row 2, column 2
+          - Row 2, column 3
+
 
     The data format used by pickle is Python-specific. This has the advantage that there are no restrictions imposed by external standards such as JSON or XDR (which can’t represent pointer sharing); however it means that non-Python programs may not be able to reconstruct pickled Python objects.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
     ```
 
    > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from astro-sdk-python release 1.2 and above. This functionality is now deprecated.
-   > - For airflow version < 2.5 and astro-sdk-python release < 1.2 Users can either use a custom XCom backend [AstroCustomXcomBackend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#xcom-backend) with Xcom pickling disabled (or) enable Xcom pickling. Currently, custom XCom backends are limited to data types that are json serializable. Since Dataframes are not json serializable, we need to enable XCom pickling to store dataframes.
+   > - For airflow version < 2.5 and astro-sdk-python release < 1.2 Users can either use a custom XCom backend [AstroCustomXcomBackend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#xcom-backend) with Xcom pickling disabled (or) enable Xcom pickling.
    > - For airflow version >= 2.5 and astro-sdk-python release >= 1.3.3 Users can either use [Airflow's Xcom backend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#airflow_xcom_backend) with Xcom pickling disabled (or) enable Xcom pickling.
 
     The data format used by pickle is Python-specific. This has the advantage that there are no restrictions imposed by external standards such as JSON or XDR (which can’t represent pointer sharing); however it means that non-Python programs may not be able to reconstruct pickled Python objects.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install astro-sdk-python[amazon,google,snowflake,postgres]
     ```
 
    > **Note:** `AIRFLOW__CORE__ENABLE_XCOM_PICKLING` no longer needs to be enabled from astro-sdk-python release 1.2 and above. This functionality is now deprecated.
-   > - For airflow version < 2.5 and astro-sdk-python release < 1.2 Users can either use a custom XCom backend [AstroCustomXcomBackend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#xcom-backend) with Xcom pickling disabled (or) enable Xcom pickling.
+   > - For airflow version < 2.5 and astro-sdk-python release < 1.3 Users can either use a custom XCom backend [AstroCustomXcomBackend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#xcom-backend) with Xcom pickling disabled (or) enable Xcom pickling.
    > - For airflow version >= 2.5 and astro-sdk-python release >= 1.3.3 Users can either use [Airflow's Xcom backend](https://astro-sdk-python.readthedocs.io/en/latest/guides/xcom_backend.html#airflow_xcom_backend) with Xcom pickling disabled (or) enable Xcom pickling.
 
     The data format used by pickle is Python-specific. This has the advantage that there are no restrictions imposed by external standards such as JSON or XDR (which can’t represent pointer sharing); however it means that non-Python programs may not be able to reconstruct pickled Python objects.

--- a/python-sdk/docs/guides/xcom_backend.rst
+++ b/python-sdk/docs/guides/xcom_backend.rst
@@ -4,6 +4,9 @@
 XCom Backend
 ============
 
+.. note::
+    Recommended to be used with airflow < 2.5
+
 The custom XCom backend adds special handling to Astro's custom constructs (see :ref:`concepts`) so they can
 be used without enabling XCom picking (the ``xcom_pickling`` configuration). When the custom constructs are
 not accessed, this is simply a wrapper around Airflow's default XCom backend, so a migration from the default
@@ -48,3 +51,27 @@ metadatabase instead, by setting
 
 or the environment variable ``AIRFLOW__ASTRO_SDK__STORE_DATA_LOCAL_DEV`` instead. Note that this is considered
 suboptimal, and should not be used in a production environment.
+
+.. _airflow_xcom_backend:
+
+======================
+Airflow's XCom Backend
+======================
+
+.. note::
+    Recommended to be used with airflow >= 2.5
+
+We can also use Airflow’s Xcom Backend if you are using Airflow >= 2.5. From Airflow 2.5, airflow can internally handle serialization and deserialization of custom constructs of SDK. All we need to do to enable this feature is set a few configs in airflow’s config file as shown below.
+
+.. code-block:: ini
+
+   [core]
+   enable_xcom_pickling = false
+   allowed_deserialization_classes = airflow.* astro.*
+
+or we can also set env variables like
+
+.. code-block:: ini
+
+   AIRFLOW__CORE__ENABLE_XCOM_PICKLING = false
+   AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES=airflow.* astro.*

--- a/python-sdk/docs/guides/xcom_backend.rst
+++ b/python-sdk/docs/guides/xcom_backend.rst
@@ -66,12 +66,10 @@ You don't need to use a Custom XCom backend or XCom pickling for Airflow >=2.5 a
 .. code-block:: ini
 
    [core]
-   enable_xcom_pickling = false
    allowed_deserialization_classes = airflow.* astro.*
 
 or we can also set env variables like
 
 .. code-block:: ini
 
-   AIRFLOW__CORE__ENABLE_XCOM_PICKLING = false
    AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES=airflow.* astro.*

--- a/python-sdk/docs/guides/xcom_backend.rst
+++ b/python-sdk/docs/guides/xcom_backend.rst
@@ -61,7 +61,7 @@ Airflow's XCom Backend
 .. note::
     Recommended to be used with airflow >= 2.5
 
-You don't need to use a Custom XCom backend or XCom pickling for Airflow >=2.5 and SDK 1.3+, from Airflow 2.5, airflow can internally handle serialization and deserialization of custom constructs of SDK. All we need to do to enable this feature is set a few configs in airflow’s config file as shown below.
+You don't need to use a Custom XCom backend or XCom pickling for Airflow >=2.5 and SDK 1.3+. From Airflow 2.5 onwards, airflow can internally handle serialization and deserialization of custom constructs of SDK. All we need to do to enable this feature is set a few configs in airflow’s config file as shown below.
 
 .. code-block:: ini
 

--- a/python-sdk/docs/guides/xcom_backend.rst
+++ b/python-sdk/docs/guides/xcom_backend.rst
@@ -61,7 +61,7 @@ Airflow's XCom Backend
 .. note::
     Recommended to be used with airflow >= 2.5
 
-We can also use Airflow’s Xcom Backend if you are using Airflow >= 2.5. From Airflow 2.5, airflow can internally handle serialization and deserialization of custom constructs of SDK. All we need to do to enable this feature is set a few configs in airflow’s config file as shown below.
+You don't need to use a Custom XCom backend or XCom pickling for Airflow >=2.5 and SDK 1.3+, from Airflow 2.5, airflow can internally handle serialization and deserialization of custom constructs of SDK. All we need to do to enable this feature is set a few configs in airflow’s config file as shown below.
 
 .. code-block:: ini
 


### PR DESCRIPTION
# Description
## What is the current behavior?
Current docs don't reflect the new Xcom requirements.

## What is the new behavior?
Modified the docs to reflect the new Xcom requirements.

## Does this introduce a breaking change?
Nope.
