### PR TITLE
Display workflow name as argument instead of flag in help

### DIFF
--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -308,7 +308,7 @@ def init(
     help="""Deploy workflows to Astro Cloud.""",
 )
 def deploy(
-    workflow_name: str = typer.Option(  # skipcq: PYL-W0613
+    workflow_name: str = typer.Argument(  # skipcq: PYL-W0613
         default=None,
         show_default=False,
         help="name of the workflow directory within workflows directory.",

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -309,7 +309,7 @@ def init(
 )
 def deploy(
     workflow_name: str = typer.Argument(  # skipcq: PYL-W0613
-        default=...,
+        default=None,
         show_default=False,
         help="name of the workflow directory within workflows directory.",
     ),

--- a/sql-cli/sql_cli/__main__.py
+++ b/sql-cli/sql_cli/__main__.py
@@ -309,7 +309,7 @@ def init(
 )
 def deploy(
     workflow_name: str = typer.Argument(  # skipcq: PYL-W0613
-        default=None,
+        default=...,
         show_default=False,
         help="name of the workflow directory within workflows directory.",
     ),


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, workflow name is used as a flag in the Astro CLI deploy command.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
related: #1651 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
As per the original specification, workflow name should be an argument and not a flag.
Same implementaiton changes are being done in the Astro CLI deploy cobra command, but
since Astro CLI relies on flow's help, we need to change the type of it here.

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
