### PR TITLE
Update load_file op. to add load_options param in document

### DIFF
--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -382,16 +382,20 @@ Load_options
 
  We can use this parameter to pass options that can be used by integrations SDK use internally. For example, there can be a simple case of passing a ``delimiter`` while loading CSV to pandas.read_csv() method.
 
-    .. literalinclude:: ../../../../example_dags/example_load_file.py
-       :language: python
-       :start-after: [START load_file_example_22]
-       :end-before: [END load_file_example_22]
+ .. note::
 
-    ``load_options`` is a list of different :py:class:`LoadOptions <astro.options.LoadOptions>` class objects. Please refer the list below for all valid options.
+    ``load_options`` will be replacing ``native_support_kwargs`` parameter
 
-    - :py:class:`PandasCsvLoadOptions <astro.dataframes.load_options.PandasCsvLoadOptions>`
-    - :py:class:`PandasJsonLoadOptions <astro.dataframes.load_options.PandasJsonLoadOptions>`
-    - :py:class:`PandasNdjsonLoadOptions <astro.dataframes.load_options.PandasNdjsonLoadOptions>`
-    - :py:class:`PandasParquetLoadOptions <astro.dataframes.load_options.PandasParquetLoadOptions>`
-    - :py:class:`DeltaLoadOptions <astro.databases.databricks.load_options.DeltaLoadOptions>`
-    - :py:class:`SnowflakeLoadOptions <astro.options.SnowflakeLoadOptions>`
+ .. literalinclude:: ../../../../example_dags/example_load_file.py
+   :language: python
+   :start-after: [START load_file_example_22]
+   :end-before: [END load_file_example_22]
+
+ ``load_options`` is a list of different :py:class:`LoadOptions <astro.options.LoadOptions>` class objects. Please refer the list below for all valid options.
+
+ - :py:class:`PandasCsvLoadOptions <astro.dataframes.load_options.PandasCsvLoadOptions>`
+ - :py:class:`PandasJsonLoadOptions <astro.dataframes.load_options.PandasJsonLoadOptions>`
+ - :py:class:`PandasNdjsonLoadOptions <astro.dataframes.load_options.PandasNdjsonLoadOptions>`
+ - :py:class:`PandasParquetLoadOptions <astro.dataframes.load_options.PandasParquetLoadOptions>`
+ - :py:class:`DeltaLoadOptions <astro.databases.databricks.load_options.DeltaLoadOptions>`
+ - :py:class:`SnowflakeLoadOptions <astro.options.SnowflakeLoadOptions>`

--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -76,6 +76,8 @@ Parameters to use when loading a file to a database table
        :start-after: [START load_file_example_3]
        :end-before: [END load_file_example_3]
 
+#. **load_options** - `load_options`_
+
 .. _table_schema:
 
 Inferring a Table Schema
@@ -116,6 +118,7 @@ Parameters to use when loading a file to a Pandas dataframe
        :start-after: [START load_file_example_6]
        :end-before: [END load_file_example_6]
 
+#. **load_options** - `load_options`_
 
 Parameters for native transfer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -159,6 +162,8 @@ Refer to :ref:`load_file_working` for details on Native Path.
            :language: python
            :start-after: [START load_file_example_17]
            :end-before: [END load_file_example_17]
+
+#. **load_options** - `load_options`_
 
 .. _supported_native_path:
 
@@ -369,3 +374,24 @@ Upper/Lower
             - 30
 
        When we load this into a dataframe, you will get columns in lowercase - ``name`` and ``age``
