### PR TITLE
add a results_format field to run_raw_sql

### DIFF
--- a/python-sdk/docs/astro/sql/operators/raw_sql.rst
+++ b/python-sdk/docs/astro/sql/operators/raw_sql.rst
@@ -24,3 +24,15 @@ This example shows how you can run a ``select`` query in Bigquery and return row
     :language: python
     :start-after: [START howto_run_raw_sql_with_handle_1]
     :end-before: [END howto_run_raw_sql_with_handle_1]
+
+Parameters
+-----------
+* **handler** - This parameter is used to pass a callback and this callback gets a cursor object from the database.
+
+* **results_format** - There are common scenarios where the kind of results you would expect from the handler function to return.
+
+    #. List - If you expect a query return to be a list of rows. instead of passing handler to do ``cursor.fetchall()``, we can pass ``results_format=='list'``
+
+    #. Pandas Dataframe - If you expect query result to be converted to ``Pandas Dataframe`` we can pass ``results_format=='pandas_dataframe'``
+
+* **fail_on_empty** - Sometimes the handler function can raise an exception when the data is not returned by the database and we try to run ``fetchall()``. We can make sure that the handler function doesn't raise an exception by passing ``fail_on_empty==False``. The default value for this parameter is ``True``.

--- a/python-sdk/src/astro/constants.py
+++ b/python-sdk/src/astro/constants.py
@@ -76,3 +76,5 @@ ExportExistsStrategy = Literal["replace", "exception"]
 MergeConflictStrategy = Literal["ignore", "update", "exception"]
 
 ColumnCapitalization = Literal["upper", "lower", "original"]
+
+RunRawSQLResultFormat = Literal["list", "pandas_dataframe"]

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -63,6 +63,8 @@ class BaseDatabase(ABC):
     # illegal_column_name_chars[0] will be replaced by value in illegal_column_name_chars_replacement[0]
     illegal_column_name_chars: list[str] = []
     illegal_column_name_chars_replacement: list[str] = []
+    # In run_raw_sql operator decides if we want to return results directly or process them by handler provided
+    IGNORE_HANDLER_IN_RUN_RAW_SQL: bool = False
     NATIVE_PATHS: dict[Any, Any] = {}
     DEFAULT_SCHEMA = SCHEMA
     NATIVE_LOAD_EXCEPTIONS: Any = DatabaseCustomError

--- a/python-sdk/src/astro/databases/databricks/delta.py
+++ b/python-sdk/src/astro/databases/databricks/delta.py
@@ -26,7 +26,9 @@ from astro.table import BaseTable, Metadata
 class DeltaDatabase(BaseDatabase):
 
     LOAD_OPTIONS_CLASS_NAME = "DeltaLoadOptions"
-
+    # In run_raw_sql operator decides if we want to return results directly or process them by handler provided
+    # For delta tables we ignore the handler
+    IGNORE_HANDLER_IN_RUN_RAW_SQL: bool = True
     _create_table_statement: str = "CREATE TABLE IF NOT EXISTS {} USING DELTA AS {} "
 
     def __init__(self, conn_id: str, table: BaseTable | None = None, load_options: LoadOptions | None = None):

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -135,7 +135,8 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
             def handle_exceptions(result):
                 try:
                     return conversion_func(result)
-                except Exception:  # skipcq: PYL-W0703
+                except Exception as e:  # skipcq: PYL-W0703
+                    logging.info(f"Exception {e} handled 'fail_on_empty' parameter")
                     return None
 
             return handle_exceptions

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -136,7 +136,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
                 try:
                     return conversion_func(result)
                 except Exception as e:  # skipcq: PYL-W0703
-                    logging.info(f"Exception {e} handled 'fail_on_empty' parameter")
+                    logging.info(f"Exception {e} handled since 'fail_on_empty' parameter was passed")
                     return None
 
             return handle_exceptions

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -10,9 +10,8 @@ except ImportError:
     from airflow.decorators import _TaskDecorator as TaskDecorator
 
 import airflow
-from airflow.decorators.base import task_decorator_factory
-
 import pandas as pd
+from airflow.decorators.base import task_decorator_factory
 from sqlalchemy.engine import ResultProxy
 
 if airflow.__version__ >= "2.3":
@@ -37,7 +36,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
 
     def __init__(
         self,
-        results_format: Literal['list', 'dataframe'] | None = None,
+        results_format: Literal["list", "dataframe"] | None = None,
         fail_on_empty: bool = False,
         **kwargs: Any,
     ):
