### PR TITLE
Use common sql 1.2.0 for airflow 2.2.5

### DIFF
--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -45,6 +45,7 @@ def test(session: nox.Session, airflow) -> None:
         # install apache-airflow-providers-sftp==4.0.0 since it is the compatible version
         # to run sftp example dag to load file with airflow 2.2.5
         session.install("apache-airflow-providers-sftp==4.0.0")
+        session.install("apache-airflow-providers-common-sql==1.2.0")
         # install smart-open 6.3.0 since it has FTP implementation
         session.install("smart-open>=6.3.0")
     else:

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -45,7 +45,7 @@ def test(session: nox.Session, airflow) -> None:
         # install apache-airflow-providers-sftp==4.0.0 since it is the compatible version
         # to run sftp example dag to load file with airflow 2.2.5
         session.install("apache-airflow-providers-sftp==4.0.0")
-        session.install("apache-airflow-providers-sqlite==3.1.0")
+        session.install("apache-airflow-providers-sqlite>=3.1.0")
         session.install("apache-airflow-providers-common-sql==1.2.0")
         # install smart-open 6.3.0 since it has FTP implementation
         session.install("smart-open>=6.3.0")

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -45,6 +45,7 @@ def test(session: nox.Session, airflow) -> None:
         # install apache-airflow-providers-sftp==4.0.0 since it is the compatible version
         # to run sftp example dag to load file with airflow 2.2.5
         session.install("apache-airflow-providers-sftp==4.0.0")
+        session.install("apache-airflow-providers-sqlite==3.1.0")
         session.install("apache-airflow-providers-common-sql==1.2.0")
         # install smart-open 6.3.0 since it has FTP implementation
         session.install("smart-open>=6.3.0")

--- a/python-sdk/src/astro/sql/operators/data_validations/check_table.py
+++ b/python-sdk/src/astro/sql/operators/data_validations/check_table.py
@@ -58,7 +58,12 @@ class SQLCheckOperator(SQLTableCheckOperator):
         db = create_database(self.dataset.conn_id)
         self.table = db.get_table_qualified_name(self.dataset)
         self.conn_id = self.dataset.conn_id
-        self.sql = f"SELECT check_name, check_result FROM ({self._generate_sql_query()}) AS check_table"
+        # apache-airflow-providers-common-sql == 1.2.0 which is compatible with airflow 2.2.5 implements the self.sql
+        # differently compared to apache-airflow-providers-common-sql == 1.3.3
+        try:
+            self.sql = f"SELECT check_name, check_result FROM ({self._generate_sql_query()}) AS check_table"
+        except AttributeError:
+            self.sql = f"SELECT * FROM {self.table};"
         super().execute(context)
 
     def get_db_hook(self) -> DbApiHook:


### PR DESCRIPTION
# Description
## What is the current behavior?
Right now this is not working for airflow 2.2.5


## What is the new behavior?
We need to select a different version of common-sql==1.2.0 provider

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
