### PR TITLE
Add temp-flow make command

### DIFF
--- a/sql-cli/Makefile
+++ b/sql-cli/Makefile
@@ -28,7 +28,8 @@ setup: system install  ## Setup a local development environment
 pre-commit:  # Run pre-commit
 	@git ls-files -- . | xargs pre-commit run --files
 
-flow:  # Build and run the latest version of flow
+temp-flow: # Build flow project in temp directory
+	@flow init $(shell mktemp -d)
 
 test:  # Run tests
 	@TERMINAL_WIDTH=3000 _TYPER_FORCE_DISABLE_TERMINAL=1 PYTHONWARNINGS="ignore" poetry run pytest -vv


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we don't have an easy way of creating a flow project for development purposes.

## What is the new behavior?

This change adds a simply `temp-flow` which can be called via `make temp-flow` and creates a flow project in a new temp directory.

## Does this introduce a breaking change?

No.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
