### PR TITLE
Add fix and testcase for run_raw_sql

### DIFF
--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -94,7 +94,7 @@ connections:
     password: $DATABRICKS_TOKEN
     extra:
       http_path: /sql/1.0/warehouses/cf414a2206dfb397
-  - conn_id: wasb_default_conn
+  - conn_id: wasb_default
     conn_type: wasb
     description: null
     extra:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: python-check-mock-methods
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.4.1
+    rev: v1.4.2
     hooks:
       - id: forbid-crlf
       - id: remove-crlf
@@ -71,7 +71,7 @@ repos:
         additional_dependencies: [black>=22.10.0]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.230'
+    rev: 'v0.0.237'
     hooks:
       - id: ruff
         args:

--- a/python-sdk/dev/Dockerfile
+++ b/python-sdk/dev/Dockerfile
@@ -6,7 +6,11 @@ RUN apt-get install -y --no-install-recommends \
         build-essential \
         libsasl2-2 \
         libsasl2-dev \
-        libsasl2-modules
+        libsasl2-modules \
+        freetds-dev \
+        libssl-dev \
+        libkrb5-dev
+
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 
 COPY ../pyproject.toml  ${AIRFLOW_HOME}/astro_sdk/

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -333,7 +333,7 @@ with dag:
 
     # [START load_file_example_25]
     aql.load_file(
-        input_file=File("wasb://astro-sdk/sample.csv", conn_id="wasb_default_conn"),
+        input_file=File("wasb://astro-sdk/sample.csv"),
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
             metadata=Metadata(

--- a/python-sdk/src/astro/databases/databricks/delta.py
+++ b/python-sdk/src/astro/databases/databricks/delta.py
@@ -232,7 +232,7 @@ class DeltaDatabase(BaseDatabase):
             )
             return True
         except ServerOperationError as s:
-            if "Table or view not found" in s.message:
+            if "TABLE_OR_VIEW_NOT_FOUND" in s.message:
                 return False
             else:
                 raise s

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -356,23 +356,8 @@ class SnowflakeDatabase(BaseDatabase):
             file.location.location_type
         )
         if storage_integration is not None:
-            auth = f"storage_integration = {storage_integration};"
-        else:
-            if file.location.location_type == FileLocation.GS:
-                raise DatabaseCustomError(
-                    "In order to create an stage for GCS, `storage_integration` is required."
-                )
-            elif file.location.location_type == FileLocation.S3:
-                aws = file.location.hook.get_credentials()
-                if aws.access_key and aws.secret_key:
-                    auth = f"credentials=(aws_key_id='{aws.access_key}' aws_secret_key='{aws.secret_key}');"
-                else:
-                    raise DatabaseCustomError(
-                        "In order to create an stage for S3, one of the following is required: "
-                        "* `storage_integration`"
-                        "* AWS_KEY_ID and SECRET_KEY_ID"
-                    )
-        return auth
+            return f"storage_integration = {storage_integration};"
+        return file.location.get_snowflake_stage_auth_sub_statement()
 
     def create_stage(
         self,

--- a/python-sdk/src/astro/files/locations/amazon/s3.py
+++ b/python-sdk/src/astro/files/locations/amazon/s3.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse, urlunparse
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
 from astro.constants import FileLocation
+from astro.exceptions import DatabaseCustomError
 from astro.files.locations.base import BaseFileLocation
 
 
@@ -85,3 +86,15 @@ class S3Location(BaseFileLocation):
             ] = "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"
             cred_dict["fs.s3a.session.token"] = credentials.token
         return cred_dict
+
+    def get_snowflake_stage_auth_sub_statement(self) -> str:
+        aws = self.hook.get_credentials()
+        if aws.access_key and aws.secret_key:
+            auth = f"credentials=(aws_key_id='{aws.access_key}' aws_secret_key='{aws.secret_key}');"
+        else:
+            raise DatabaseCustomError(
+                "In order to create an stage for S3, one of the following is required: "
+                "* `storage_integration`"
+                "* AWS_KEY_ID and SECRET_KEY_ID"
+            )
+        return auth

