### PR TITLE
Remove benchmark pod once job run is done

### DIFF
--- a/python-sdk/tests/benchmark/wait_for_completion.sh
+++ b/python-sdk/tests/benchmark/wait_for_completion.sh
@@ -10,7 +10,7 @@ while [[ $complete_status -ne 0 ]] && [[ $failed_status -ne 0 ]]; do
   complete_status=$?
 done
 
-#kubectl delete job benchmark-"${GIT_HASH}" -n benchmark
+kubectl delete job benchmark-"${GIT_HASH}" -n benchmark
 
 if [ $failed_status -eq 0 ]; then
     echo "Job failed. Please check logs."


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/1011

## What is the current behavior?
currently, a benchmark we do not delete and kept it for some debugging purpose  


## What is the new behavior?
let's delete the pod it helps in reusing cluster sometimes 

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
