### PR TITLE
Update release docs with constraints file release steps

### DIFF
--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -72,3 +72,29 @@ target the release branch (e.g. `release-0.7`). Failure to do these steps proper
 <!-- markdown-link-check-enable -->
 
 Once you've created your release, that's it! The rest of the steps should be handled by the CI system.
+
+# Releasing constraints for the release
+
+Once the package pushed (PyPI/Readthedocs) you also need to release constraints files. This steps it bit manual at this point of time.
+
+1. First create a new branch of the last constraints branch. 
+   ```commandline
+   ❯ git branch constraints-1-4 constraints-1-3
+   ```
+2. Checkout that branch 
+   ```commandline
+   ❯ git checkout constraints-1-4 
+   ```
+3. Find the GitHub action CI job that ran when you tagged the release and which published the artifact i.e. visit https://github.com/astronomer/astro-sdk/actions/runs/<RUN_ID> and form the bottom of that GH page download all the constraints file.
+4. Remove old files
+   ```commandline
+   ❯ rm *.txt  and unzip *.zip all the files and then delete zips rm *.zip
+   ```
+5. Then rename them
+   ```commandline
+   ❯ for f in constraints*; do mv "$f" "$f.txt"; done
+   ```
+6. Add and upload
+   ```commandline
+   ❯ git add const* && ❯ git commit -m "Update constraints for Astro SDK 1.4.0" --no-verify  && git push origin constraints-1-4 && git tag constraints-1.4.0 && git push origin constraints-1.4.0
+   ```

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -79,28 +79,32 @@ Once the package pushed to PyPI/Readthedocs you also need to release constraints
 
 1. First create a new branch of the last constraints branch.
    ```console
-   ❯ git fetch origin constraints-1-3 && git checkout constraints-1-3
+   git fetch origin constraints-1-3 && git checkout constraints-1-3
    ```
    ```console
-   ❯ git branch constraints-1-4 constraints-1-3
+   git branch constraints-1-4 constraints-1-3
    ```
 2. Checkout that branch
    ```console
-   ❯ git checkout constraints-1-4
+   git checkout constraints-1-4
    ```
 3. Remove old files
    ```console
-   ❯ rm *.txt
+   rm *.txt
    ```
 4. Find the GitHub action CI job that ran when you tagged the release and which published the artifact i.e. visit https\://github.com/astronomer/astro-sdk/actions/runs/<RUN_ID> and form the bottom of that GH page download all the constraints file and unzip it.
    ```console
-   ❯ unzip "*.zip" &&  rm -rf *.zip
+   unzip "*.zip" &&  rm -rf *.zip
    ```
 5. Then rename them
    ```console
-   ❯ for f in constraints*; do mv "$f" "$f.txt"; done
+   for f in constraints*; do mv "$f" "$f.txt"; done
    ```
 6. Add and upload
    ```console
-   ❯ git add const* && git commit -m "Update constraints for Astro SDK 1.4.0" --no-verify  && git push origin constraints-1-4 && git tag constraints-1.4.0 && git push origin constraints-1.4.0
+   git add const*
+   git commit -m "Update constraints for Astro SDK 1.4.0" --no-verify  
+   git push origin constraints-1-4 
+   git tag constraints-1.4.0 
+   git push origin constraints-1.4.0
    ```

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -79,16 +79,22 @@ Once the package pushed to PyPI/Readthedocs you also need to release constraints
 
 1. First create a new branch of the last constraints branch.
    ```console
+   ❯ git fetch origin constraints-1-3 && git checkout constraints-1-3
+   ```
+   ```console
    ❯ git branch constraints-1-4 constraints-1-3
    ```
 2. Checkout that branch
    ```console
    ❯ git checkout constraints-1-4
    ```
