### PR TITLE
Fix the dataframe test function name

### DIFF
--- a/python-sdk/tests_integration/sql/operators/test_dataframe.py
+++ b/python-sdk/tests_integration/sql/operators/test_dataframe.py
@@ -284,13 +284,13 @@ def test_empty_dataframe_fail(sample_dag, conn_id):
 )
 def test_dataframe_replace_table_if_exist(sample_dag, conn_id):
     @aql.dataframe
-    def get_empty_dataframe():
+    def get_sample_dataframe():
         arr = {"col1": [1, 2]}
         return pandas.DataFrame(data=arr)
 
     output_tb = Table(conn_id=conn_id)
     with sample_dag:
-        get_empty_dataframe(output_table=output_tb)
+        get_sample_dataframe(output_table=output_tb)
 
     test_utils.run_dag(sample_dag)
     assert output_tb.row_count == 2
@@ -317,13 +317,13 @@ def test_dataframe_replace_table_if_exist(sample_dag, conn_id):
 )
 def test_dataframe_append_table_if_exist(sample_dag, conn_id):
     @aql.dataframe(if_exists="append")
-    def get_empty_dataframe():
+    def get_sample_dataframe():
         arr = {"col1": [1, 2]}
         return pandas.DataFrame(data=arr)
 
     output_tb = Table(conn_id=conn_id)
     with sample_dag:
-        get_empty_dataframe(output_table=output_tb)
+        get_sample_dataframe(output_table=output_tb)
 
     test_utils.run_dag(sample_dag)
     assert output_tb.row_count == 2


### PR DESCRIPTION
# Description
## What is the current behavior?
currently, the `get_empty_dataframe` name does not reflect the correct behaviour of the function since it does not return empty df



## What is the new behavior?
Rename `get_empty_dataframe` to `get_sample_dataframe`

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
