### PR TITLE
We shouldn't need to load files multiple times if we don't need to

### DIFF
--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -77,7 +77,7 @@ def database_table_fixture(request):
     database = create_database(conn_id)
     file = params.get("file")
     if file:
-        file_table_key = file.name + "_" + conn_id
+        file_table_key = file.path + "_" + conn_id
     else:
         file_table_key = "no_file"
     if file_table_map.get(file_table_key) and not params.get("table"):

--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -76,7 +76,10 @@ def database_table_fixture(request):
 
     database = create_database(conn_id)
     file = params.get("file")
-    file_table_key = file.name + "_" + conn_id
+    if file:
+        file_table_key = file.name + "_" + conn_id
+    else:
+        file_table_key = "no_file"
     if file_table_map.get(file_table_key) and not params.get("table"):
         table = file_table_map.get(file_table_key)
     else:


### PR DESCRIPTION
# Description
## What is the current behavior?

Currently, when we run tests we upload our files to each external system for every single test run. This significantly slows down our testing process due to unnecessary file loading.

## What is the new behavior?

With this pull request, we are introducing programmatic naming to ensure that we only upload a file once per-session. By uploading once per session, we are able to ensure that we are still using fresh data while also significantly improving CI/CD speed.


## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