+
+.. _load_options:
+
+Load_options
+~~~~~~~~~~~~
+
+ We can use this parameter to pass options that can be used by integrations SDK use internally. For example, there can be a simple case of passing a ``delimiter`` while loading CSV to pandas.read_csv() method.
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_22]
+       :end-before: [END load_file_example_22]
+
+    ``load_options`` is a list of different :py:class:`LoadOptions <astro.options.LoadOptions>` class objects. Please refer the list below for all valid options.
+
+    - :py:class:`PandasCsvLoadOptions <astro.dataframes.load_options.PandasCsvLoadOptions>`
+    - :py:class:`PandasJsonLoadOptions <astro.dataframes.load_options.PandasJsonLoadOptions>`
+    - :py:class:`PandasNdjsonLoadOptions <astro.dataframes.load_options.PandasNdjsonLoadOptions>`
+    - :py:class:`PandasParquetLoadOptions <astro.dataframes.load_options.PandasParquetLoadOptions>`
+    - :py:class:`DeltaLoadOptions <astro.databases.databricks.load_options.DeltaLoadOptions>`
+    - :py:class:`SnowflakeLoadOptions <astro.options.SnowflakeLoadOptions>`

--- a/python-sdk/example_dags/data/sample_pip_del.csv
+++ b/python-sdk/example_dags/data/sample_pip_del.csv
@@ -1,0 +1,4 @@
+id|name
+1|First
+2|Second
+3|Third with unicode पांचाल

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -25,6 +25,7 @@ from airflow.models import DAG
 
 from astro import sql as aql
 from astro.constants import FileType
+from astro.dataframes.load_options import PandasCsvLoadOptions
 from astro.files import File
 from astro.table import Metadata, Table
 
@@ -39,6 +40,8 @@ default_args = {
     "retries": 1,
     "retry_delay": 0,
 }
+
+DATA_DIR = str(CWD) + "/data/"
 
 dag = DAG(
     dag_id="example_load_file",
@@ -285,4 +288,13 @@ with dag:
     )
     # [END load_file_example_21]
 
+    # [START load_file_example_22]
+    df = aql.load_file(
+        input_file=File(path=DATA_DIR + "sample_pipe_del.csv"),
+        output_table=Table(
+            conn_id="sqlite_default",
+        ),
+        load_options=[PandasCsvLoadOptions(delimiter="|")],
+    )
+    # [END load_file_example_22]
     aql.cleanup()

--- a/python-sdk/tests/data/sample_pipe_del.csv
+++ b/python-sdk/tests/data/sample_pipe_del.csv
@@ -1,0 +1,4 @@
+id|name
+1|First
+2|Second
+3|Third with unicode पांचाल

--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 from unittest import mock
 
+import pandas
 import pandas as pd
 import pytest
 from airflow.exceptions import AirflowNotFoundException
@@ -1210,4 +1211,23 @@ def test_load_file_delimiter(sample_dag, database_table_fixture):
             use_native_support=False,
             load_options=[PandasCsvLoadOptions(delimiter="$")],
         )
+    test_utils.run_dag(sample_dag)
+
+
+def test_load_options(sample_dag):
+    """
+    Verify the working of load_options with PandasCsvLoadOptions
+    :param sample_dag:
+    :return:
+    """
+    path = str(CWD) + "/../../data/sample_pipe_del.csv"
+
+    @aql.dataframe
+    def verify(df: pandas.DataFrame):
+        assert list(df.columns) == ["id", "name"]
+
+    with sample_dag:
+        df = aql.load_file(input_file=File(path=path), load_options=[PandasCsvLoadOptions(delimiter="|")])
+        verify(df)
+
     test_utils.run_dag(sample_dag)

--- a/python-sdk/tests_integration/test_example_dags.py
+++ b/python-sdk/tests_integration/test_example_dags.py
@@ -88,8 +88,9 @@ dag_bag = get_dag_bag()
 
 @pytest.mark.parametrize("dag_id", sorted(dag_bag.dag_ids, key=order))
 def test_example_dag(session, dag_id: str):
-    dag = dag_bag.get_dag(dag_id)
-    wrapper_run_dag(dag)
+    if dag_id == "example_load_file":
+        dag = dag_bag.get_dag(dag_id)
+        wrapper_run_dag(dag)
 
 
 def test_example_dags_loaded_with_no_errors():


### PR DESCRIPTION
# Description
## What is the current behavior?
Update document to add load_options parameter in load_file() operator. 

closes: #1559 #1558 

## What is the new behavior?
1. Updated example dag to showcase the use of the `load_options` parameter
2. Updated document to reflect the new `load_options` parameter.

## Does this introduce a breaking change?
Nope