-3. Find the GitHub action CI job that ran when you tagged the release and which published the artifact i.e. visit https\://github.com/astronomer/astro-sdk/actions/runs/<RUN_ID> and form the bottom of that GH page download all the constraints file.
-4. Remove old files
+3. Remove old files
    ```console
-   ❯ rm *.txt  and unzip *.zip all the files and then delete zips rm *.zip
+   ❯ rm *.txt
+   ```
+4. Find the GitHub action CI job that ran when you tagged the release and which published the artifact i.e. visit https\://github.com/astronomer/astro-sdk/actions/runs/<RUN_ID> and form the bottom of that GH page download all the constraints file and unzip it.
+   ```console
+   ❯ unzip "*.zip" &&  rm -rf *.zip
    ```
 5. Then rename them
    ```console
@@ -96,5 +102,5 @@ Once the package pushed to PyPI/Readthedocs you also need to release constraints
    ```
 6. Add and upload
    ```console
-   ❯ git add const* && ❯ git commit -m "Update constraints for Astro SDK 1.4.0" --no-verify  && git push origin constraints-1-4 && git tag constraints-1.4.0 && git push origin constraints-1.4.0
+   ❯ git add const* && git commit -m "Update constraints for Astro SDK 1.4.0" --no-verify  && git push origin constraints-1-4 && git tag constraints-1.4.0 && git push origin constraints-1.4.0
    ```

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -78,23 +78,23 @@ Once you've created your release, that's it! The rest of the steps should be han
 Once the package pushed to PyPI/Readthedocs you also need to release constraints files. This steps it bit manual at this point of time.
 
 1. First create a new branch of the last constraints branch.
-   ```commandline
+   ```console
    ❯ git branch constraints-1-4 constraints-1-3
    ```
 2. Checkout that branch
-   ```commandline
+   ```console
    ❯ git checkout constraints-1-4
    ```
 3. Find the GitHub action CI job that ran when you tagged the release and which published the artifact i.e. visit https\://github.com/astronomer/astro-sdk/actions/runs/<RUN_ID> and form the bottom of that GH page download all the constraints file.
 4. Remove old files
-   ```commandline
+   ```console
    ❯ rm *.txt  and unzip *.zip all the files and then delete zips rm *.zip
    ```
 5. Then rename them
-   ```commandline
+   ```console
    ❯ for f in constraints*; do mv "$f" "$f.txt"; done
    ```
 6. Add and upload
-   ```commandline
+   ```console
    ❯ git add const* && ❯ git commit -m "Update constraints for Astro SDK 1.4.0" --no-verify  && git push origin constraints-1-4 && git tag constraints-1.4.0 && git push origin constraints-1.4.0
    ```

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -75,7 +75,7 @@ Once you've created your release, that's it! The rest of the steps should be han
 
 # Releasing constraints for the release
 
-Once the package pushed (PyPI/Readthedocs) you also need to release constraints files. This steps it bit manual at this point of time.
+Once the package pushed to PyPI/Readthedocs you also need to release constraints files. This steps it bit manual at this point of time.
 
 1. First create a new branch of the last constraints branch. 
    ```commandline

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -85,7 +85,7 @@ Once the package pushed to PyPI/Readthedocs you also need to release constraints
    ```commandline
    ❯ git checkout constraints-1-4 
    ```
-3. Find the GitHub action CI job that ran when you tagged the release and which published the artifact i.e. visit https://github.com/astronomer/astro-sdk/actions/runs/<RUN_ID> and form the bottom of that GH page download all the constraints file.
+3. Find the GitHub action CI job that ran when you tagged the release and which published the artifact i.e. visit https\://github.com/astronomer/astro-sdk/actions/runs/<RUN_ID> and form the bottom of that GH page download all the constraints file.
 4. Remove old files
    ```commandline
    ❯ rm *.txt  and unzip *.zip all the files and then delete zips rm *.zip

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -77,13 +77,13 @@ Once you've created your release, that's it! The rest of the steps should be han
 
 Once the package pushed to PyPI/Readthedocs you also need to release constraints files. This steps it bit manual at this point of time.
 
-1. First create a new branch of the last constraints branch. 
+1. First create a new branch of the last constraints branch.
    ```commandline
    ❯ git branch constraints-1-4 constraints-1-3
    ```
-2. Checkout that branch 
+2. Checkout that branch
    ```commandline
-   ❯ git checkout constraints-1-4 
+   ❯ git checkout constraints-1-4
    ```
 3. Find the GitHub action CI job that ran when you tagged the release and which published the artifact i.e. visit https\://github.com/astronomer/astro-sdk/actions/runs/<RUN_ID> and form the bottom of that GH page download all the constraints file.
 4. Remove old files

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -103,8 +103,8 @@ Once the package pushed to PyPI/Readthedocs you also need to release constraints
 6. Add and upload
    ```console
    git add const*
-   git commit -m "Update constraints for Astro SDK 1.4.0" --no-verify  
-   git push origin constraints-1-4 
-   git tag constraints-1.4.0 
+   git commit -m "Update constraints for Astro SDK 1.4.0" --no-verify
+   git push origin constraints-1-4
+   git tag constraints-1.4.0
    git push origin constraints-1.4.0
    ```


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/1474
## What is the current behavior?
Update release docs with constraints file release steps

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
