### PR TITLE
Fix databricks flaky tests

### DIFF
--- a/python-sdk/tests_integration/databricks_tests/test_delta.py
+++ b/python-sdk/tests_integration/databricks_tests/test_delta.py
@@ -131,7 +131,6 @@ def test_create_table_from_select_statement(database_table_fixture):
 
     df = database.hook.get_pandas_df(f"SELECT * FROM {target_table.name}")
     assert len(df) == 26
-    assert df.NAME[0] == "Dancer"
     database.drop_table(target_table)
 
 

--- a/python-sdk/tests_integration/databricks_tests/test_delta.py
+++ b/python-sdk/tests_integration/databricks_tests/test_delta.py
@@ -131,7 +131,7 @@ def test_create_table_from_select_statement(database_table_fixture):
 
     df = database.hook.get_pandas_df(f"SELECT * FROM {target_table.name}")
     assert len(df) == 26
-    assert "Dancer" in df.NAME
+    assert "Dancer" in df["NAME"].tolist()
     database.drop_table(target_table)
 
 

--- a/python-sdk/tests_integration/databricks_tests/test_delta.py
+++ b/python-sdk/tests_integration/databricks_tests/test_delta.py
@@ -131,6 +131,7 @@ def test_create_table_from_select_statement(database_table_fixture):
 
     df = database.hook.get_pandas_df(f"SELECT * FROM {target_table.name}")
     assert len(df) == 26
+    assert "Dancer" in df.NAME
     database.drop_table(target_table)
 
 


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/1510

## What is the current behavior?
Look like select stmt does not return value in the same order always or load does not happen in the same order so sometimes value assertion is failing 


## What is the new behavior?
check value exists in any row of a column

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
