### PR TITLE
Add documentation around LoadOptions with example DAGs

### DIFF
--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -52,32 +52,7 @@ Parameters to use when loading a file to a database table
 
 #. **columns_names_capitalization** - If you are working with a ``Snowflake`` database with :ref:`table_schema` and with ``if_exists=replace``, you can control whether the column names of the output table are capitalized. The default is to convert all column names to lowercase. Valid inputs are ``lower``, ``upper``, or ``original`` which will convert column names to lowercase.
 
-#. **load_options** - If you want to provide the list of load options(specific to database or file location) while reading or loading the file pass the list of :py:obj:`LoadOptions <astro.options.LoadOptions>`. Following are the different load options supported:
-
-    - :py:obj:`PandasLoadOptions <astro.options.LoadOptions>` - Pandas load options for reading and loading file using pandas path for various file types:
-        1. :py:obj:`PandasCsvLoadOptions <astro.dataframes.load_options.PandasCsvLoadOptions>` - Pandas load options while reading and loading csv file.
-        2. :py:obj:`PandasJsonLoadOptions <astro.dataframes.load_options.PandasJsonLoadOptions>` - Pandas load options while reading and loading json file.
-        3. :py:obj:`PandasNdjsonLoadOptions <astro.dataframes.load_options.PandasNdjsonLoadOptions>` - Pandas load options while reading and loading Ndjson file.
-        4. :py:obj:`PandasParquetLoadOptions <astro.dataframes.load_options.PandasParquetLoadOptions>` - Pandas load options while reading and loading Parquet file.
-
-    .. literalinclude:: ../../../../example_dags/example_load_file.py
-       :language: python
-       :start-after: [START load_file_example_22]
-       :end-before: [END load_file_example_22]
-
-    - :py:obj:`SnowflakeLoadOptions <astro.options.SnowflakeLoadOptions>` - Load options to load file to snowflake using native approach.
-
-    .. literalinclude:: ../../../../example_dags/example_load_file.py
-       :language: python
-       :start-after: [START load_file_example_23]
-       :end-before: [END load_file_example_23]
-
-    - :py:obj:`DeltaLoadOptions <astro.databases.databricks.load_options.DeltaLoadOptions>` - Load options to rendering options into COPY_INTO Databricks SQL statements.
-
-    .. literalinclude:: ../../../../example_dags/example_load_file.py
-       :language: python
-       :start-after: [START load_file_example_24]
-       :end-before: [END load_file_example_24]
+#. **load_options** - :ref:`load_options`
 
 #. **ndjson_normalize_sep** - If your input file type is NDJSON, you can use this parameter to normalize the data to two dimensions. This makes the data suitable for loading into a table. This parameter is used as a delimiter for combining columns names if required.
 
@@ -143,6 +118,8 @@ Parameters to use when loading a file to a Pandas dataframe
        :start-after: [START load_file_example_6]
        :end-before: [END load_file_example_6]
 
+#. **load_options** - :ref:`load_options`
+
 
 Parameters for native transfer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -186,6 +163,8 @@ Refer to :ref:`load_file_working` for details on Native Path.
            :language: python
            :start-after: [START load_file_example_17]
            :end-before: [END load_file_example_17]
+
+#. **load_options** - :ref:`load_options`
 
 .. _supported_native_path:
 
@@ -396,3 +375,39 @@ Upper/Lower
             - 30
 
        When we load this into a dataframe, you will get columns in lowercase - ``name`` and ``age``