--- a/python-sdk/src/astro/files/locations/azure/wasb.py
+++ b/python-sdk/src/astro/files/locations/azure/wasb.py
@@ -68,9 +68,7 @@ class WASBLocation(BaseFileLocation):
         if object_name.startswith("/"):
             object_name = object_name[1:]
         return int(
-            self.hook._get_blob_client(  # skipcq: PYL-W0212
-                container_name=container_name, blob_name=object_name
-            )
+            self.hook.blob_service_client.get_blob_client(container=container_name, blob=object_name)
             .get_blob_properties()
             .size
         )

--- a/python-sdk/src/astro/files/locations/base.py
+++ b/python-sdk/src/astro/files/locations/base.py
@@ -10,6 +10,7 @@ import smart_open
 from airflow.hooks.base import BaseHook
 
 from astro.constants import FileLocation
+from astro.exceptions import DatabaseCustomError
 from astro.options import LoadOptions
 
 
@@ -188,3 +189,6 @@ class BaseFileLocation(ABC):
         :param df: pandas dataframe
         """
         return smart_open.open(self.smartopen_uri, mode="wb", transport_params=self.transport_params)
+
+    def get_snowflake_stage_auth_sub_statement(self) -> str:  # skipcq: PYL-R0201
+        raise DatabaseCustomError("In order to create a stage, `storage_integration` is required.")

--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -31,7 +31,7 @@ def test_create_stage_google_fails_due_to_no_storage_integration():
     database = SnowflakeDatabase(conn_id="fake-conn")
     with pytest.raises(ValueError) as exc_info:
         database.create_stage(file=File("gs://some-bucket/some-file.csv"))
-    expected_msg = "In order to create an stage for GCS, `storage_integration` is required."
+    expected_msg = "In order to create a stage, `storage_integration` is required."
     assert exc_info.match(expected_msg)
 
 

--- a/python-sdk/tests/sql/operators/test_base_decorator.py
+++ b/python-sdk/tests/sql/operators/test_base_decorator.py
@@ -1,9 +1,15 @@
 from unittest import mock
 
+import pandas as pd
 import pytest
 
 from astro.sql import RawSQLOperator
-from astro.sql.operators.base_decorator import BaseSQLDecoratedOperator
+from astro.sql.operators.base_decorator import (
+    BaseSQLDecoratedOperator,
+    load_op_arg_dataframes_into_sql,
+    load_op_kwarg_dataframes_into_sql,
+)
+from astro.table import BaseTable, Table
 
 
 def test_base_sql_decorated_operator_template_fields_with_parameters():
@@ -22,3 +28,35 @@ def test_get_source_code_handle_exception(mock_getsource, exception):
     RawSQLOperator(task_id="test", sql="select * from 1", python_callable=lambda: 1).get_source_code(
         py_callable=None
     )
+
+
+def test_load_op_arg_dataframes_into_sql():
+    df_1 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    df_2 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    op_args = (df_1, df_2, Table(conn_id="sqlite_default"), "str")
+    results = load_op_arg_dataframes_into_sql(
+        conn_id="sqlite_default", op_args=op_args, output_table=Table(conn_id="sqlite_default")
+    )
+
+    assert isinstance(results[0], BaseTable)
+    assert isinstance(results[1], BaseTable)
+    assert results[0].name != results[1].name
+
+    assert isinstance(results[2], BaseTable)
+    assert isinstance(results[3], str)
+
+
+def test_load_op_kwarg_dataframes_into_sql():
+    df_1 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    df_2 = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    op_kwargs = {"df_1": df_1, "df_2": df_2, "table": Table(conn_id="sqlite_default"), "some_str": "str"}
+    results = load_op_kwarg_dataframes_into_sql(
+        conn_id="sqlite_default", op_kwargs=op_kwargs, output_table=Table(conn_id="sqlite_default")
+    )
+
+    assert isinstance(results["df_1"], BaseTable)
+    assert isinstance(results["df_2"], BaseTable)
+    assert results["df_1"].name != results["df_2"].name
+
+    assert isinstance(results["table"], BaseTable)
+    assert isinstance(results["some_str"], str)

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -154,10 +154,17 @@ def test_handlers():
     Test the handler return desired results
     """
 
