### PR TITLE
Bump sql-cli version to 0.3.0a0

### DIFF
--- a/sql-cli/pyproject.toml
+++ b/sql-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astro-sql-cli"
-version = "0.2.3a2"
+version = "0.3.0a0"
 description = "Empower analysts to build workflows to transform data using SQL"
 authors = [
     "Astronomer <humans@astronomer.io>",


### PR DESCRIPTION
Bump sql-cli version to 0.3.0a0 (including releasing to pypi)