+
+.. _load_options:
+
+LoadOptions
+~~~~~~~~~~~~
+
+If you want to provide the list of load options(specific to database or file location) while reading or loading the file pass the list of :py:obj:`LoadOptions <astro.options.LoadOptions>`. For example, there can be a simple case of passing a ``delimiter`` while loading CSV to pandas.read_csv() method. Following are the different load options supported:
+
+    .. note::
+
+        ``load_options`` will be replacing ``native_support_kwargs`` parameter
+
+    - :py:obj:`PandasLoadOptions <astro.options.LoadOptions>` - Pandas load options for reading and loading file using pandas path for various file types:
+        1. :py:obj:`PandasCsvLoadOptions <astro.dataframes.load_options.PandasCsvLoadOptions>` - Pandas load options while reading and loading csv file.
+        2. :py:obj:`PandasJsonLoadOptions <astro.dataframes.load_options.PandasJsonLoadOptions>` - Pandas load options while reading and loading json file.
+        3. :py:obj:`PandasNdjsonLoadOptions <astro.dataframes.load_options.PandasNdjsonLoadOptions>` - Pandas load options while reading and loading Ndjson file.
+        4. :py:obj:`PandasParquetLoadOptions <astro.dataframes.load_options.PandasParquetLoadOptions>` - Pandas load options while reading and loading Parquet file.
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_22]
+       :end-before: [END load_file_example_22]
+
+    - :py:obj:`SnowflakeLoadOptions <astro.options.SnowflakeLoadOptions>` - Load options to load file to snowflake using native approach.
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_23]
+       :end-before: [END load_file_example_23]
+
+    - :py:obj:`DeltaLoadOptions <astro.databases.databricks.load_options.DeltaLoadOptions>` - Load options to rendering options into COPY_INTO Databricks SQL statements.
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_24]
+       :end-before: [END load_file_example_24]

--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -52,6 +52,33 @@ Parameters to use when loading a file to a database table
 
 #. **columns_names_capitalization** - If you are working with a ``Snowflake`` database with :ref:`table_schema` and with ``if_exists=replace``, you can control whether the column names of the output table are capitalized. The default is to convert all column names to lowercase. Valid inputs are ``lower``, ``upper``, or ``original`` which will convert column names to lowercase.
 
+#. **load_options** - If you want to provide the list of load options(specific to database or file location) while reading or loading the file pass the list of :py:obj:`LoadOptions <astro.options.LoadOptions>`. Following are the different load options supported:
+
+    - :py:obj:`PandasLoadOptions <astro.options.LoadOptions>` - Pandas load options for reading and loading file using pandas path for various file types:
+        1. :py:obj:`PandasCsvLoadOptions <astro.dataframes.load_options.PandasCsvLoadOptions>` - Pandas load options while reading and loading csv file.
+        2. :py:obj:`PandasJsonLoadOptions <astro.dataframes.load_options.PandasJsonLoadOptions>` - Pandas load options while reading and loading json file.
+        3. :py:obj:`PandasNdjsonLoadOptions <astro.dataframes.load_options.PandasNdjsonLoadOptions>` - Pandas load options while reading and loading Ndjson file.
+        4. :py:obj:`PandasParquetLoadOptions <astro.dataframes.load_options.PandasParquetLoadOptions>` - Pandas load options while reading and loading Parquet file.
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_22]
+       :end-before: [END load_file_example_22]
+
+    - :py:obj:`SnowflakeLoadOptions <astro.options.SnowflakeLoadOptions>` - Load options to load file to snowflake using native approach.
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_23]
+       :end-before: [END load_file_example_23]
+
+    - :py:obj:`DeltaLoadOptions <astro.databases.databricks.load_options.DeltaLoadOptions>` - Load options to rendering options into COPY_INTO Databricks SQL statements.
+
+    .. literalinclude:: ../../../../example_dags/example_load_file.py
+       :language: python
+       :start-after: [START load_file_example_24]
+       :end-before: [END load_file_example_24]
+
 #. **ndjson_normalize_sep** - If your input file type is NDJSON, you can use this parameter to normalize the data to two dimensions. This makes the data suitable for loading into a table. This parameter is used as a delimiter for combining columns names if required.
 
     example:

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -302,7 +302,7 @@ with dag:
 
     # [START load_file_example_23]
     aql.load_file(
-        input_file=File("s3://tmp9/delimiter_dollar.csv", conn_id="aws_conn"),
+        input_file=File("s3://astro-sdk/python_sdk/example_dags/data/sample.csv", conn_id="aws_conn"),
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
         ),

--- a/python-sdk/src/astro/databases/databricks/load_options.py
+++ b/python-sdk/src/astro/databases/databricks/load_options.py
@@ -9,7 +9,22 @@ from astro.options import LoadOptions
 
 @define
 class DeltaLoadOptions(LoadOptions):
