### PR TITLE
Run unit tests for Python-3.10

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -229,7 +229,7 @@ jobs:
           key: ${{ runner.os }}-2.5-${{ hashFiles('python-sdk/pyproject.toml') }}-${{ hashFiles('python-sdk/src/astro/__init__.py') }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.5.0')" -- tests/ --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test(airflow='2.5.0')" -- tests/ --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -194,6 +194,9 @@ jobs:
       AZURE_WASB_CONN_STRING: ${{ secrets.AZURE_WASB_CONN_STRING }}
 
   Run-Unit-tests-Airflow-2-5:
+    strategy:
+      matrix:
+        version: [ '3.8', '3.9', '3.10' ]
     if: >-
       github.event_name == 'push' ||
       (
@@ -219,7 +222,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.version }}
           architecture: 'x64'
       - uses: actions/cache@v3
         with:
@@ -229,7 +232,7 @@ jobs:
           key: ${{ runner.os }}-2.5-${{ hashFiles('python-sdk/pyproject.toml') }}-${{ hashFiles('python-sdk/src/astro/__init__.py') }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test(airflow='2.5.0')" -- tests/ --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-${{ matrix.version }}(airflow='2.5.0')" -- tests/ --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -19,7 +19,7 @@ def dev(session: nox.Session) -> None:
     session.install("-e", ".[all,tests]")
 
 
-@nox.session(python=["3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 @nox.parametrize("airflow", ["2.2.5", "2.4", "2.5.0"])
 def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""


### PR DESCRIPTION
# Description
closes: https://github.com/astronomer/astro-sdk/issues/760

## What is the current behavior?
Currently, we run tests in CI for only Python-3.8


## What is the new behavior?
Run unit tests for `Python-{3.8,3.9,3.10}`

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