+    class Val:
+        def __init__(self, val):
+            self.value = [val]
+
+        def values(self) -> list:
+            return self.value
+
     class MockResultProxy:
         @staticmethod
         def fetchall():
-            return [1, 2, 3]
+            return [Val(1), Val(2), Val(3)]
 
         @staticmethod
         def keys():
@@ -165,7 +172,7 @@ def test_handlers():
 
     result = MockResultProxy()
     processed_result = aql.RawSQLOperator.results_as_list(result)
-    assert processed_result == [1, 2, 3]
+    assert processed_result == [[1], [2], [3]]
 
     processed_result = aql.RawSQLOperator.results_as_pandas_dataframe(result)
     assert isinstance(processed_result, pandas.DataFrame)

--- a/python-sdk/tests_integration/conftest.py
+++ b/python-sdk/tests_integration/conftest.py
@@ -150,7 +150,7 @@ def multiple_tables_fixture(request, database_table_fixture):
 
 
 @pytest.fixture
-def remote_files_fixture(request):  # noqa: C901
+def remote_files_fixture(request):
     """
     Return a list of remote object filenames.
     By default, this fixture also creates objects using sample.<filetype>, unless
@@ -182,80 +182,111 @@ def remote_files_fixture(request):  # noqa: C901
     object_path_list = []
     object_prefix_list = []
     unique_value = uuid.uuid4()
+    get_bucket_name(provider)
+    get_hook(provider)
     for item_count in range(file_count):
         object_prefix = f"test/{unique_value}{item_count}.{file_extension}"
-        bucket_name, hook, object_path = _upload_or_delete_remote_file(
-            file_create, object_prefix, provider, source_path
-        )
+        object_path = _upload_or_delete_remote_file(file_create, object_prefix, provider, source_path)
         object_path_list.append(object_path)
         object_prefix_list.append(object_prefix)
 
     yield object_path_list
 
+    delete_all_blobs(provider=provider, object_prefix_list=object_prefix_list)
+
+
+def create_blob(provider, source_path, bucket_name, object_prefix):
+    hook = get_hook(provider)
     if provider == "google":
-        for object_prefix in object_prefix_list:
-            # if an object doesn't exist, GCSHook.delete fails:
-            hook.exists(bucket_name, object_prefix) and hook.delete(  # skipcq: PYL-W0106
-                bucket_name, object_prefix
-            )
+        hook.upload(bucket_name, object_prefix, source_path)
     elif provider == "amazon":
-        for object_prefix in object_prefix_list:
-            hook.delete_objects(bucket_name, object_prefix)
-
+        hook.load_file(source_path, object_prefix, bucket_name)
     elif provider == "azure":
-        for object_prefix in object_prefix_list:
-            hook.check_for_blob(bucket_name, object_prefix) and hook.delete_blobs(  # skipcq: PYL-W0106
-                bucket_name, object_prefix
-            )
+        hook.load_file(source_path, bucket_name, object_prefix)
 
 
-def _upload_or_delete_remote_file(file_create, object_prefix, provider, source_path):  # noqa: C901
+def delete_all_blobs(provider: str, object_prefix_list: list):
+    hook = get_hook(provider)
+    bucket_name = get_bucket_name(provider)
+    delete_blob_provider = {
+        "google": delete_google_blob,
+        "amazon": delete_amazon_blob,
+        "azure": delete_azure_blob,
+        "local": delete_local_blob,
+    }
+    delete_blob_fun = delete_blob_provider[provider]
+    for object_prefix in object_prefix_list:
+        delete_blob_fun(hook, bucket_name, object_prefix)
+
+
+def delete_google_blob(hook, bucket_name, object_prefix):
+    hook.exists(bucket_name, object_prefix) and hook.delete(bucket_name, object_prefix)  # skipcq: PYL-W0106
+
+
+def delete_amazon_blob(hook, bucket_name, object_prefix):
+    hook.delete_objects(bucket_name, object_prefix)
+
+
+def delete_azure_blob(hook, bucket_name, object_prefix):
+    hook.check_for_blob(bucket_name, object_prefix) and hook.delete_file(  # skipcq: PYL-W0106
+        bucket_name, object_prefix
+    )
+
+
+def delete_local_blob(hook, bucket_name, object_prefix):
+    pass
+
+
+def get_bucket_name(provider):
+    bucket_provider = {
+        "google": os.getenv("GOOGLE_BUCKET", "dag-authoring"),
+        "amazon": os.getenv("AWS_BUCKET", "tmp9"),
+        "azure": os.getenv("AZURE_BUCKET", "astro-sdk"),
+        "local": None,
+    }
+    return bucket_provider[provider]
+
+
+def get_object_path(provider: str, object_prefix: str, source_path) -> str:
+    bucket_name = get_bucket_name(provider)
+    path_provider = {
+        "google": f"gs://{bucket_name}/{object_prefix}",
+        "amazon": f"s3://{bucket_name}/{object_prefix}",
+        "azure": f"wasb://{bucket_name}/{object_prefix}",
+        "local": str(source_path),
+    }
+    return path_provider[provider]
+
+
+def get_hook(provider):
+    from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+    from airflow.providers.google.cloud.hooks.gcs import GCSHook
+    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+
+    hook_provider = {
+        "google": GCSHook(),
+        "amazon": S3Hook(),
+        "azure": WasbHook(),
+        "local": None,
+    }
+    return hook_provider[provider]
+
+
+def _upload_or_delete_remote_file(file_create, object_prefix, provider, source_path):
     """
     Upload a local file to remote bucket if file_create is True.
     And deletes a file if it already exists and file_create is False.
     """
-    if provider == "google":
-        from airflow.providers.google.cloud.hooks.gcs import GCSHook
+    bucket_name = get_bucket_name(provider=provider)
+    object_path = get_object_path(provider=provider, object_prefix=object_prefix, source_path=source_path)
+    if file_create:
+        create_blob(
+            provider=provider, bucket_name=bucket_name, object_prefix=object_prefix, source_path=source_path
+        )
+    else:
+        delete_all_blobs(provider, [object_prefix])
 
-        bucket_name = os.getenv("GOOGLE_BUCKET", "dag-authoring")
-        object_path = f"gs://{bucket_name}/{object_prefix}"
-        hook = GCSHook()
-        if file_create:
-            hook.upload(bucket_name, object_prefix, source_path)
-        else:
-            # if an object doesn't exist, GCSHook.delete fails:
-            hook.exists(bucket_name, object_prefix) and hook.delete(  # skipcq: PYL-W0106
-                bucket_name, object_prefix
-            )
-    elif provider == "amazon":
-        from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-
-        bucket_name = os.getenv("AWS_BUCKET", "tmp9")
-        object_path = f"s3://{bucket_name}/{object_prefix}"
-        hook = S3Hook()
-        if file_create:
-            hook.load_file(source_path, object_prefix, bucket_name)
-        else:
-            hook.delete_objects(bucket_name, object_prefix)
-
-    elif provider == "azure":
-        from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
-
-        bucket_name = os.getenv("AZURE_BUCKET", "astro-sdk")
-        object_path = f"wasb://{bucket_name}/{object_prefix}"
-        hook = WasbHook()
-        if file_create:
-            hook.load_file(source_path, bucket_name, object_prefix)
-        else:
-            hook.check_for_blob(bucket_name, object_prefix) and hook.delete_file(  # skipcq: PYL-W0106
-                bucket_name, object_prefix
-            )
-
-    elif provider == "local":
-        bucket_name = None
-        hook = None
-        object_path = str(source_path)
-    return bucket_name, hook, object_path
+    return object_path
 
 
 def method_map_fixture(method, base_path, classes, get):

--- a/python-sdk/tests_integration/databases/databricks_tests/test_delta.py
+++ b/python-sdk/tests_integration/databases/databricks_tests/test_delta.py
@@ -149,10 +149,9 @@ def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
     database, non_existent_table = database_table_fixture
     from databricks.sql.exc import ServerOperationError
 
-    with pytest.raises(ServerOperationError) as exc_info:
+    with pytest.raises(ServerOperationError):
         database.export_table_to_pandas_dataframe(non_existent_table)
-    error_message = exc_info.value.args[0]
-    assert error_message.startswith("Table or view not found:")
+    assert not database.table_exists(non_existent_table)
 
 
 # TODO: uncomment these tests as we add functions

--- a/python-sdk/tests_integration/files/locations/test_wasb.py
+++ b/python-sdk/tests_integration/files/locations/test_wasb.py
@@ -9,13 +9,13 @@ from astro.files.locations.azure.wasb import WASBLocation
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "remote_files_fixture",
-    [{"provider": "azure", "file_count": 2, "conn_id": "wasb_default_conn"}],
+    [{"provider": "azure", "file_count": 2}],
     indirect=True,
     ids=["azure_wasb"],
 )
 def test_remote_object_store_connection(remote_files_fixture):
     """integration test to confirm if location is able to access blob storage"""
-    location = create_file_location("wasb://astro-sdk/", conn_id="wasb_default_conn")
+    location = create_file_location("wasb://astro-sdk/")
     expected_blobs_list = [Path(item).name for item in remote_files_fixture]
     actual_blobs_list = location.hook.get_blobs_list(container_name="astro-sdk", prefix="test/")
     actual_blobs_list = [Path(item).name for item in actual_blobs_list]
@@ -31,5 +31,5 @@ def test_remote_object_store_connection(remote_files_fixture):
 )
 def test_size(remote_files_fixture):
     """Test get_size() of for Blob Storage file."""
-    location = WASBLocation(path=remote_files_fixture[0], conn_id="wasb_default_conn")
+    location = WASBLocation(path=remote_files_fixture[0])
     assert location.size == 65

--- a/python-sdk/tests_integration/sql/operators/test_export_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_export_file.py
@@ -75,10 +75,7 @@ def test_export_to_file_dbs_to_remote_file(sample_dag, database_table_fixture, r
     _, test_table = database_table_fixture
     file_uri = remote_files_fixture[0]
 
-    if file_uri.startswith("wasb"):
-        file_ = File(file_uri, conn_id="wasb_default_conn")
-    else:
-        file_ = File(file_uri)
+    file_ = File(file_uri)
 
     assert not file_.exists()
 

--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -132,10 +132,7 @@ def test_aql_load_remote_file_to_dbs(sample_dag, database_table_fixture, remote_
     db, test_table = database_table_fixture
     file_uri = remote_files_fixture[0]
 
-    if file_uri.startswith("wasb"):
-        file_ = File(file_uri, conn_id="wasb_default_conn")
-    else:
-        file_ = File(file_uri)
+    file_ = File(file_uri)
 
     with sample_dag:
         load_file(

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -1,12 +1,14 @@
 import logging
 import pathlib
 
+import pandas as pd
 import pytest
 from airflow.decorators import task
 
 from astro import sql as aql
 from astro.constants import Database
 from astro.files import File
+from astro.table import BaseTable
 
 from ..operators import utils as test_utils
 
@@ -144,5 +146,40 @@ def test_run_raw_sql_with_limit_for_mssql(sample_dag, database_table_fixture):
             handler=lambda cursor: cursor.fetchall(),
         )
         assert_num_rows(results)
+
+    test_utils.run_dag(sample_dag)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [{"database": Database.SQLITE, "file": File(path=str(DATA_FILEPATH))}],
+    indirect=True,
+    ids=["sqlite"],
+)
+def test_run_raw_sql_handle_multiple_tables(sample_dag, database_table_fixture):
+    """
+    Handle the case when we are passing multiple dataframe to run_raw_sql() operator
+    and all the dataframes are converted to different tables.
+    """
+    _, test_table = database_table_fixture
+
+    @aql.run_raw_sql(handler=lambda x: pd.DataFrame(x.fetchall(), columns=x.keys()))
+    def raw_sql_query_1(input_table: BaseTable):
+        return "SELECT * from {{input_table}}"
+
+    @aql.run_raw_sql(handler=lambda x: pd.DataFrame(x.fetchall(), columns=x.keys()))
+    def raw_sql_query_2(input_table: BaseTable):
+        return "SELECT * from {{input_table}}"
+
+    @aql.run_raw_sql(handler=lambda x: pd.DataFrame(x.fetchall(), columns=x.keys()), conn_id="sqlite_default")
+    def raw_sql_query_3(table_1: BaseTable, table_2: BaseTable):
+        assert table_1.name != table_2.name
+        return "SELECT 1 + 1"
+
+    with sample_dag:
+        results_1 = raw_sql_query_1(input_table=test_table)
+        results_2 = raw_sql_query_2(input_table=test_table)
+        _ = raw_sql_query_3(table_1=results_1, table_2=results_2)
 
     test_utils.run_dag(sample_dag)

--- a/python-sdk/tests_integration/sql/operators/test_raw_sql.py
+++ b/python-sdk/tests_integration/sql/operators/test_raw_sql.py
@@ -238,3 +238,31 @@ def test_run_raw_sql__results_format__list(sample_dag, database_table_fixture):
         results = raw_sql_query(input_table=test_table)
         assert_num_rows(results)
     test_utils.run_dag(sample_dag)
+
+
+def test_run_raw_sql_handle_multiple_tables(sample_dag, database_table_fixture):
+    """
+    Handle the case when we are passing multiple dataframe to run_raw_sql() operator
+    and all the dataframes are converted to different tables.
+    """
+    _, test_table = database_table_fixture
+
+    @aql.run_raw_sql(handler=lambda x: pd.DataFrame(x.fetchall(), columns=x.keys()))
+    def raw_sql_query_1(input_table: BaseTable):
+        return "SELECT * from {{input_table}}"
+
+    @aql.run_raw_sql(handler=lambda x: pd.DataFrame(x.fetchall(), columns=x.keys()))
+    def raw_sql_query_2(input_table: BaseTable):
+        return "SELECT * from {{input_table}}"
+
+    @aql.run_raw_sql(handler=lambda x: pd.DataFrame(x.fetchall(), columns=x.keys()), conn_id="sqlite_default")
+    def raw_sql_query_3(table_1: BaseTable, table_2: BaseTable):
+        assert table_1.name != table_2.name
+        return "SELECT 1 + 1"
+
+    with sample_dag:
+        results_1 = raw_sql_query_1(input_table=test_table)
+        results_2 = raw_sql_query_2(input_table=test_table)
+        _ = raw_sql_query_3(table_1=results_1, table_2=results_2)
+    test_utils.run_dag(sample_dag)
+

--- a/python-sdk/tests_integration/test_example_dags.py
+++ b/python-sdk/tests_integration/test_example_dags.py
@@ -68,6 +68,8 @@ def get_dag_bag() -> DagBag:
     print(".airflowignore contents: ")
     print(airflow_ignore_file.read_text())
     dag_bag = DagBag(example_dags_dir, include_examples=False)
+    assert dag_bag.dags
+    assert not dag_bag.import_errors
     return dag_bag
 
 
@@ -90,8 +92,3 @@ dag_bag = get_dag_bag()
 def test_example_dag(session, dag_id: str):
     dag = dag_bag.get_dag(dag_id)
     wrapper_run_dag(dag)
-
-
-def test_example_dags_loaded_with_no_errors():
-    assert dag_bag.dags
-    assert not dag_bag.import_errors


### PR DESCRIPTION
# Description
## What is the current behavior?
When we pass multiple dataframes to run_raw_sql() the expected behavior is that the dataframes should be loaded to different temp tables. Currently, that's not happening, and the second dataframe is loaded to the same temp table.

closes: #1687


## What is the new behavior?
Every dataframe is loaded to a different temp table.

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
