### PR TITLE
Fix pre-commit issues

### DIFF
--- a/python-sdk/tests/benchmark/analyse.py
+++ b/python-sdk/tests/benchmark/analyse.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import argparse
 import json
@@ -11,9 +12,9 @@ import pandas as pd
 from google.cloud import storage
 from sqlalchemy import text
 
-import settings as benchmark_settings
 from astro.databases import create_database
 from astro.table import Metadata, Table
+from tests.benchmark import settings as benchmark_settings
 
 SUMMARY_FIELDS = [
     "database",
@@ -130,7 +131,7 @@ def analyse_results_from_database(bq_git_sha: str, output_filepath: str):
     analyse_results(df, output_filepath)
 
 
-def analyse_results(df: pd.DataFrame, output_filepath: str = None):
+def analyse_results(df: pd.DataFrame, output_filepath: str | None = None):
     # calculate total CPU from process & children
     mean_by_dag = df.groupby("dag_id", as_index=False).mean()
 

--- a/python-sdk/tests/benchmark/dags/evaluate_load_file.py
+++ b/python-sdk/tests/benchmark/dags/evaluate_load_file.py
@@ -9,11 +9,11 @@ from urllib.parse import urlparse
 from airflow import DAG
 from run import export_profile_data_to_bq
 
-import settings as benchmark_settings
 from astro import sql as aql
 from astro.constants import DEFAULT_CHUNK_SIZE, FileType
 from astro.files import File
 from astro.table import Metadata, Table
+from tests.benchmark import settings as benchmark_settings
 
 START_DATE = datetime(2000, 1, 1)
 

--- a/python-sdk/tests/benchmark/run.py
+++ b/python-sdk/tests/benchmark/run.py
@@ -14,9 +14,9 @@ from airflow.models import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
 
-import settings as benchmark_settings
 from astro.databases import create_database
 from astro.table import Metadata, Table
+from tests.benchmark import settings as benchmark_settings
 
 
 def get_disk_usage():

--- a/python-sdk/tests/benchmark/synthetic_csv_generator.py
+++ b/python-sdk/tests/benchmark/synthetic_csv_generator.py
@@ -9,7 +9,7 @@ from faker import Faker
 
 def generate_data(row_size, file_name):
 
-    faked_obj: object = Faker("en_GB")
+    faked_obj = Faker("en_GB")
 
     file_obj = open(file_name, "w")
     write_obj = csv.writer(file_obj)


### PR DESCRIPTION
This is related to https://github.com/astronomer/astro-sdk/commit/7d1a613d6b5620027d54e4d0da0c2112470f475c and tries to fix flaky pre-commit changes, specific to isort import ordering.

Additionally, it fixes a mypy issues:
```
python-sdk/tests/benchmark/analyse.py:133: error: Incompatible default for argument "output_filepath" (default has type "None", argument has type "str")  [assignment]
```