### PR TITLE
Add retry and delay in cleanup operator

### DIFF
--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -18,11 +18,9 @@ Pre-requisites for load_file_example_19:
 """
 import os
 import pathlib
-import time
 from datetime import datetime, timedelta
 
 import sqlalchemy
-from airflow.decorators import task
 from airflow.models import DAG
 
 from astro import sql as aql
@@ -318,7 +316,7 @@ with dag:
     # [END load_file_example_23]
 
     # [START load_file_example_24]
-    databricks_load = aql.load_file(
+    aql.load_file(
         input_file=File("s3://astro-sdk/python_sdk/example_dags/data/sample.csv", conn_id="aws_conn"),
         output_table=Table(
             conn_id=DATABRICKS_CONN_ID,
@@ -345,10 +343,4 @@ with dag:
     )
     # [END load_file_example_25]
 
-    @task
-    def add_delay():
-        time.sleep(120)
-
-    databricks_load >> add_delay()  # skipcq: PYL-W0104
-
-    aql.cleanup()
+    aql.cleanup(retries=2, retry_delay=timedelta(seconds=120))

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -18,9 +18,11 @@ Pre-requisites for load_file_example_19:
 """
 import os
 import pathlib
+import time
 from datetime import datetime, timedelta
 
 import sqlalchemy
+from airflow.decorators import task
 from airflow.models import DAG
 
 from astro import sql as aql
@@ -316,7 +318,7 @@ with dag:
     # [END load_file_example_23]
 
     # [START load_file_example_24]
-    aql.load_file(
+    databricks_load = aql.load_file(
         input_file=File("s3://astro-sdk/python_sdk/example_dags/data/sample.csv", conn_id="aws_conn"),
         output_table=Table(
             conn_id=DATABRICKS_CONN_ID,
@@ -342,5 +344,11 @@ with dag:
         ),
     )
     # [END load_file_example_25]
+
+    @task
+    def add_delay():
+        time.sleep(120)
+
+    databricks_load >> add_delay  # skipcq: PYL-W0104
 
     aql.cleanup()

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -349,6 +349,6 @@ with dag:
     def add_delay():
         time.sleep(120)
 
-    databricks_load >> add_delay  # skipcq: PYL-W0104
+    databricks_load >> add_delay()  # skipcq: PYL-W0104
 
     aql.cleanup()


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/1574

## What is the current behavior?
The databricks load example fails with an error
```
databricks.sql.exc.ServerOperationError: org.apache.hadoop.hive.ql.metadata.HiveException: at least one column must be specified for the table
```

## What is the new behavior?
Add retry and delay in cleanup operator

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
