### PR TITLE
Deprecate `export_table_to_file` to `export_to_file`

### DIFF
--- a/python-sdk/docs/astro/sql/operators/export.rst
+++ b/python-sdk/docs/astro/sql/operators/export.rst
@@ -1,16 +1,16 @@
-.. _export_table_to_file:
+.. _export_to_file:
 
 ==================================================================================
-:py:mod:`export_table_to_file operator <astro.sql.operators.export_table_to_file>`
+:py:mod:`export_to_file operator <astro.sql.operators.export_to_file>`
 ==================================================================================
 
-.. _export_table_to_file_operator:
+.. _export_to_file_operator:
 
-When to use the ``export_table_to_file`` operator
+When to use the ``export_to_file`` operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``export_table_to_file`` operator allows you to write SQL tables to CSV or parquet files and store them locally, on S3, or on GCS. The ``export_table_to_file`` function can export data from :ref:`supported_databases` or a Pandas dataframe.
+The ``export_to_file`` operator allows you to write SQL tables to CSV or parquet files and store them locally, on S3, or on GCS. The ``export_to_file`` function can export data from :ref:`supported_databases` or a Pandas dataframe.
 
-There are two main uses for the ``export_table_to_file`` operator.
+There are two main uses for the ``export_to_file`` operator.
 
 Case 1: Export data from a table.
 

--- a/python-sdk/example_dags/example_amazon_s3_postgres_load_and_save.py
+++ b/python-sdk/example_dags/example_amazon_s3_postgres_load_and_save.py
@@ -30,7 +30,7 @@ def example_amazon_s3_postgres_load_and_save():
         # [END named_table_example]  skipcq: PY-W0069
     )
 
