### PR TITLE
Support json output for version command

### DIFF
--- a/sql-cli/pyproject.toml
+++ b/sql-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astro-sql-cli"
-version = "0.3.1a0"
+version = "0.3.0"
 description = "Empower analysts to build workflows to transform data using SQL"
 authors = [
     "Astronomer <humans@astronomer.io>",

--- a/sql-cli/pyproject.toml
+++ b/sql-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "astro-sql-cli"
-version = "0.3.0"
+version = "0.3.1a0"
 description = "Empower analysts to build workflows to transform data using SQL"
 authors = [
     "Astronomer <humans@astronomer.io>",

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -88,8 +88,8 @@ def version(
     if as_json:
         output_dict = {"version": sql_cli.__version__}
         print(json.dumps(output_dict))
-        return
-    rprint("Astro SQL CLI", sql_cli.__version__)
+    else:
+        rprint("Astro SQL CLI", sql_cli.__version__)
 
 
 @app.command(

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -79,7 +80,15 @@ def set_debug_mode(debug: bool) -> None:
     cls=AstroCommand,
     help="Print the SQL CLI version.",
 )
-def version() -> None:
+def version(
+    as_json: bool = typer.Option(
+        False, "--json", help="If the response should be in JSON format", show_default=True
+    ),
+) -> None:
+    if as_json:
+        output_dict = {"version": sql_cli.__version__}
+        print(json.dumps(output_dict))
+        return
     rprint("Astro SQL CLI", sql_cli.__version__)
 
 

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pathlib
 from unittest import mock
@@ -117,7 +118,8 @@ def test_version():
 def test_version_json_output():
     result = runner.invoke(app, ["version", "--json"])
     assert result.exit_code == 0
-    assert f'{{"version": "{__version__}"}}' in result.stdout
+    result_json = json.loads(result.stdout)
+    assert result_json["version"] == __version__
 
 
 @pytest.mark.parametrize(

--- a/sql-cli/tests/test___main__.py
+++ b/sql-cli/tests/test___main__.py
@@ -114,6 +114,12 @@ def test_version():
     assert f"Astro SQL CLI {__version__}" in result.stdout
 
 
+def test_version_json_output():
+    result = runner.invoke(app, ["version", "--json"])
+    assert result.exit_code == 0
+    assert f'{{"version": "{__version__}"}}' in result.stdout
+
+
 @pytest.mark.parametrize(
     "key,value",
     [


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently we print the output of version typer command as rich text output. This makes it difficult to parse
and extract the version in integrations for further processing.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->

close: #1652 
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Provide a json flag to the typer command which when provided in the command
prints a json output making it easier to parse for integraitons

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
