### PR TITLE
Fix run_raw_sql() return type when results_format=list/pandas_dataframe

### DIFF
--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -79,7 +79,11 @@ class RawSQLOperator(BaseSQLDecoratedOperator):
             if 0 <= self.response_limit < len(response):
                 raise IllegalLoadToDatabaseException()  # pragma: no cover
             if self.response_size >= 0:
-                return response[: self.response_size]
+                resp = response[: self.response_size]
+                # We do the following is slicing pandas dataframe creates a pd.Dataframe object
+                # which isn't serializable
+                # TODO: We could add a __getitem__ to PandasDataframe object
+                return PandasDataframe.from_pandas_df(resp) if isinstance(resp, pd.DataFrame) else resp
             else:
                 return response
 

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -154,10 +154,17 @@ def test_handlers():
     Test the handler return desired results
     """
 
+    class val:
+        def __init__(self, val):
+            self.val = [val]
+
+        def values(self) -> list:
+            return self.val
+
     class MockResultProxy:
         @staticmethod
         def fetchall():
-            return [1, 2, 3]
+            return [val(1), val(2), val(3)]
 
         @staticmethod
         def keys():
@@ -165,7 +172,7 @@ def test_handlers():
 
     result = MockResultProxy()
     processed_result = aql.RawSQLOperator.results_as_list(result)
-    assert processed_result == [1, 2, 3]
+    assert processed_result == [[1], [2], [3]]
 
     processed_result = aql.RawSQLOperator.results_as_pandas_dataframe(result)
     assert isinstance(processed_result, pandas.DataFrame)

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -154,17 +154,17 @@ def test_handlers():
     Test the handler return desired results
     """
 
-    class val:
+    class Val:
         def __init__(self, val):
-            self.val = [val]
+            self.value = [val]
 
         def values(self) -> list:
-            return self.val
+            return self.value
 
     class MockResultProxy:
         @staticmethod
         def fetchall():
-            return [val(1), val(2), val(3)]
+            return [Val(1), Val(2), Val(3)]
 
         @staticmethod
         def keys():

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -167,6 +167,7 @@ def test_run_raw_sql__results_format__pandas_dataframe(sample_dag, database_tabl
     @task
     def assert_num_rows(result):
         assert isinstance(result, pandas.DataFrame)
+        assert result.equals(pandas.read_csv(DATA_FILEPATH))
         assert result.shape == (1, 2)
 
     with sample_dag:

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -170,7 +170,7 @@ def test_run_raw_sql__results_format__pandas_dataframe(sample_dag, database_tabl
         assert result.shape == (1, 2)
 
     with sample_dag:
-        results = raw_sql_query(input_table=test_table, response_size=1)
+        results = raw_sql_query(input_table=test_table)
         assert_num_rows(results)
 
     test_utils.run_dag(sample_dag)

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -185,10 +185,9 @@ def test_run_raw_sql__results_format__pandas_dataframe(sample_dag, database_tabl
         {"database": Database.SNOWFLAKE, "file": File(path=str(DATA_FILEPATH))},
         {"database": Database.POSTGRES, "file": File(path=str(DATA_FILEPATH))},
         {"database": Database.BIGQUERY, "file": File(path=str(DATA_FILEPATH))},
-        {"database": Database.MSSQL, "file": File(path=str(DATA_FILEPATH))},
     ],
     indirect=True,
-    ids=["sqlite", "snowflake", "postgres", "bigquery", "mssql"],
+    ids=["sqlite", "snowflake", "postgres", "bigquery"],
 )
 def test_run_raw_sql__results_format__list(sample_dag, database_table_fixture):
     """run_raw_sql() command should return `pandas.DataFrame` when `results_format='list' is passed"""

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -190,7 +190,7 @@ def test_run_raw_sql__results_format__pandas_dataframe(sample_dag, database_tabl
     ids=["sqlite", "snowflake", "postgres", "bigquery"],
 )
 def test_run_raw_sql__results_format__list(sample_dag, database_table_fixture):
-    """run_raw_sql() command should return `pandas.DataFrame` when `results_format='list' is passed"""
+    """run_raw_sql() command should return `List` when `results_format='list' is passed"""
     _, test_table = database_table_fixture
 
     @aql.run_raw_sql(results_format="list")

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -179,9 +179,15 @@ def test_run_raw_sql__results_format__pandas_dataframe(sample_dag, database_tabl
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "database_table_fixture",
-    [{"database": Database.SQLITE, "file": File(path=str(DATA_FILEPATH))}],
+    [
+        {"database": Database.SQLITE, "file": File(path=str(DATA_FILEPATH))},
+        {"database": Database.SNOWFLAKE, "file": File(path=str(DATA_FILEPATH))},
+        {"database": Database.POSTGRES, "file": File(path=str(DATA_FILEPATH))},
+        {"database": Database.BIGQUERY, "file": File(path=str(DATA_FILEPATH))},
+        {"database": Database.MSSQL, "file": File(path=str(DATA_FILEPATH))},
+    ],
     indirect=True,
-    ids=["sqlite"],
+    ids=["sqlite", "snowflake", "postgres", "bigquery", "mssql"],
 )
 def test_run_raw_sql__results_format__list(sample_dag, database_table_fixture):
     """run_raw_sql() command should return `pandas.DataFrame` when `results_format='list' is passed"""
@@ -194,6 +200,9 @@ def test_run_raw_sql__results_format__list(sample_dag, database_table_fixture):
     @task
     def assert_num_rows(result):
         assert isinstance(result, list)
+        assert result[0] == ["First"]
+        assert result[1] == ["Second"]
+        assert result[2] == ["Third with unicode पांचाल"]
         assert len(result) == 3
 
     with sample_dag:

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -168,7 +168,7 @@ def test_run_raw_sql__results_format__pandas_dataframe(sample_dag, database_tabl
     def assert_num_rows(result):
         assert isinstance(result, pandas.DataFrame)
         assert result.equals(pandas.read_csv(DATA_FILEPATH))
-        assert result.shape == (1, 2)
+        assert result.shape == (3, 2)
 
     with sample_dag:
         results = raw_sql_query(input_table=test_table)


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, the right data type was not returned by run_raw_sql() 

## What is the new behavior?
1. Added checks for pandas dataframe
2. Returned list from `results_as_list()` function 

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