-    """Helper class for rendering options into COPY_INTO Databricks SQL statements"""
+    """
+    Helper class for rendering options into COPY_INTO Databricks SQL statements
+
+    :param copy_into_format_options: File format options for COPY INTO. Read more at:
+        https://docs.databricks.com/sql/language-manual/delta-copy-into.html#format-options
+    :param copy_into_copy_options: Options to control the operation of the COPY INTO command. Read more at:
+        https://docs.databricks.com/sql/language-manual/delta-copy-into.html
+    :param existing_cluster_id: Existing cluster ID on databricks.
+    :param new_cluster_spec: New cluster specifications.
+    :param if_exists: default override an existing Table. Options: fail, replace, append
+    :param secret_scope: Secrets scope
+    :param load_secrets: Defaults to False.
+    :param load_mode: defaults to autoloader. Options: autoloader, COPY INTO
+    :param autoloader_load_options: Options for load using autoloader. Read more at:
+        https://docs.databricks.com/ingestion/auto-loader/options.html
+    """
 
     copy_into_format_options: dict = field(init=True, factory=dict)
     copy_into_copy_options: dict = field(init=True, factory=dict)

--- a/python-sdk/src/astro/dataframes/load_options.py
+++ b/python-sdk/src/astro/dataframes/load_options.py
@@ -8,25 +8,56 @@ from astro.options import LoadOptions
 
 @define
 class PandasLoadOptions(LoadOptions):
+    """Pandas load options while reading and loading file"""
+
     pass
 
 
 @define
 class PandasCsvLoadOptions(PandasLoadOptions):
+    """
+    Pandas load options while reading and loading csv file.
+
+    :param delimiter: Delimiter to use. Defaults to None
+    :param dtype: Data type for data or columns. E.g. ``{"a": np.float64, "b": np.int32, "c": "Int64"}`` Use str or
+        object together with suitable na_values settings to preserve and not interpret dtype. If converters are
+        specified, they will be applied INSTEAD of dtype conversion.
+    """
+
     delimiter: str | None = None
     dtype: DtypeArg | None = None
 
 
 @define
 class PandasJsonLoadOptions(PandasLoadOptions):
+    """
+    Pandas load options while reading and loading json file.
+
+    :param encoding: Encoding to use for UTF when reading/writing (ex. ‘utf-8’).
+        List of Python standard encodings: https://docs.python.org/3/library/codecs.html#standard-encodings
+    """
+
     encoding: str | None = None
 
 
 @define
 class PandasNdjsonLoadOptions(PandasLoadOptions):
+    """
+    Pandas load options while reading and loading Ndjson file.
+
+    :param normalize_sep: separator used to normalize nested ndjson.
+         ex - ``{"a": {"b":"c"}}`` will result in: ``column - "a_b"`` where ``ndjson_normalize_sep = "_"``
+    """
+
     normalize_sep: str = "_"
 
 
 @define
 class PandasParquetLoadOptions(PandasLoadOptions):
+    """
+    Pandas load options while reading and loading Parquet file.
+
+    :param columns: If not None, only these columns will be read from the file.
+    """
+
     columns: list[str] | None = None

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -49,6 +49,16 @@ class LoadOptionsList:
 
 @attr.define
 class SnowflakeLoadOptions(LoadOptions):
+    """
+    Load options to load file to snowflake using native approach.
+
+    :param file_options: Depending on the file format type specified, use one or more of the
+        format-specific optionsas key-value pair. Read more at:
+        https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#format-type-options-formattypeoptions
+    :param copy_options: Specify one or more of the copy option as key-value pair. Read more at:
+        https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
+    """
+
     file_options: dict = attr.field(init=True, factory=dict)
     copy_options: dict = attr.field(init=True, factory=dict)
 

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -53,7 +53,7 @@ class SnowflakeLoadOptions(LoadOptions):
     Load options to load file to snowflake using native approach.
 
     :param file_options: Depending on the file format type specified, use one or more of the
-        format-specific optionsas key-value pair. Read more at:
+        format-specific options as key-value pair. Read more at:
         https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#format-type-options-formattypeoptions
     :param copy_options: Specify one or more of the copy option as key-value pair. Read more at:
         https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
In Astro SDK 1.4 we introduce a series of LoadOptions classes for classes such as databricks, pandas, and snowflake. Each of these classes is unique and we should create documentation that best showcases how users can use these classes to create the loading settings they want.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1556


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add example DAG using `PandasLoadOptions`, `SnowflakeLoadOptions` and `DeltaLoadOptions`
- Add the documentation for  `PandasLoadOptions`, `SnowflakeLoadOptions` and `DeltaLoadOptions`. Add detailed documentation of how a user can use these classes.
- Add examples for PandasOptions, DeltaOptions, and Snowflake Options.

## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README/documentation, if necessary
