### PR TITLE
Fix data validation tests

### DIFF
--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -3,7 +3,7 @@ from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
 from astro.sql.operators.data_validations.check_column import ColumnCheckOperator, check_column
-from astro.sql.operators.data_validations.check_table import SQLTableCheckOperator, check_table
+from astro.sql.operators.data_validations.check_table import SQLCheckOperator, check_table
 from astro.sql.operators.append import AppendOperator, append
 from astro.sql.operators.cleanup import CleanupOperator, cleanup
 from astro.sql.operators.dataframe import DataframeOperator, dataframe
@@ -45,7 +45,7 @@ __all__ = [
     "transform",
     "ColumnCheckOperator",
     "check_column",
-    "SQLTableCheckOperator",
+    "SQLCheckOperator",
     "check_table",
 ]
 

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -2,10 +2,10 @@ from airflow.configuration import conf
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
-from astro.sql.operators.data_validations.check_column import ColumnCheckOperator, check_column
-from astro.sql.operators.data_validations.check_table import SQLCheckOperator, check_table
 from astro.sql.operators.append import AppendOperator, append
 from astro.sql.operators.cleanup import CleanupOperator, cleanup
+from astro.sql.operators.data_validations.check_column import ColumnCheckOperator, check_column
+from astro.sql.operators.data_validations.check_table import SQLCheckOperator, check_table
 from astro.sql.operators.dataframe import DataframeOperator, dataframe
 from astro.sql.operators.drop import DropTableOperator, drop_table
 from astro.sql.operators.export_file import ExportFileOperator, export_file

--- a/python-sdk/src/astro/sql/__init__.py
+++ b/python-sdk/src/astro/sql/__init__.py
@@ -2,6 +2,8 @@ from airflow.configuration import conf
 from airflow.decorators.base import get_unique_task_id
 from airflow.models.xcom_arg import XComArg
 
+from astro.sql.operators.data_validations.check_column import ColumnCheckOperator, check_column
+from astro.sql.operators.data_validations.check_table import SQLTableCheckOperator, check_table
 from astro.sql.operators.append import AppendOperator, append
 from astro.sql.operators.cleanup import CleanupOperator, cleanup
 from astro.sql.operators.dataframe import DataframeOperator, dataframe
@@ -43,7 +45,7 @@ __all__ = [
     "transform",
     "ColumnCheckOperator",
     "check_column",
-    "SQLCheckOperator",
+    "SQLTableCheckOperator",
     "check_table",
 ]
 


### PR DESCRIPTION
# Description
## What is the current behavior?
currently tests are failing in main with error 
```
FAILED tests_integration/sql/operators/data_validation/test_check_column.py::test_column_check_operator_with_table_dataset[snowflake] - AttributeError: module 'astro.sql' has no attribute 'ColumnCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_column.py::test_column_check_operator_with_table_dataset[bigquery] - AttributeError: module 'astro.sql' has no attribute 'ColumnCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_column.py::test_column_check_operator_with_table_dataset[postgresql] - AttributeError: module 'astro.sql' has no attribute 'ColumnCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_column.py::test_column_check_operator_with_table_dataset[sqlite] - AttributeError: module 'astro.sql' has no attribute 'ColumnCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_column.py::test_column_check_operator_with_table_dataset[redshift] - AttributeError: module 'astro.sql' has no attribute 'ColumnCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_table.py::test_column_check_operator_with_table_dataset[snowflake] - AttributeError: module 'astro.sql' has no attribute 'SQLCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_table.py::test_column_check_operator_with_table_dataset[bigquery] - AttributeError: module 'astro.sql' has no attribute 'SQLCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_table.py::test_column_check_operator_with_table_dataset[postgresql] - AttributeError: module 'astro.sql' has no attribute 'SQLCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_table.py::test_column_check_operator_with_table_dataset[sqlite] - AttributeError: module 'astro.sql' has no attribute 'SQLCheckOperator'
FAILED tests_integration/sql/operators/data_validation/test_check_table.py::test_column_check_operator_with_table_dataset[redshift] - AttributeError: module 'astro.sql' has no attribute 'SQLCheckOperator'
```


## What is the new behavior?
Fix import path

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
