### PR TITLE
Add source code facet for operators

### DIFF
--- a/python-sdk/docs/guides/openlineage.rst
+++ b/python-sdk/docs/guides/openlineage.rst
@@ -19,6 +19,9 @@ We'll need to specify where we want Astro Python SDK operators to send OpenLinea
 ``OPENLINEAGE_URL`` environment variable to send OpenLineage events to Marquez. Optionally, we can also
 specify a namespace where the lineage events will be stored using the ``OPENLINEAGE_NAMESPACE`` environment variable.
 
+A user may choose to send or not, the source code to the OpenLineage then user can specify an environment variable
+``OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE`` set with either ``True`` or ``False``. By default it will be set to ``True``.
+
 For example, to send OpenLineage events to a local instance of Marquez with the dev namespace, use:
 
 .. code-block:: ini

--- a/python-sdk/src/astro/lineage/__init__.py
+++ b/python-sdk/src/astro/lineage/__init__.py
@@ -13,6 +13,7 @@ try:
         OutputStatisticsOutputDatasetFacet,
         SchemaDatasetFacet,
         SchemaField,
+        SourceCodeJobFacet,
         SqlJobFacet,
     )
     from openlineage.client.run import Dataset as OpenlineageDataset

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -35,6 +35,9 @@ MAX_DATAFRAME_MEMORY_FOR_XCOM_DB = conf.getint(SECTION_KEY, "max_dataframe_mem_f
 OPENLINEAGE_EMIT_TEMP_TABLE_EVENT = conf.getboolean(
     SECTION_KEY, "openlineage_emit_temp_table_event", fallback=True
 )
+OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE = conf.getboolean(
+    SECTION_KEY, "openlineage_airflow_disable_source_code", fallback=True
+)
 XCOM_BACKEND = conf.get("core", "xcom_backend")
 IS_BASE_XCOM_BACKEND = conf.get("core", "xcom_backend") == "airflow.models.xcom.BaseXCom"
 ENABLE_XCOM_PICKLING = conf.getboolean("core", "enable_xcom_pickling")

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -279,17 +279,16 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
             inputs=input_dataset, outputs=output_dataset, run_facets=run_facets, job_facets=job_facets
         )
 
-    def get_source_code(self, callable: Callable) -> str | None:
-        import inspect
-
+    def get_source_code(self, py_callable: Callable) -> str | None:
+        """Return the source code for the lineage"""
         try:
-            return inspect.getsource(callable)
+            return inspect.getsource(py_callable)
         except TypeError:
             # Trying to extract source code of builtin_function_or_method
-            return str(callable)
+            return str(py_callable)
         except OSError:
             self.log.warning("Can't get source code facet of Operator {self.operator.task_id}")
-        return None
+            return None
 
 
 def load_op_arg_dataframes_into_sql(conn_id: str, op_args: tuple, target_table: BaseTable) -> tuple:

--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -287,7 +287,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
             return str(py_callable)
         except OSError:
             self.log.warning("Can't get source code facet of Operator {self.operator.task_id}")
-        return None
+            return None
 
 
 def load_op_arg_dataframes_into_sql(conn_id: str, op_args: tuple, target_table: BaseTable) -> tuple:

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -222,7 +222,6 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
         """
         Collect the input, output, job and run facets for DataframeOperator
         """
-        import os
 
         from astro.lineage import (
             BaseFacet,
@@ -234,6 +233,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
             SchemaField,
             SourceCodeJobFacet,
         )
+        from astro.settings import OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE
 
         output_dataset: list[OpenlineageDataset] = []
 
@@ -265,9 +265,8 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
 
         run_facets: dict[str, BaseFacet] = {}
         job_facets: dict[str, BaseFacet] = {}
-        collect_source = os.environ.get("OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE", "True")
         source_code = self.get_source_code(task_instance.task.python_callable)
