### PR TITLE
Disable logging for non-debug mode

### DIFF
--- a/sql-cli/pyproject.toml
+++ b/sql-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astro-sql-cli"
-version = "0.3.0a2"
+version = "0.3.0a3"
 description = "Empower analysts to build workflows to transform data using SQL"
 authors = [
     "Astronomer <humans@astronomer.io>",

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -62,7 +62,7 @@ def set_debug_mode(debug: bool) -> None:
         for logger_name in EXT_LOGGER_NAMES:
             logging.getLogger(logger_name).setLevel(logging.DEBUG)
     else:
-        logging.disable()
+        logging.disable()  # skipcq PY-A6006
 
 
 @app.command(

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -49,6 +49,8 @@ def set_verbose_mode(verbose: bool) -> None:
     if verbose:
         log.setLevel(logging.DEBUG)
         log.manager.disable = logging.NOTSET
+    else:
+        log.setLevel(logging.CRITICAL)
 
 
 def set_debug_mode(debug: bool) -> None:
@@ -61,8 +63,15 @@ def set_debug_mode(debug: bool) -> None:
 
     if debug:
         for logger_name in EXT_LOGGER_NAMES:
-            logging.getLogger(logger_name).setLevel(logging.DEBUG)
+            logger = logging.getLogger(logger_name)
+            logger.propagate = True
+            logger.setLevel(logging.DEBUG)
+            logger.manager.disable = logging.NOTSET
     else:
+        for logger_name in EXT_LOGGER_NAMES:
+            logger = logging.getLogger(logger_name)
+            logger.propagate = False
+            logger.setLevel(logging.CRITICAL)
         logging.disable()  # skipcq PY-A6006
 
 

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -48,6 +48,7 @@ def set_verbose_mode(verbose: bool) -> None:
     log.addHandler(RichHandler(markup=True))
     if verbose:
         log.setLevel(logging.DEBUG)
+        log.manager.disable = logging.NOTSET
 
 
 def set_debug_mode(debug: bool) -> None:

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -48,8 +48,6 @@ def set_verbose_mode(verbose: bool) -> None:
     log.addHandler(RichHandler(markup=True))
     if verbose:
         log.setLevel(logging.DEBUG)
-    else:
-        log.setLevel(logging.CRITICAL)
 
 
 def set_debug_mode(debug: bool) -> None:
@@ -60,13 +58,11 @@ def set_debug_mode(debug: bool) -> None:
     """
     STATE["debug"] = debug
 
-    for logger_name in EXT_LOGGER_NAMES:
-        logger = logging.getLogger(logger_name)
-        logger.propagate = debug
-        if debug:
-            logger.setLevel(logging.DEBUG)
-        else:
-            logger.setLevel(logging.CRITICAL)
+    if debug:
+        for logger_name in EXT_LOGGER_NAMES:
+            logging.getLogger(logger_name).setLevel(logging.DEBUG)
+    else:
+        logging.disable()
 
 
 @app.command(

--- a/sql-cli/sql_cli/dag_runner.py
+++ b/sql-cli/sql_cli/dag_runner.py
@@ -88,11 +88,6 @@ def run_dag(
         session=session,
         conf=run_conf,
     )
-    dr.log.propagate = False
-    dr.log.addHandler(RichHandler(markup=True))
-    if verbose:
-        dr.log.setLevel(logging.INFO)
-        dr.log.manager.disable = logging.NOTSET
 
     if conn_file_path or variable_file_path or connections:
         # To get around the fact that we reload certain modules, we need to import here
@@ -132,11 +127,12 @@ def add_loghandler(ti: TaskInstance, verbose: bool) -> None:
     :param verbose: Whether to enable debug or critical logs
     """
     log.debug("Adding RichHandler to taskinstance %s", ti.task_id)
-    ti.log.propagate = False
-    ti.log.addHandler(RichHandler(markup=True))
     if verbose:
         ti.log.setLevel(logging.INFO)
         ti.log.manager.disable = logging.NOTSET
+    else:
+        ti.log.setLevel(logging.CRITICAL)
+    ti.log.addHandler(RichHandler(markup=True))
 
 
 def _run_task(ti: TaskInstance, session: Session) -> None:

--- a/sql-cli/sql_cli/dag_runner.py
+++ b/sql-cli/sql_cli/dag_runner.py
@@ -88,6 +88,10 @@ def run_dag(
         session=session,
         conf=run_conf,
     )
+    dr.log.propagate = False
+    dr.log.addHandler(RichHandler(markup=True))
+    if verbose:
+        dr.log.manager.disable = logging.NOTSET
 
     if conn_file_path or variable_file_path or connections:
         # To get around the fact that we reload certain modules, we need to import here
@@ -127,11 +131,10 @@ def add_loghandler(ti: TaskInstance, verbose: bool) -> None:
     :param verbose: Whether to enable debug or critical logs
     """
     log.debug("Adding RichHandler to taskinstance %s", ti.task_id)
+    ti.log.propagate = False
+    ti.log.addHandler(RichHandler(markup=True))
     if verbose:
         ti.log.setLevel(logging.INFO)
-    else:
-        ti.log.setLevel(logging.CRITICAL)
-    ti.log.addHandler(RichHandler(markup=True))
 
 
 def _run_task(ti: TaskInstance, session: Session) -> None:

--- a/sql-cli/sql_cli/dag_runner.py
+++ b/sql-cli/sql_cli/dag_runner.py
@@ -91,6 +91,7 @@ def run_dag(
     dr.log.propagate = False
     dr.log.addHandler(RichHandler(markup=True))
     if verbose:
+        dr.log.setLevel(logging.INFO)
         dr.log.manager.disable = logging.NOTSET
 
     if conn_file_path or variable_file_path or connections:
@@ -135,6 +136,7 @@ def add_loghandler(ti: TaskInstance, verbose: bool) -> None:
     ti.log.addHandler(RichHandler(markup=True))
     if verbose:
         ti.log.setLevel(logging.INFO)
+        ti.log.manager.disable = logging.NOTSET
 
 
 def _run_task(ti: TaskInstance, session: Session) -> None:

--- a/sql-cli/tests/test_dag/dataframe_dag.py
+++ b/sql-cli/tests/test_dag/dataframe_dag.py
@@ -10,6 +10,7 @@ from airflow import DAG
 from astro import sql as aql
 
 log = logging.getLogger(__name__)
+log.manager.disable = logging.NOTSET
 
 
 START_DATE = datetime(2000, 1, 1)


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we oftentimes print some logging statements eventhough we are not using the verbose nor debug flag.

## What is the new behavior?

We disable logging for non-debug mode. The only exception is when verbose mode is set it will selectively enable logging. If debug mode is set enable logging for a selective list of loggers.

## Does this introduce a breaking change?

Not really. There are really no logs being shown when non-debug and non-verbose mode is used.

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