-    aql.export_table_to_file(
+    aql.export_to_file(
         input_data=t1,
         output_file=File(path=f"{s3_bucket}/homes.csv"),
         if_exists="replace",

--- a/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
+++ b/python-sdk/example_dags/example_google_bigquery_gcs_load_and_save.py
@@ -52,7 +52,7 @@ with DAG(
     # [START export_example_1]
     gcs_bucket = os.getenv("GCS_BUCKET", "gs://dag-authoring")
 
-    aql.export_table_to_file(
+    aql.export_to_file(
         task_id="save_file_to_gcs",
         input_data=t1,
         output_file=File(

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -15,7 +15,7 @@ from astro.sql.operators.data_validations.SQLCheckOperator import (  # skipcq: P
 from astro.sql.operators.dataframe import DataframeOperator, dataframe
 from astro.sql.operators.drop import DropTableOperator, drop_table
 from astro.sql.operators.export_file import ExportFileOperator, export_file
-from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
+from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
 from astro.sql.operators.load_file import LoadFileOperator, load_file
 from astro.sql.operators.merge import MergeOperator, merge
 from astro.sql.operators.raw_sql import RawSQLOperator, run_raw_sql
@@ -33,8 +33,8 @@ __all__ = [
     "drop_table",
     "ExportFileOperator",
     "export_file",
-    "ExportTableToFileOperator",
-    "export_table_to_file",
+    "ExportToFileOperator",
+    "export_to_file",
     "get_value_list",
     "LoadFileOperator",
     "load_file",

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -15,8 +15,8 @@ from astro.sql.operators.data_validations.SQLCheckOperator import (  # skipcq: P
 from astro.sql.operators.dataframe import DataframeOperator, dataframe
 from astro.sql.operators.drop import DropTableOperator, drop_table
 from astro.sql.operators.export_file import ExportFileOperator, export_file
-from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
 from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
+from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
 from astro.sql.operators.load_file import LoadFileOperator, load_file
 from astro.sql.operators.merge import MergeOperator, merge
 from astro.sql.operators.raw_sql import RawSQLOperator, run_raw_sql

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -16,6 +16,7 @@ from astro.sql.operators.dataframe import DataframeOperator, dataframe
 from astro.sql.operators.drop import DropTableOperator, drop_table
 from astro.sql.operators.export_file import ExportFileOperator, export_file
 from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
+from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
 from astro.sql.operators.load_file import LoadFileOperator, load_file
 from astro.sql.operators.merge import MergeOperator, merge
 from astro.sql.operators.raw_sql import RawSQLOperator, run_raw_sql
@@ -33,6 +34,8 @@ __all__ = [
     "drop_table",
     "ExportFileOperator",
     "export_file",
+    "ExportTableToFileOperator",
+    "export_table_to_file",
     "ExportToFileOperator",
     "export_to_file",
     "get_value_list",

--- a/python-sdk/src/astro/sql/operators/export_file.py
+++ b/python-sdk/src/astro/sql/operators/export_file.py
@@ -8,11 +8,11 @@ from airflow.models.xcom_arg import XComArg
 
 from astro.constants import ExportExistsStrategy
 from astro.files import File
-from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
+from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
 from astro.table import BaseTable
 
 
-class ExportFileOperator(ExportTableToFileOperator):
+class ExportFileOperator(ExportToFileOperator):
     """Write SQL table to csv/parquet on local/S3/GCS.
 
     :param input_data: Table to convert to file
@@ -32,7 +32,7 @@ class ExportFileOperator(ExportTableToFileOperator):
         super().__init__(input_data=input_data, output_file=output_file, if_exists=if_exists, **kwargs)
         warnings.warn(
             """This class is deprecated.
-            Please use `astro.sql.operators.export_table_to_file.ExportTableToFileOperator`.
+            Please use `astro.sql.operators.export_to_file.ExportToFileOperator`.
             And, will be removed in astro-sdk-python>=2.0.0.""",
             DeprecationWarning,
             stacklevel=2,
@@ -74,12 +74,12 @@ def export_file(
 
     warnings.warn(
         """This decorator is deprecated.
-        Please use `astro.sql.operators.export_table_to_file.export_table_to_file`.
+        Please use `astro.sql.operators.export_to_file.export_to_file`.
         And, will be removed in astro-sdk-python>=2.0.0.""",
         DeprecationWarning,
         stacklevel=2,
     )
 
-    return export_table_to_file(
+    return export_to_file(
         input_data=input_data, output_file=output_file, if_exists=if_exists, task_id=task_id, **kwargs
     )

--- a/python-sdk/src/astro/sql/operators/export_table_to_file.py
+++ b/python-sdk/src/astro/sql/operators/export_table_to_file.py
@@ -8,7 +8,7 @@ from airflow.models.xcom_arg import XComArg
 
 from astro.constants import ExportExistsStrategy
 from astro.files import File
-from astro.sql.operators.export_to_file import export_to_file, ExportToFileOperator
+from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
 from astro.table import BaseTable
 
 

--- a/python-sdk/src/astro/sql/operators/export_table_to_file.py
+++ b/python-sdk/src/astro/sql/operators/export_table_to_file.py
@@ -8,7 +8,7 @@ from airflow.models.xcom_arg import XComArg
 
 from astro.constants import ExportExistsStrategy
 from astro.files import File
-from astro.sql import export_to_file, ExportToFileOperator
+from astro.sql.operators.export_to_file import export_to_file, ExportToFileOperator
 from astro.table import BaseTable
 
 
@@ -46,10 +46,15 @@ def export_table_to_file(
     **kwargs: Any,
 ) -> XComArg:
     """Convert ExportTableToFileOperator into a function. Returns XComArg.
+
     Returns an XComArg object of type File which matches the output_file parameter.
+
     This will allow users to perform further actions with the exported file.
+
     e.g.:
+
     .. code-block:: python
+
       with sample_dag:
           table = aql.load_file(input_file=File(path=data_path), output_table=test_table)
           exported_file = aql.export_file(
@@ -58,6 +63,8 @@ def export_table_to_file(
               if_exists="replace",
           )
           res_df = aql.load_file(input_file=exported_file)
+
+
     :param output_file: Path and conn_id
     :param input_data: Input table / dataframe
     :param if_exists: Overwrite file if exists. Default "exception"

--- a/python-sdk/src/astro/sql/operators/export_table_to_file.py
+++ b/python-sdk/src/astro/sql/operators/export_table_to_file.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pandas as pd
+from airflow.models.xcom_arg import XComArg
+
+from astro.constants import ExportExistsStrategy
+from astro.files import File
+from astro.sql import export_to_file, ExportToFileOperator
+from astro.table import BaseTable
+
+
+class ExportTableToFileOperator(ExportToFileOperator):
+    """Write SQL table to csv/parquet on local/S3/GCS.
+    :param input_data: Table to convert to file
+    :param output_file: File object containing the path to the file and connection id.
+    :param if_exists: Overwrite file if exists. Default False.
+    """
+
+    template_fields = ("input_data", "output_file")
+
+    def __init__(
+        self,
+        input_data: BaseTable | pd.DataFrame,
+        output_file: File,
+        if_exists: ExportExistsStrategy = "exception",
+        **kwargs,
+    ) -> None:
+        super().__init__(input_data=input_data, output_file=output_file, if_exists=if_exists, **kwargs)
+        warnings.warn(
+            """This class is deprecated.
+            Please use `astro.sql.operators.export_to_file.ExportToFileOperator`.
+            And, will be removed in astro-sdk-python>=1.5.0.""",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+
+def export_table_to_file(
+    input_data: BaseTable | pd.DataFrame,
+    output_file: File,
+    if_exists: ExportExistsStrategy = "exception",
+    task_id: str | None = None,
+    **kwargs: Any,
+) -> XComArg:
+    """Convert ExportTableToFileOperator into a function. Returns XComArg.
+    Returns an XComArg object of type File which matches the output_file parameter.
+    This will allow users to perform further actions with the exported file.
+    e.g.:
+    .. code-block:: python
+      with sample_dag:
+          table = aql.load_file(input_file=File(path=data_path), output_table=test_table)
+          exported_file = aql.export_file(
+              input_data=table,
+              output_file=File(path="/tmp/saved_df.csv"),
+              if_exists="replace",
+          )
+          res_df = aql.load_file(input_file=exported_file)
+    :param output_file: Path and conn_id
+    :param input_data: Input table / dataframe
+    :param if_exists: Overwrite file if exists. Default "exception"
+    :param task_id: task id, optional
+    """
+
+    warnings.warn(
+        """This decorator is deprecated.
+        Please use `astro.sql.operators.export_to_file.export_to_file`.
+        And, will be removed in astro-sdk-python>=1.5.0.""",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return export_to_file(
+        input_data=input_data, output_file=output_file, if_exists=if_exists, task_id=task_id, **kwargs
+    )

--- a/python-sdk/src/astro/sql/operators/export_to_file.py
+++ b/python-sdk/src/astro/sql/operators/export_to_file.py
@@ -15,7 +15,7 @@ from astro.table import BaseTable, Table
 from astro.utils.typing_compat import Context
 
 
-class ExportTableToFileOperator(AstroSQLBaseOperator):
+class ExportToFileOperator(AstroSQLBaseOperator):
     """Write SQL table to csv/parquet on local/S3/GCS.
 
     :param input_data: Table to convert to file
@@ -137,14 +137,14 @@ class ExportTableToFileOperator(AstroSQLBaseOperator):
         )
 
 
-def export_table_to_file(
+def export_to_file(
     input_data: BaseTable | pd.DataFrame,
     output_file: File,
     if_exists: ExportExistsStrategy = "exception",
     task_id: str | None = None,
     **kwargs: Any,
 ) -> XComArg:
-    """Convert ExportTableToFileOperator into a function. Returns XComArg.
+    """Convert ExportToFileOperator into a function. Returns XComArg.
 
     Returns an XComArg object of type File which matches the output_file parameter.
 
@@ -170,9 +170,9 @@ def export_table_to_file(
     :param task_id: task id, optional
     """
 
-    task_id = task_id or get_unique_task_id("export_table_to_file")
+    task_id = task_id or get_unique_task_id("export_to_file")
 
-    return ExportTableToFileOperator(
+    return ExportToFileOperator(
         task_id=task_id,
         output_file=output_file,
         input_data=input_data,

--- a/python-sdk/tests/benchmark/README.md
+++ b/python-sdk/tests/benchmark/README.md
@@ -110,7 +110,7 @@ If you're interested in running each test case more times, this is an example of
 ./run.sh 5
 ```
 
-It is also possible to specify the chunk size, if the `load_file` or `export_table_to_file` operators are being used, by setting an integer value in the environment variable `ASTRO_CHUNKSIZE`.
+It is also possible to specify the chunk size, if the `load_file` or `export_to_file` operators are being used, by setting an integer value in the environment variable `ASTRO_CHUNKSIZE`.
 
 The command outputs something similar to:
 ```

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -188,7 +188,7 @@ def test_warnings_message():
     with pytest.warns(
         expected_warning=DeprecationWarning,
         match="""This decorator is deprecated.
-        Please use `astro.sql.operators.export_to_file.export_table_to_file`.
+        Please use `astro.sql.operators.export_to_file.export_to_file`.
         And, will be removed in astro-sdk-python>=2.0.0.""",
     ):
         export_file(input_data=Table(), output_file=File(path="/tmp/saved_df.csv"), if_exists="replace")

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -10,7 +10,7 @@ from astro.constants import Database, FileType
 from astro.files import File
 
 # Import Operator
-from astro.sql import ExportFileOperator, export_file, ExportTableToFileOperator, export_table_to_file
+from astro.sql import ExportFileOperator, ExportTableToFileOperator, export_file, export_table_to_file
 from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
 from astro.table import Table
 
@@ -220,4 +220,6 @@ def test_export_table_to_file_warnings_message():
         Please use `astro.sql.operators.export_to_file.export_to_file`.
         And, will be removed in astro-sdk-python>=1.5.0.""",
     ):
-        export_table_to_file(input_data=Table(), output_file=File(path="/tmp/saved_df.csv"), if_exists="replace")
+        export_table_to_file(
+            input_data=Table(), output_file=File(path="/tmp/saved_df.csv"), if_exists="replace"
+        )

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -116,7 +116,7 @@ def test_unique_task_id_for_same_path(
     assert tasks[0].operator.task_id != tasks[1].operator.task_id
     assert tasks[0].operator.task_id == "export_to_file"
     assert tasks[1].operator.task_id == "export_to_file__1"
-    assert tasks[2].operator.task_id == "export__to_file__2"
+    assert tasks[2].operator.task_id == "export_to_file__2"
     assert tasks[3].operator.task_id == "task_id"
 
     os.remove(OUTPUT_FILE_PATH)
@@ -188,7 +188,7 @@ def test_warnings_message():
     with pytest.warns(
         expected_warning=DeprecationWarning,
         match="""This decorator is deprecated.
-        Please use `astro.sql.operators.export_table_to_file.export_table_to_file`.
+        Please use `astro.sql.operators.export_to_file.export_table_to_file`.
         And, will be removed in astro-sdk-python>=2.0.0.""",
     ):
         export_file(input_data=Table(), output_file=File(path="/tmp/saved_df.csv"), if_exists="replace")

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -10,7 +10,7 @@ from astro.constants import Database, FileType
 from astro.files import File
 
 # Import Operator
-from astro.sql import ExportFileOperator, export_file
+from astro.sql import ExportFileOperator, export_file, ExportTableToFileOperator, export_table_to_file
 from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
 from astro.table import Table
 
@@ -166,7 +166,7 @@ def test_raise_exception_for_invalid_input_type():
 
 
 # TODO: Remove this test in astro-sdk 2.0.0
-def test_warnings_message():
+def test_export_file_warnings_message():
     """Assert the warning log when using deprecated method"""
     with pytest.warns(
         expected_warning=DeprecationWarning,
@@ -192,3 +192,32 @@ def test_warnings_message():
         And, will be removed in astro-sdk-python>=2.0.0.""",
     ):
         export_file(input_data=Table(), output_file=File(path="/tmp/saved_df.csv"), if_exists="replace")
+
+
+# TODO: Remove this test in astro-sdk 1.5.0
+def test_export_table_to_file_warnings_message():
+    """Assert the warning log when using deprecated method"""
+    with pytest.warns(
+        expected_warning=DeprecationWarning,
+        match="""This class is deprecated.
+            Please use `astro.sql.operators.export_to_file.ExportToFileOperator`.
+            And, will be removed in astro-sdk-python>=1.5.0.""",
+    ):
+        ExportTableToFileOperator(
+            task_id="task_id",
+            input_data=123,
+            output_file=File(
+                path="gs://astro-sdk/workspace/openlineage_export_file.csv",
+                conn_id="bigquery",
+                filetype=FileType.CSV,
+            ),
+            if_exists="replace",
+        )
+
+    with pytest.warns(
+        expected_warning=DeprecationWarning,
+        match="""This decorator is deprecated.
+        Please use `astro.sql.operators.export_to_file.export_to_file`.
+        And, will be removed in astro-sdk-python>=1.5.0.""",
+    ):
+        export_table_to_file(input_data=Table(), output_file=File(path="/tmp/saved_df.csv"), if_exists="replace")

--- a/python-sdk/tests/sql/operators/test_export_file.py
+++ b/python-sdk/tests/sql/operators/test_export_file.py
@@ -11,7 +11,7 @@ from astro.files import File
 
 # Import Operator
 from astro.sql import ExportFileOperator, export_file
-from astro.sql.operators.export_table_to_file import ExportTableToFileOperator, export_table_to_file
+from astro.sql.operators.export_to_file import ExportToFileOperator, export_to_file
 from astro.table import Table
 
 from ..operators import utils as test_utils
@@ -26,7 +26,7 @@ def test_save_dataframe_to_local(sample_dag):
 
     with sample_dag:
         df = make_df()
-        aql.export_table_to_file(
+        aql.export_to_file(
             input_data=df,
             output_file=File(path="/tmp/saved_df.csv"),
             if_exists="replace",
@@ -66,7 +66,7 @@ def test_save_returns_output_file(sample_dag, database_table_fixture):
     data_path = str(CWD) + "/../../data/homes.csv"
     with sample_dag:
         table = aql.load_file(input_file=File(path=data_path), output_table=test_table)
-        file = aql.export_table_to_file(
+        file = aql.export_to_file(
             input_data=table,
             output_file=File(path="/tmp/saved_df.csv"),
             if_exists="replace",
@@ -109,14 +109,14 @@ def test_unique_task_id_for_same_path(
 
             if i == 3:
                 params["task_id"] = "task_id"
-            task = export_table_to_file(**params)
+            task = export_to_file(**params)
             tasks.append(task)
     test_utils.run_dag(sample_dag)
 
     assert tasks[0].operator.task_id != tasks[1].operator.task_id
-    assert tasks[0].operator.task_id == "export_table_to_file"
-    assert tasks[1].operator.task_id == "export_table_to_file__1"
-    assert tasks[2].operator.task_id == "export_table_to_file__2"
+    assert tasks[0].operator.task_id == "export_to_file"
+    assert tasks[1].operator.task_id == "export_to_file__1"
+    assert tasks[2].operator.task_id == "export__to_file__2"
     assert tasks[3].operator.task_id == "task_id"
 
     os.remove(OUTPUT_FILE_PATH)
@@ -127,7 +127,7 @@ def test_inlets_outlets_supported_ds():
     """Test Datasets are set as inlets and outlets"""
     input_data = Table("test_name")
     output_file = File("gs://bucket/object.csv")
-    task = aql.export_table_to_file(
+    task = aql.export_to_file(
         input_data=input_data,
         output_file=output_file,
     )
@@ -140,7 +140,7 @@ def test_inlets_outlets_non_supported_ds():
     """Test inlets and outlets are not set if Datasets are not supported"""
     input_data = Table("test_name")
     output_file = File("gs://bucket/object.csv")
-    task = aql.export_table_to_file(
+    task = aql.export_to_file(
         input_data=input_data,
         output_file=output_file,
     )
@@ -149,9 +149,9 @@ def test_inlets_outlets_non_supported_ds():
 
 
 def test_raise_exception_for_invalid_input_type():
-    """Raise value error when input data is not correct in ExportTableToFileOperator"""
+    """Raise value error when input data is not correct in ExportToFileOperator"""
     with pytest.raises(ValueError) as exc_info:
-        ExportTableToFileOperator(
+        ExportToFileOperator(
             task_id="task_id",
             input_data=123,
             output_file=File(
@@ -171,7 +171,7 @@ def test_warnings_message():
     with pytest.warns(
         expected_warning=DeprecationWarning,
         match="""This class is deprecated.
-            Please use `astro.sql.operators.export_table_to_file.ExportTableToFileOperator`.
+            Please use `astro.sql.operators.export_to_file.ExportToFileOperator`.
             And, will be removed in astro-sdk-python>=2.0.0.""",
     ):
         ExportFileOperator(

--- a/python-sdk/tests_integration/extractors/test_extractor.py
+++ b/python-sdk/tests_integration/extractors/test_extractor.py
@@ -16,7 +16,7 @@ from astro.files import File
 from astro.lineage.facets import InputFileDatasetFacet, InputFileFacet, OutputDatabaseDatasetFacet
 from astro.settings import LOAD_FILE_ENABLE_NATIVE_FALLBACK
 from astro.sql import AppendOperator, DataframeOperator, MergeOperator
-from astro.sql.operators.export_table_to_file import ExportTableToFileOperator
+from astro.sql.operators.export_to_file import ExportToFileOperator
 from astro.sql.operators.load_file import LoadFileOperator
 from astro.sql.operators.transform import TransformOperator
 from astro.table import Metadata, Table
@@ -132,7 +132,7 @@ def test_python_sdk_export_file_extract_on_complete():
     """
     Tests that  the custom PythonSDKExtractor is able to process the
     operator's metadata that needs to be extracted as per OpenLineage
-    for ExportTableToFileOperator.
+    for ExportToFileOperator.
     """
     load_file = LoadFileOperator(
         task_id="load_file",
@@ -144,7 +144,7 @@ def test_python_sdk_export_file_extract_on_complete():
     load_file.execute(context=create_context(load_file))
 
     task_id = "export_file"
-    export_file_operator = ExportTableToFileOperator(
+    export_file_operator = ExportToFileOperator(
         task_id=task_id,
         input_data=Table(conn_id="sqlite_conn", name="test_extractor"),
         output_file=File(
@@ -156,7 +156,7 @@ def test_python_sdk_export_file_extract_on_complete():
     )
 
     task_instance = TaskInstance(task=export_file_operator)
-    python_sdk_extractor = Extractors().get_extractor_class(ExportTableToFileOperator)
+    python_sdk_extractor = Extractors().get_extractor_class(ExportToFileOperator)
     assert python_sdk_extractor is DefaultExtractor
     task_meta_extract = python_sdk_extractor(export_file_operator).extract()
     assert task_meta_extract is None

--- a/python-sdk/tests_integration/sql/operators/test_export_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_export_file.py
@@ -12,7 +12,7 @@ from astro import sql as aql
 from astro.constants import SUPPORTED_FILE_TYPES, Database
 from astro.files import File
 from astro.settings import SCHEMA
-from astro.sql import export_file, export_table_to_file
+from astro.sql import export_file, export_to_file
 from astro.table import Table
 
 from ..operators import utils as test_utils
@@ -122,7 +122,7 @@ def test_save_all_db_tables_to_gcs(sample_dag, database_table_fixture):
     output_file_path = f"gs://{bucket}/test/{file_name}"
 
     with sample_dag:
-        export_table_to_file(
+        export_to_file(
             input_data=test_table,
             output_file=File(path=output_file_path, conn_id="google_cloud_default"),
             if_exists="replace",
@@ -168,7 +168,7 @@ def test_save_all_db_tables_to_local_file_exists_overwrite_false(sample_dag, dat
     _, test_table = database_table_fixture
     with tempfile.NamedTemporaryFile(suffix=".csv") as temp_file, pytest.raises(FileExistsError):
         with sample_dag:
-            export_table_to_file(
+            export_to_file(
                 input_data=test_table,
                 output_file=File(path=temp_file.name),
                 if_exists="exception",
@@ -216,7 +216,7 @@ def test_save_table_remote_file_exists_overwrite_false(
     _, test_table = database_table_fixture
     with pytest.raises(FileExistsError):
         with sample_dag:
-            export_table_to_file(
+            export_to_file(
                 input_data=test_table,
                 output_file=File(path=remote_files_fixture[0]),
                 if_exists="exception",
@@ -258,7 +258,7 @@ def test_export_file(sample_dag, database_table_fixture, file_type):
     with tempfile.TemporaryDirectory() as tmp_dir:
         filepath = Path(tmp_dir, f"sample.{file_type}")
         with sample_dag:
-            export_table_to_file(
+            export_to_file(
                 input_data=test_table,
                 output_file=File(path=str(filepath)),
                 if_exists="exception",
@@ -305,7 +305,7 @@ def test_populate_table_metadata(sample_dag, database_table_fixture):
         assert table.metadata.schema == SCHEMA
 
     with sample_dag:
-        aql.export_table_to_file(
+        aql.export_to_file(
             input_data=test_table,
             output_file=File(path="/tmp/saved_df.csv"),
             if_exists="replace",


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/1530
Related to: https://astronomer.slack.com/archives/C03868KGF2Q/p1671621286602989

## What is the current behavior?
Recently, we deprecated `export_file` to `export_table_to_file` but looks like `export_to_file` is a better name fit for this


## What is the new behavior?
Deprecate  to `export_table_to_file` to  `export_to_file` 

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
