### PR TITLE
Update release doc with best practice for creating changelog

### DIFF
--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -2,7 +2,9 @@
 
 ## Updating the changelog
 
-The first step to creating a release is identifying what changed from the previous release and adding a description to the [CHANGELOG.md](../CHANGELOG.md)
+The first step to creating a release is identifying what changed from the previous release and adding a description to the [CHANGELOG.md](../CHANGELOG.md).
+
+One way to identify what changed from the previous release is to raise a dummy PR from the main branch to the previous release branch. This will show all the commits that are in the main branch but not in the release branch. Using this we can note all the changes significant enough to be mentioned in CHANGELOGS.
 
 ## Handling patch releases
 

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -7,7 +7,7 @@ The first step to creating a release is identifying what changed from the previo
 One way to identify what changed from the previous release is to use a comparison URL between the previous release branch and the main branch.
 
 Example -
-```https://github.com/astronomer/astro-sdk/compare/1.3.3...main```
+[https://github.com/astronomer/astro-sdk/compare/1.3.3...main](https://github.com/astronomer/astro-sdk/compare/1.3.3...main)
 
 This will show all the commits that are in the main branch but not in the release branch. Using this we can note all the changes significant enough to be mentioned in CHANGELOGS.
 

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -4,7 +4,12 @@
 
 The first step to creating a release is identifying what changed from the previous release and adding a description to the [CHANGELOG.md](../CHANGELOG.md).
 
-One way to identify what changed from the previous release is to raise a dummy PR from the main branch to the previous release branch. This will show all the commits that are in the main branch but not in the release branch. Using this we can note all the changes significant enough to be mentioned in CHANGELOGS.
+One way to identify what changed from the previous release is to use a comparison URL between the previous release branch and the main branch.
+
+Example -
+```https://github.com/astronomer/astro-sdk/compare/1.3.3...main```
+
+This will show all the commits that are in the main branch but not in the release branch. Using this we can note all the changes significant enough to be mentioned in CHANGELOGS.
 
 ## Handling patch releases
 

--- a/python-sdk/docs/development/RELEASE.md
+++ b/python-sdk/docs/development/RELEASE.md
@@ -11,6 +11,7 @@ Example -
 
 This will show all the commits that are in the main branch but not in the release branch. Using this we can note all the changes significant enough to be mentioned in CHANGELOGS.
 
+
 ## Handling patch releases
 
 ### When should I create a patch release?


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, we relied on milestones to form the changelogs but this can lead us to miss important changes. 

closes: #1593  

## What is the new behavior?
Going forward we can follow the below approach to avoid such occurrences.

```
One way to identify what changed from the previous release is to use a comparison URL between the previous release branch and the main branch.

Example -
`https://github.com/astronomer/astro-sdk/compare/1.3.3...main`

This will show all the commits that are in the main branch but not in the release branch. Using this we can note all the changes significant enough to be mentioned in CHANGELOGS.

```

Add it as best practice. 

## Does this introduce a breaking change?
Nope


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
