### PR TITLE
Add flow deploy command

### DIFF
--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -313,10 +313,7 @@ def deploy(
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
 ) -> None:
-    rprint(
-        "Native deployment not yet available."
-        " Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."
-    )
+    rprint("Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details.")
     raise typer.Exit(code=1)
 
 

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -294,6 +294,32 @@ def init(
     rprint("Initialized an Astro SQL project at", project.directory)
 
 
+@app.command(
+    cls=AstroCommand,
+    help="""Deploy workflows to Astro Cloud.""",
+)
+def deploy(
+    workflow_name: str = typer.Option(
+        default=None,
+        show_default=False,
+        help="name of the workflow directory within workflows directory.",
+    ),
+    env: str = typer.Option(
+        metavar="environment",
+        default="default",
+        help="environment to deploy",
+    ),
+    project_dir: Path = typer.Option(
+        None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
+    ),
+):
+    rprint(
+        "Native deployment not yet available."
+        " Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."
+    )
+    raise typer.Exit(code=1)
+
+
 def _generate_dag(
     project: Project, workflow_name: str, generate_tasks: bool, output_dir: Path | None = None
 ) -> Path:

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -314,7 +314,7 @@ def deploy(
     ),
 ) -> None:
     rprint(
-        "Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."
+        "Please use the Astro CLI to deploy. See https://docs.astronomer.io/astro/cli/sql-cli for details."
     )
     raise typer.Exit(code=1)
 

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -312,7 +312,7 @@ def deploy(
     project_dir: Path = typer.Option(
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
-):
+) -> None:
     rprint(
         "Native deployment not yet available."
         " Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -299,17 +299,17 @@ def init(
     help="""Deploy workflows to Astro Cloud.""",
 )
 def deploy(
-    workflow_name: str = typer.Option(
+    workflow_name: str = typer.Option(  # skipcq: PYL-W0613
         default=None,
         show_default=False,
         help="name of the workflow directory within workflows directory.",
     ),
-    env: str = typer.Option(
+    env: str = typer.Option(  # skipcq: PYL-W0613
         metavar="environment",
         default="default",
         help="environment to deploy",
     ),
-    project_dir: Path = typer.Option(
+    project_dir: Path = typer.Option(  # skipcq: PYL-W0613
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
 ) -> None:

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -313,7 +313,9 @@ def deploy(
         None, dir_okay=True, metavar="PATH", help="(Optional) Default: current directory.", show_default=False
     ),
 ) -> None:
-    rprint("Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details.")
+    rprint(
+        "Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."
+    )
     raise typer.Exit(code=1)
 
 

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -638,3 +638,13 @@ def test_main_no_debug(args, ext_loggers):
     result = runner.invoke(app, args)
     assert result.exit_code == 0
     assert all(logger.manager.disable == logging.CRITICAL for logger in ext_loggers)
+
+
+def test_deploy():
+    result = runner.invoke(app, ["deploy"])
+    assert result.exit_code == 1
+    assert (
+        "Native deployment not yet available."
+        " Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."
+        in result.stdout
+    )

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -644,7 +644,6 @@ def test_deploy():
     result = runner.invoke(app, ["deploy"])
     assert result.exit_code == 1
     assert (
-        "Native deployment not yet available."
-        " Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."
+        "Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."
         in result.stdout
     )

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -644,6 +644,6 @@ def test_deploy():
     result = runner.invoke(app, ["deploy"])
     assert result.exit_code == 1
     assert (
-        "Please use the astro-cli to deploy. See https://docs.astronomer.io/astro/cli/overview for details."
+        "Please use the Astro CLI to deploy. See https://docs.astronomer.io/astro/cli/sql-cli for details."
         in result.stdout
     )


### PR DESCRIPTION
# Description

## What is the current behavior?

Currently, we don't have the deploy command registered in the sql-cli, but the astro-cli implements it and forwards the help command to the sql-cli hence we need it in there, too.

related: https://github.com/astronomer/astro-cli/pull/1007
closes: #1601 

## What is the new behavior?

We register a deploy command so that when called from the astro-cli it will show consistent help output.

## Does this introduce a breaking change?

No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
