### PR TITLE
Bump astro-runtime version 7.2.0

### DIFF
--- a/python-sdk/dev/Dockerfile
+++ b/python-sdk/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:7.1.0-base
+FROM quay.io/astronomer/astro-runtime:7.2.0-base
 
 USER root
 RUN apt-get update -y && apt-get install -y git

--- a/universal_transfer_operator/dev/Dockerfile
+++ b/universal_transfer_operator/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:7.1.0-base
+FROM quay.io/astronomer/astro-runtime:7.2.0-base
 
 USER root
 RUN apt-get update -y && apt-get install -y git


### PR DESCRIPTION
# Description
Bump astro-runtime version 7.2.0

Tested astro-sdk is pre-installed in runtime 7.2.0 image 

<img width="1006" alt="Screenshot 2023-01-23 at 12 54 18 PM" src="https://user-images.githubusercontent.com/98807258/213985802-7c363826-bbe2-4e83-8bac-5f56cee3896a.png">
