### PR TITLE
Create a Databricks Notebook Operator

### DIFF
--- a/python-sdk/src/astro/databricks/api_utils.py
+++ b/python-sdk/src/astro/databricks/api_utils.py
@@ -168,7 +168,16 @@ def create_and_run_job(
         python_params=None,
         spark_submit_params=None,
     )["run_id"]
+    monitor_job(api_client=api_client, run_id=run_id)
 
+
+def monitor_job(api_client: ApiClient, run_id: str):
+    """
+    Take an existing spark job and monitor it until it either succeeds or fail
+    :param api_client: Api Client with credentials for communicating with databricks
+    :param run_id: the run ID returned by the databricks JobsAPI
+    :return:
+    """
     runs_api = RunsApi(api_client)
     ping_interval = int(conf.get("astro_sdk", "databricks_ping_interval", fallback=5))
     while runs_api.get_run(run_id)["state"]["life_cycle_state"] == "PENDING":

--- a/python-sdk/src/astro/databricks/notebooks.py
+++ b/python-sdk/src/astro/databricks/notebooks.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+from typing import Any
+
+from airflow.configuration import conf
+from airflow.models.operator import BaseOperator
+
+from astro.databricks.api_utils import create_and_run_job
+from astro.utils.typing_compat import Context
+
+
+class DatabricksNotebookOperator(BaseOperator):
+    def __init__(
+        self,
+        notebook_path: str,
+        source: str,
+        databricks_conn_id: str,
+        existing_cluster_id: str = "",
+        new_cluster_spec: dict | None = None,
+        **kwargs,
+    ):
+        """
+
+        Run a notebook in your databricks instance. This function assumes the notebook already exists in your DBFS.
+
+        :param notebook_path: A URL that is accessible by databricks (either using DBFS or an accessible s3/GCS cluster)
+        :param databricks_conn_id: Connection ID to a databricks instance
+        :param existing_cluster_id: Cluster ID to existing databricks cluster for re-use.
+        :param new_cluster_spec: Optional spec if you want to create a new cluste for running notebook
+        :param kwargs:
+        """
+        self.existing_cluster_id = existing_cluster_id
+        self.notebook_path = notebook_path
+        self.source = source
+        self.databricks_conn_id = databricks_conn_id
+        self.new_cluster_spec = new_cluster_spec or {}
+        super().__init__(**kwargs)
+
+    def execute(self, context: Context) -> Any:
+        from astro.databricks.delta import DeltaDatabase
+
+        db = DeltaDatabase(conn_id=self.databricks_conn_id)
+        databricks_cluster_id = conf.get("astro_sdk", "databricks_cluster_id")
+        api_client = db.api_client
+        create_and_run_job(
+            api_client=api_client,
+            file_to_run=self.notebook_path,
+            databricks_job_name="run file " + self.notebook_path,
+            existing_cluster_id=databricks_cluster_id,
+            new_cluster_specs=self.new_cluster_spec,
+        )

--- a/python-sdk/tests_integration/databricks_tests/Test workflow.ipynb
+++ b/python-sdk/tests_integration/databricks_tests/Test workflow.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "source": [
+    "import logging\n",
+    "log4jLogger = sc._jvm.org.apache.log4j\n",
+    "LOGGER = log4jLogger.LogManager.getLogger(__name__)\n",
+    "LOGGER.info(\"pyspark script logger initialized\")\n",
+    "\n",
+    "\n",
+    "logger.info(\"world hello\")\n",
+    "print(\"hello world\")"
+   ],
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "showTitle": false,
+     "cellMetadata": {},
+     "nuid": "d391beb4-4bf0-41b0-b85f-153a4ef5ff1d",
+     "inputWidgets": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "execution_count": 0
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "notebookName": "Test workflow",
+   "dashboards": [],
+   "notebookMetadata": {
+    "pythonIndentUnit": 4,
+    "mostRecentlyExecutedCommandWithImplicitDF": {
+     "commandId": 667021647627922,
+     "dataframes": [
+      "_sqldf"
+     ]
+    }
+   },
+   "language": "python",
+   "widgets": {},
+   "notebookOrigID": 3532289136011851
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
# Description

## What is the current behavior?

There is no way to run an existing notebook in a Databricks cluster using the Astro SDK. While users can run notebooks using the DatabricksSubmitRunOperator, this operator is a part of the OSS airflow library and will not have the future benefits of Workflow support and lineage.

## What is the new behavior?

This PR introduces a `DatabricksNotebookOperator` that allows users to point to an existing notebook in their Databricks cluster and run it using the Astro SDK. We will later decide how this operator is interfaced to users using our functional API, but this PR should create the basis for future notebook support.

## Does this introduce a breaking change?

No, this PR does not introduce any breaking changes.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
