### PR TITLE
Support "s3" conn type for S3Location

### DIFF
--- a/python-sdk/src/astro/files/locations/amazon/s3.py
+++ b/python-sdk/src/astro/files/locations/amazon/s3.py
@@ -13,7 +13,7 @@ class S3Location(BaseFileLocation):
     """Handler S3 object store operations"""
 
     location_type = FileLocation.S3
-    supported_conn_type = {S3Hook.conn_type, "aws"}
+    supported_conn_type = {S3Hook.conn_type, "s3", "aws"}
 
     @property
     def hook(self) -> S3Hook:


### PR DESCRIPTION
Amazon S3 conn type was removed in Airflow in favor of AWS in https://github.com/apache/airflow/commit/cf73cb79d7aba49d3934864acdd9ce1599836d0f

In SDK, we should support both. This was identified in Cloud IDE

![image](https://user-images.githubusercontent.com/8811558/213798026-bc17dbc0-50f2-47b1-b7e1-419578ef2cd5.png)

