### PR TITLE
Fix typo in CI job

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -504,7 +504,7 @@ jobs:
       AIRFLOW__ASTRO_SDK__DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
       AZURE_WASB_CONN_STRING: ${{ secrets.AZURE_WASB_CONN_STRING }}
 
-  Run-Unit-tests-Airflow-2-2-5:
+  Run-Integration-tests-Airflow-2-2-5:
     if: >-
       github.event_name == 'push' ||
       (
@@ -659,7 +659,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     needs:
       - Run-Unit-tests-Airflow-2-5
-      - Run-Unit-tests-Airflow-2-2-5
+      - Run-Integration-tests-Airflow-2-2-5
       - Run-Integration-tests-Airflow-2-5
       - Run-load-file-Integration-Airflow-2-5
       - Run-example-dag-Integration-Airflow-2-5


### PR DESCRIPTION
# Description
## What is the current behavior?
currently, we have a job name `Run-Unit-tests-Airflow-2-2-5` which runs integration tests. I feel its a typo

## What is the new behavior?
Rename it to `Run-Integration-tests-Airflow-2-2-5 `

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