-        if collect_source and source_code:
+        if OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE and source_code:
             job_facets.update(
                 {
                     "sourceCode": SourceCodeJobFacet("python", source_code),
@@ -286,7 +285,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
             return str(py_callable)
         except OSError:
             self.log.warning("Can't get source code facet of Operator {self.operator.task_id}")
-            return None
+        return None
 
 
 def dataframe(

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -285,7 +285,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
             return str(py_callable)
         except OSError:
             self.log.warning("Can't get source code facet of Operator {self.operator.task_id}")
-        return None
+            return None
 
 
 def dataframe(

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -222,6 +222,8 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
         """
         Collect the input, output, job and run facets for DataframeOperator
         """
+        import os
+
         from astro.lineage import (
             BaseFacet,
             DataSourceDatasetFacet,
@@ -230,6 +232,7 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
             OutputStatisticsOutputDatasetFacet,
             SchemaDatasetFacet,
             SchemaField,
+            SourceCodeJobFacet,
         )
 
         output_dataset: list[OpenlineageDataset] = []
@@ -262,9 +265,29 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
 
         run_facets: dict[str, BaseFacet] = {}
         job_facets: dict[str, BaseFacet] = {}
+        collect_source = os.environ.get("OPENLINEAGE_AIRFLOW_DISABLE_SOURCE_CODE", "True")
+        source_code = self.get_source_code(task_instance.task.python_callable)
+        if collect_source and source_code:
+            job_facets.update(
+                {
+                    "sourceCode": SourceCodeJobFacet("python", source_code),
+                }
+            )
         return OperatorLineage(
             inputs=[], outputs=output_dataset, run_facets=run_facets, job_facets=job_facets
         )
+
+    def get_source_code(self, callable: Callable) -> str | None:
+        import inspect
+
+        try:
+            return inspect.getsource(callable)
+        except TypeError:
+            # Trying to extract source code of builtin_function_or_method
+            return str(callable)
+        except OSError:
+            self.log.warning("Can't get source code facet of Operator {self.operator.task_id}")
+        return None
 
 
 def dataframe(

--- a/python-sdk/src/astro/sql/operators/dataframe.py
+++ b/python-sdk/src/astro/sql/operators/dataframe.py
@@ -277,17 +277,16 @@ class DataframeOperator(AstroSQLBaseOperator, DecoratedOperator):
             inputs=[], outputs=output_dataset, run_facets=run_facets, job_facets=job_facets
         )
 
-    def get_source_code(self, callable: Callable) -> str | None:
-        import inspect
-
+    def get_source_code(self, py_callable: Callable) -> str | None:
+        """Return the source code for the lineage"""
         try:
-            return inspect.getsource(callable)
+            return inspect.getsource(py_callable)
         except TypeError:
             # Trying to extract source code of builtin_function_or_method
-            return str(callable)
+            return str(py_callable)
         except OSError:
             self.log.warning("Can't get source code facet of Operator {self.operator.task_id}")
-        return None
+            return None
 
 
 def dataframe(

--- a/python-sdk/tests/sql/operators/test_base_decorator.py
+++ b/python-sdk/tests/sql/operators/test_base_decorator.py
@@ -1,3 +1,7 @@
+from unittest import mock
+import pytest
+
+from astro.sql import RawSQLOperator
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 
 
@@ -7,3 +11,17 @@ def test_base_sql_decorated_operator_template_fields_with_parameters():
      as this required for taskflow to work if XCom args are being passed via parameters.
     """
     assert "parameters" in BaseSQLDecoratedOperator.template_fields
+
+
+@pytest.mark.parametrize(
+    "exception", [OSError("os error"), TypeError("type error")]
+)
+@mock.patch("astro.sql.operators.base_decorator.inspect.getsource", autospec=True)
+def test_get_source_code_handle_exception(mock_getsource, exception):
+    """assert get_source_code not raise exception"""
+    mock_getsource.side_effect = exception
+    RawSQLOperator(
+        task_id="test",
+        sql="select * from 1",
+        python_callable=lambda: 1
+    ).get_source_code(py_callable=None)

--- a/python-sdk/tests/sql/operators/test_base_decorator.py
+++ b/python-sdk/tests/sql/operators/test_base_decorator.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import pytest
 
 from astro.sql import RawSQLOperator
@@ -13,15 +14,11 @@ def test_base_sql_decorated_operator_template_fields_with_parameters():
     assert "parameters" in BaseSQLDecoratedOperator.template_fields
 
 
-@pytest.mark.parametrize(
-    "exception", [OSError("os error"), TypeError("type error")]
-)
+@pytest.mark.parametrize("exception", [OSError("os error"), TypeError("type error")])
 @mock.patch("astro.sql.operators.base_decorator.inspect.getsource", autospec=True)
 def test_get_source_code_handle_exception(mock_getsource, exception):
     """assert get_source_code not raise exception"""
     mock_getsource.side_effect = exception
-    RawSQLOperator(
-        task_id="test",
-        sql="select * from 1",
-        python_callable=lambda: 1
-    ).get_source_code(py_callable=None)
+    RawSQLOperator(task_id="test", sql="select * from 1", python_callable=lambda: 1).get_source_code(
+        py_callable=None
+    )

--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -12,8 +12,8 @@ from airflow.utils import timezone
 import astro.sql as aql
 from astro.airflow.datasets import DATASET_SUPPORT
 from astro.files import File
-from astro.table import Table
 from astro.sql.operators.dataframe import DataframeOperator
+from astro.table import Table
 
 from ..operators import utils as test_utils
 
@@ -238,14 +238,9 @@ def test_dataframe_from_file_xcom_pickling(mock_serde, sample_dag):
     mock_serde.deserialize.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "exception", [OSError("os error"), TypeError("type error")]
-)
+@pytest.mark.parametrize("exception", [OSError("os error"), TypeError("type error")])
 @mock.patch("astro.sql.operators.base_decorator.inspect.getsource", autospec=True)
 def test_get_source_code_handle_exception(mock_getsource, exception):
     """assert get_source_code not raise exception"""
     mock_getsource.side_effect = exception
-    DataframeOperator(
-        task_id="test",
-        python_callable=lambda: 1
-    ).get_source_code(py_callable=None)
+    DataframeOperator(task_id="test", python_callable=lambda: 1).get_source_code(py_callable=None)

--- a/python-sdk/tests/sql/operators/test_dataframe.py
+++ b/python-sdk/tests/sql/operators/test_dataframe.py
@@ -247,6 +247,5 @@ def test_get_source_code_handle_exception(mock_getsource, exception):
     mock_getsource.side_effect = exception
     DataframeOperator(
         task_id="test",
-        sql="select * from 1",
         python_callable=lambda: 1
     ).get_source_code(py_callable=None)

--- a/python-sdk/tests_integration/extractors/test_extractor.py
+++ b/python-sdk/tests_integration/extractors/test_extractor.py
@@ -296,6 +296,10 @@ def test_python_sdk_transform_extract_on_complete():
     assert task_meta_extract is None
     task_meta = python_sdk_extractor(task.operator).extract_on_complete(task_instance=task_instance)
     assert task_meta.name == f"adhoc_airflow.{task_id}"
+    source_code = task_meta.job_facets.get("sourceCode")
+    # check for transform code return is present in source code facet.
+    validate_string = """return "SELECT title, rating FROM {{ input_table }} LIMIT 5;"""
+    assert validate_string in source_code.source
     assert len(task_meta.job_facets) > 0
     assert task_meta.run_facets == {}
 


### PR DESCRIPTION
**Please describe the feature you'd like to see**
closes: https://github.com/astronomer/astro-sdk/issues/1467

The python transform should also expose its content with the sourceCode facet, similar to the sql facet. Example: [link](https://github.com/OpenLineage/OpenLineage/blob/3090ced24604c95716dacd667c2cff52bf438aba/integration/airflow/openlineage/airflow/extractors/python_extractor.py#L31) [Action item: Create an issue on astro-sdk]
Include the transformation python code that the transformations were running in the OpenLineage events so that they showed up in the Info tab
For demo purposes I hard-coded both of these in a custom openlineage-airflow fork like:
```
code = inspect.getsource(task.python_callable)
job_facet = {"sql": SqlJobFacet(query=code), "sourceCodeLocation": SourceCodeLocationJobFacet("git", "https://github.com/astronomer/astro-days-chicago/blob/9cca4e166d73106e903f3d9f32af334d7b5560a3/dags/airflow_ecosystem.py")}
```
^ the code would probably be cleaner as {"sourceCode": SourceCodeJobFacet("python", code)} I stuffed it in sql only due to the lack of: https://github.com/astronomer/astro/issues/2150 which is a temporary limitation

**Describe the solution you'd like**
- Add source code facet for operators for open lineage integrations

Currently source code facet is done for base decorator operators.