### PR TITLE
Remove stale .airflow/global directory

### DIFF
--- a/sql-cli/tests/test_project.py
+++ b/sql-cli/tests/test_project.py
@@ -11,7 +11,6 @@ BASE_PATHS = [
     Path(".airflow/default/airflow.cfg"),
     Path(".airflow/default/airflow.db"),
     Path(".airflow/dev"),
-    Path(".airflow/global"),
     Path(".env"),
     Path("config"),
     Path("config/default"),


### PR DESCRIPTION
The `include/base/config/.airflow/global` directory was added to include 
the `configuration.yml` file under it. But, that file as moved to 
`include/base/config/global.yml` and we missed removing the earlier 
global subdirectory.