@@ -72,7 +71,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
                     return conversion_func(result)
                 except Exception:
                     return None
-            
+
             # otherwise, just return the result
             return conversion_func(result)
 
@@ -143,7 +142,7 @@ def run_raw_sql(
     database: str | None = None,
     schema: str | None = None,
     handler: Callable | None = None,
-    results_format: Literal['list', 'dataframe'] | None = None,
+    results_format: Literal["list", "dataframe"] | None = None,
     fail_on_empty: bool = False,
     response_size: int = settings.RAW_SQL_MAX_RESPONSE_SIZE,
     **kwargs: Any,

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -129,7 +129,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
         # if fail_on_empty is set to False, wrap in a try/except block
         # this is because the conversion function will fail if the result is empty
         # due to sqlalchemy failing when there are no results
-        if fail_on_empty:
+        if not fail_on_empty:
 
             def handle_exceptions(result):
                 try:

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -137,7 +137,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
                 try:
                     return conversion_func(result)
                 except Exception as e:  # skipcq: PYL-W0703
-                    logging.info(f"Exception {e} handled since 'fail_on_empty' parameter was passed")
+                    logging.info("Exception %s handled since 'fail_on_empty' parameter was passed", str(e))
                     return None
 
             return handle_exceptions

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -118,6 +118,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
         # note that it takes precedence over the handler
         if self.results_format:
             self.handler = self.get_results_format_handler(results_format=self.results_format)
+            logging.info("Provided 'handler' will be overridden when 'results_format' is given.")
         if self.handler:
             self.handler = self.get_wrapped_handler(
                 fail_on_empty=self.fail_on_empty, conversion_func=self.handler

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -134,7 +134,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
             def handle_exceptions(result):
                 try:
                     return conversion_func(result)
-                except Exception:
+                except Exception:  # skipcq: PYL-W0703
                     return None
 
             return handle_exceptions

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -21,6 +21,7 @@ else:
 
 from astro import settings
 from astro.constants import RunRawSQLResultFormat
+from astro.dataframes.pandas import PandasDataframe
 from astro.exceptions import IllegalLoadToDatabaseException
 from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
 from astro.utils.compat.typing import Context
@@ -108,7 +109,7 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
         """
         Convert the result of a SQL query to a pandas dataframe
         """
-        return pd.DataFrame(result.fetchall(), columns=result.keys())
+        return PandasDataframe(result.fetchall(), columns=result.keys())
 
     def get_results_format_handler(self, results_format: str):
         return getattr(self, f"results_as_{results_format}")

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -29,7 +29,7 @@ def test_run_sql_calls_list_handler(run_sql, results_as_list, sample_dag):
     run_sql.return_value = []
     with sample_dag:
 
-        @aql.run_raw_sql(results_format="list", conn_id="google_cloud_default")
+        @aql.run_raw_sql(results_format="list", conn_id="sqlite_default")
         def dummy_method():
             return "SELECT 1+1"
 
@@ -46,7 +46,7 @@ def test_run_sql_calls_pandas_dataframe_handler(run_sql, results_as_pandas_dataf
     run_sql.return_value = []
     with sample_dag:
 
-        @aql.run_raw_sql(results_format="pandas_dataframe", conn_id="google_cloud_default")
+        @aql.run_raw_sql(results_format="pandas_dataframe", conn_id="sqlite_default")
         def dummy_method():
             return "SELECT 1+1"
 
@@ -67,7 +67,7 @@ def test_run_sql_gives_priority_to_pandas_dataframe_handler(run_sql, results_as_
     with sample_dag:
 
         @aql.run_raw_sql(
-            results_format="pandas_dataframe", conn_id="google_cloud_default", handler=lambda x: x.fetchall()
+            results_format="pandas_dataframe", conn_id="sqlite_default", handler=lambda x: x.fetchall()
         )
         def dummy_method():
             return "SELECT 1+1"
@@ -94,7 +94,7 @@ def test_run_sql_called_handler(run_sql, results_as_pandas_dataframe, sample_dag
 
     with sample_dag:
 
-        @aql.run_raw_sql(conn_id="google_cloud_default", handler=verify)
+        @aql.run_raw_sql(conn_id="sqlite_default", handler=verify)
         def dummy_method():
             return "SELECT 1+1"
 
@@ -118,7 +118,7 @@ def test_run_sql_should_raise_exception(run_sql, results_as_pandas_dataframe, sa
     with pytest.raises(ValueError) as e:
         with sample_dag:
 
-            @aql.run_raw_sql(conn_id="google_cloud_default", handler=raise_exception, fail_on_empty=False)
+            @aql.run_raw_sql(conn_id="sqlite_default", handler=raise_exception, fail_on_empty=False)
             def dummy_method():
                 return "SELECT 1+1"
 
@@ -142,7 +142,7 @@ def test_run_sql_should_not_raise_exception(run_sql, results_as_pandas_dataframe
 
     with sample_dag:
 
-        @aql.run_raw_sql(conn_id="google_cloud_default", handler=raise_exception, fail_on_empty=True)
+        @aql.run_raw_sql(conn_id="sqlite_default", handler=raise_exception, fail_on_empty=True)
         def dummy_method():
             return "SELECT 1+1"
 

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -115,7 +115,7 @@ def test_run_sql_should_raise_exception(run_sql, results_as_pandas_dataframe, sa
     def raise_exception(result):
         raise ValueError("dummy exception")
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="dummy exception"):
         with sample_dag:
 
             @aql.run_raw_sql(conn_id="sqlite_default", handler=raise_exception, fail_on_empty=True)
@@ -124,7 +124,6 @@ def test_run_sql_should_raise_exception(run_sql, results_as_pandas_dataframe, sa
 
             dummy_method()
         test_utils.run_dag(sample_dag)
-    e.match("dummy exception")
 
 
 @mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -118,7 +118,7 @@ def test_run_sql_should_raise_exception(run_sql, results_as_pandas_dataframe, sa
     with pytest.raises(ValueError) as e:
         with sample_dag:
 
-            @aql.run_raw_sql(conn_id="sqlite_default", handler=raise_exception, fail_on_empty=False)
+            @aql.run_raw_sql(conn_id="sqlite_default", handler=raise_exception, fail_on_empty=True)
             def dummy_method():
                 return "SELECT 1+1"
 
@@ -142,7 +142,7 @@ def test_run_sql_should_not_raise_exception(run_sql, results_as_pandas_dataframe
 
     with sample_dag:
 
-        @aql.run_raw_sql(conn_id="sqlite_default", handler=raise_exception, fail_on_empty=True)
+        @aql.run_raw_sql(conn_id="sqlite_default", handler=raise_exception, fail_on_empty=False)
         def dummy_method():
             return "SELECT 1+1"
 

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -1,8 +1,12 @@
 import pathlib
+from unittest import mock
 
+import pandas
 import pytest
 
 from astro import sql as aql
+
+from ..operators import utils as test_utils
 
 CWD = pathlib.Path(__file__).parent
 DATA_FILEPATH = pathlib.Path(CWD.parent.parent, "data/sample.csv")
@@ -16,3 +20,152 @@ def test_make_row_serializable(rows):
     input_rows, expected_output = rows
     result = aql.RawSQLOperator.make_row_serializable(input_rows)
     assert result == expected_output
+
+
+@mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_list")
+@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+def test_run_sql_calls_list_handler(run_sql, results_as_list, sample_dag):
+    results_as_list.return_value = []
+    run_sql.return_value = []
+    with sample_dag:
+
+        @aql.run_raw_sql(results_format="list", conn_id="google_cloud_default")
+        def dummy_method():
+            return "SELECT 1+1"
+
+        dummy_method()
+
+    test_utils.run_dag(sample_dag)
+    results_as_list.assert_called_with([])
+
+
+@mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")
+@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+def test_run_sql_calls_pandas_dataframe_handler(run_sql, results_as_pandas_dataframe, sample_dag):
+    results_as_pandas_dataframe.return_value = []
+    run_sql.return_value = []
+    with sample_dag:
+
+        @aql.run_raw_sql(results_format="pandas_dataframe", conn_id="google_cloud_default")
+        def dummy_method():
+            return "SELECT 1+1"
+
+        dummy_method()
+
+    test_utils.run_dag(sample_dag)
+    results_as_pandas_dataframe.assert_called_with([])
+
+
+@mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")
+@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+def test_run_sql_gives_priority_to_pandas_dataframe_handler(run_sql, results_as_pandas_dataframe, sample_dag):
+    """
+    Test that run_sql calls `results_format` specified handler over handler passed in decorator.
+    """
+    results_as_pandas_dataframe.return_value = []
+    run_sql.return_value = []
+    with sample_dag:
+
+        @aql.run_raw_sql(
+            results_format="pandas_dataframe", conn_id="google_cloud_default", handler=lambda x: x.fetchall()
+        )
+        def dummy_method():
+            return "SELECT 1+1"
+
+        dummy_method()
+
+    test_utils.run_dag(sample_dag)
+    results_as_pandas_dataframe.assert_called_with([])
+
+
+@mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")
+@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+def test_run_sql_called_handler(run_sql, results_as_pandas_dataframe, sample_dag):
+    """
+    Test that run_sql calls `handler` passed in decorator.
+    """
+    results_as_pandas_dataframe.return_value = []
+    return_value = [1, 2, 3]
+    run_sql.return_value = return_value
+
+    def verify(result):
+        assert result == return_value
+        return result
+
+    with sample_dag:
+
+        @aql.run_raw_sql(conn_id="google_cloud_default", handler=verify)
+        def dummy_method():
+            return "SELECT 1+1"
+
+        dummy_method()
+    test_utils.run_dag(sample_dag)
+
+
+@mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")
+@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+def test_run_sql_should_raise_exception(run_sql, results_as_pandas_dataframe, sample_dag):
+    """
+    Test that run_sql should raise an exception when fail_on_empty=False
+    """
+    results_as_pandas_dataframe.return_value = []
+    return_value = [1, 2, 3]
+    run_sql.return_value = return_value
+
+    def raise_exception(result):
+        raise ValueError("dummy exception")
+
+    with pytest.raises(ValueError) as e:
+        with sample_dag:
+
+            @aql.run_raw_sql(conn_id="google_cloud_default", handler=raise_exception, fail_on_empty=False)
+            def dummy_method():
+                return "SELECT 1+1"
+
+            dummy_method()
+        test_utils.run_dag(sample_dag)
+    e.match("dummy exception")
+
+
+@mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")
+@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+def test_run_sql_should_not_raise_exception(run_sql, results_as_pandas_dataframe, sample_dag):
+    """
+    Test that run_sql should not raise an exception when fail_on_empty=True
+    """
+    results_as_pandas_dataframe.return_value = []
+    return_value = [1, 2, 3]
+    run_sql.return_value = return_value
+
+    def raise_exception(result):
+        raise ValueError("dummy exception")
+
+    with sample_dag:
+
+        @aql.run_raw_sql(conn_id="google_cloud_default", handler=raise_exception, fail_on_empty=True)
+        def dummy_method():
+            return "SELECT 1+1"
+
+        dummy_method()
+    test_utils.run_dag(sample_dag)
+
+
+def test_handlers():
+    """
+    Test the handler return desired results
+    """
+
+    class MockResultProxy:
+        def fetchall(self):
+            return [1, 2, 3]
+
+        def keys(self):
+            return ["col"]
+
+    result = MockResultProxy()
+    processed_result = aql.RawSQLOperator.results_as_list(result)
+    assert processed_result == [1, 2, 3]
+
+    processed_result = aql.RawSQLOperator.results_as_pandas_dataframe(result)
+    assert type(processed_result) == pandas.DataFrame
+    assert processed_result.shape == (3, 1)

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -156,10 +156,12 @@ def test_handlers():
     """
 
     class MockResultProxy:
-        def fetchall(self):
+        @staticmethod
+        def fetchall():
             return [1, 2, 3]
 
-        def keys(self):
+        @staticmethod
+        def keys():
             return ["col"]
 
     result = MockResultProxy()
@@ -167,5 +169,5 @@ def test_handlers():
     assert processed_result == [1, 2, 3]
 
     processed_result = aql.RawSQLOperator.results_as_pandas_dataframe(result)
-    assert type(processed_result) == pandas.DataFrame
+    assert isinstance(processed_result, pandas.DataFrame)
     assert processed_result.shape == (3, 1)


### PR DESCRIPTION
# Description

related: #1583

This PR extends the `run_raw_sql` to make it easier to get results. Previously, you'd have to write a `handler` yourself. The idea behind this change is to abstract some of the common handlers (get the results as a list, dataframe).

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->

Specifically, it:
- introduces two new fields to the run_raw_sql operator:
  - `results_format`: let the user specify a common format they want their results (list, dataframe)
  - `fail_on_empty`: let the user decide what the behavior should be if there are no results

## Does this introduce a breaking change?

No, everything is incremental


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
