### PR TITLE
Change the table to temp table in example_snowflake_partial_table_with_append DAG

### DIFF
--- a/python-sdk/example_dags/example_snowflake_partial_table_with_append.py
+++ b/python-sdk/example_dags/example_snowflake_partial_table_with_append.py
@@ -9,7 +9,6 @@ This example DAG creates the reporting table & truncates it by the end of the ex
 """
 
 import os
-import time
 from datetime import datetime
 
 import pandas as pd
@@ -72,7 +71,7 @@ def create_table(table: Table):
 
 @dag(start_date=datetime(2021, 12, 1), schedule_interval="@daily", catchup=False)
 def example_snowflake_partial_table_with_append():
-    homes_reporting = Table(name="homes_reporting_data", temp=True, conn_id=SNOWFLAKE_CONN_ID)
+    homes_reporting = Table(conn_id=SNOWFLAKE_CONN_ID)
     create_results_table = create_table(table=homes_reporting, conn_id=SNOWFLAKE_CONN_ID)
     # [END howto_run_raw_sql_snowflake_1]
 
@@ -100,18 +99,16 @@ def example_snowflake_partial_table_with_append():
     )
 
     # Define task dependencies
-    extracted_data = extract_data(
+    extracted_data_table = extract_data(
         homes1=homes_data1,
         homes2=homes_data2,
-        output_table=Table(name="combined_homes_data_" + str(int(time.time())), temp=True),
+        output_table=Table(),
     )
 
-    transformed_data = transform_data(
-        df=extracted_data, output_table=Table(name="homes_data_long_" + str(int(time.time())), temp=True)
-    )
+    transformed_data_table = transform_data(df=extracted_data_table, output_table=Table())
 
     filtered_data = filter_data(
-        homes_long=transformed_data,
+        homes_long=transformed_data_table,
         output_table=Table(),
     )
 


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, the `SANDBOX.ASTROFLOW_CI.homes_reporting_data` on snowflake doesn't have write access. Snowflake UI logs and profiles don't show more details. Added the screenshot below:

<img width="1060" alt="Screenshot 2023-01-23 at 2 59 54 PM" src="https://user-images.githubusercontent.com/8670962/214006160-133360f4-b4fa-45b6-b7f0-c68697f24f17.png">

Currently, the table used in the example DAG is that it is named a temporary table. And it doesn't have correct access for this table as per logs.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1654 1654


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Change the tables to `temp` table in example DAG.


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
