### PR TITLE
Add validation mode support in COPY INTO in snowflake

### DIFF
--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -424,6 +424,13 @@ If you want to provide the list of load options(specific to database or file loc
 
     - :py:obj:`SnowflakeLoadOptions <astro.options.SnowflakeLoadOptions>` - Load options to load file to snowflake using native approach.
 
+        .. note::
+
+            ``file_options`` default to
+                ```
+                file_options={"TYPE": "filetype", "TRIM_SPACE": True},
+                ```
+
     .. literalinclude:: ../../../../example_dags/example_load_file.py
        :language: python
        :start-after: [START load_file_example_23]

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -78,6 +78,7 @@ def example_amazon_s3_snowflake_transform():
         output_table=input_table_1,
         load_options=[
             SnowflakeLoadOptions(
+                file_options={"TYPE": "CSV", "TRIM_SPACE": True},
                 copy_options={"ON_ERROR": "CONTINUE"},
             )
         ],
@@ -87,6 +88,7 @@ def example_amazon_s3_snowflake_transform():
         output_table=input_table_2,
         load_options=[
             SnowflakeLoadOptions(
+                file_options={"TYPE": "CSV", "TRIM_SPACE": True},
                 copy_options={"ON_ERROR": "CONTINUE"},
             )
         ],

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -9,6 +9,7 @@ from airflow.decorators import dag
 
 from astro import sql as aql
 from astro.files import File
+from astro.options import SnowflakeLoadOptions
 from astro.table import Metadata, Table
 
 
@@ -75,10 +76,22 @@ def example_amazon_s3_snowflake_transform():
     temp_table_1 = aql.load_file(
         input_file=File(path=f"{s3_bucket}/ADOPTION_CENTER_1_unquoted.csv"),
         output_table=input_table_1,
+        load_options=[
+            SnowflakeLoadOptions(
+                file_options={"SKIP_HEADER": 1, "SKIP_BLANK_LINES": True},
+                copy_options={"ON_ERROR": "CONTINUE"},
+            )
+        ],
     )
     temp_table_2 = aql.load_file(
         input_file=File(path=f"{s3_bucket}/ADOPTION_CENTER_2_unquoted.csv"),
         output_table=input_table_2,
+        load_options=[
+            SnowflakeLoadOptions(
+                file_options={"SKIP_HEADER": 1, "SKIP_BLANK_LINES": True},
+                copy_options={"ON_ERROR": "CONTINUE"},
+            )
+        ],
     )
 
     combined_data = combine_data(

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -78,7 +78,6 @@ def example_amazon_s3_snowflake_transform():
         output_table=input_table_1,
         load_options=[
             SnowflakeLoadOptions(
-                file_options={"SKIP_HEADER": 1, "SKIP_BLANK_LINES": True},
                 copy_options={"ON_ERROR": "CONTINUE"},
             )
         ],
@@ -88,7 +87,6 @@ def example_amazon_s3_snowflake_transform():
         output_table=input_table_2,
         load_options=[
             SnowflakeLoadOptions(
-                file_options={"SKIP_HEADER": 1, "SKIP_BLANK_LINES": True},
                 copy_options={"ON_ERROR": "CONTINUE"},
             )
         ],

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -393,7 +393,7 @@ class SnowflakeDatabase(BaseDatabase):
         file_options = [f"{k}={v}" for k, v in self.load_options.file_options.items()]
         file_options.extend([f"TYPE={fileformat}", "TRIM_SPACE=TRUE"])
         file_options_str = ", ".join(file_options)
-        copy_options_str = ", ".join(copy_options)  # type:ignore
+        copy_options_str = ", ".join(copy_options)
         sql_statement = "".join(
             [
                 f"CREATE OR REPLACE STAGE {stage.qualified_name} URL='{stage.url}' ",

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -392,7 +392,7 @@ class SnowflakeDatabase(BaseDatabase):
         stage.set_url_from_file(file)
 
         fileformat = ASTRO_SDK_TO_SNOWFLAKE_FILE_FORMAT_MAP[file.type.name]
-        copy_options = [COPY_OPTIONS.get(file.type.name)] if COPY_OPTIONS.get(file.type.name, None) else []
+        copy_options = [COPY_OPTIONS.get(file.type.name)] if COPY_OPTIONS.get(file.type.name) else []
         copy_options.extend([f"{k}={v}" for k, v in self.load_options.copy_options.items()])
         file_options = [f"{k}={v}" for k, v in self.load_options.file_options.items()]
         file_options.extend([f"TYPE={fileformat}", "TRIM_SPACE=TRUE"])

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -651,7 +651,7 @@ class SnowflakeDatabase(BaseDatabase):
         )
         try:
             self.hook.run(sql_statement, handler=lambda cur: cur.fetchall())
-        except self.NATIVE_LOAD_EXCEPTIONS as load_exception:
+        except ProgrammingError as load_exception:
             self.drop_stage(stage)
             raise load_exception
 

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -51,10 +51,6 @@ ASTRO_SDK_TO_SNOWFLAKE_FILE_FORMAT_MAP = {
     FileType.PARQUET: "PARQUET",
 }
 
-COPY_OPTIONS = {
-    FileType.NDJSON: "MATCH_BY_COLUMN_NAME=CASE_INSENSITIVE",
-    FileType.PARQUET: "MATCH_BY_COLUMN_NAME=CASE_INSENSITIVE",
-}
 
 DEFAULT_STORAGE_INTEGRATION = {
     FileLocation.S3: settings.SNOWFLAKE_STORAGE_INTEGRATION_AMAZON,
@@ -392,7 +388,7 @@ class SnowflakeDatabase(BaseDatabase):
         stage.set_url_from_file(file)
 
         fileformat = ASTRO_SDK_TO_SNOWFLAKE_FILE_FORMAT_MAP[file.type.name]
-        copy_options = [COPY_OPTIONS.get(file.type.name)] if COPY_OPTIONS.get(file.type.name) else []
+        copy_options = []
         copy_options.extend([f"{k}={v}" for k, v in self.load_options.copy_options.items()])
         file_options = [f"{k}={v}" for k, v in self.load_options.file_options.items()]
         file_options.extend([f"TYPE={fileformat}", "TRIM_SPACE=TRUE"])

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -392,12 +392,12 @@ class SnowflakeDatabase(BaseDatabase):
         stage.set_url_from_file(file)
 
         fileformat = ASTRO_SDK_TO_SNOWFLAKE_FILE_FORMAT_MAP[file.type.name]
-        copy_options = [COPY_OPTIONS.get(file.type.name, "")]
+        copy_options = [COPY_OPTIONS.get(file.type.name)] if COPY_OPTIONS.get(file.type.name, None) else []
         copy_options.extend([f"{k}={v}" for k, v in self.load_options.copy_options.items()])
         file_options = [f"{k}={v}" for k, v in self.load_options.file_options.items()]
         file_options.extend([f"TYPE={fileformat}", "TRIM_SPACE=TRUE"])
         file_options_str = ", ".join(file_options)
-        copy_options_str = ", ".join(copy_options)
+        copy_options_str = ", ".join(copy_options)  # type:ignore
         sql_statement = "".join(
             [
                 f"CREATE OR REPLACE STAGE {stage.qualified_name} URL='{stage.url}' ",

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -58,10 +58,22 @@ class SnowflakeLoadOptions(LoadOptions):
     :param copy_options: Specify one or more of the copy option as key-value pair. Read more at:
         https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
     :param storage_integration: Specify the previously created Snowflake storage integration
-    :param validation_mode: Specify the supported validation mode; RETURN_n_ROWS | RETURN_ERRORS | RETURN_ALL_ERRORS
-        This instructs the COPY command to validate the data files instead of loading them into the specified table;
-        i.e. the COPY command tests the files for errors but does not load them. Read more at:
-        https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#optional-parameters
+    :param validation_mode: Defaults to `validation_mode=None`. This instructs the COPY command to validate the data
+        files instead of loading them into the specified table; i.e. the COPY command tests the files for errors but
+        does not load them. Supported validation mode; `RETURN_n_ROWS` | `RETURN_ERRORS` | `RETURN_ALL_ERRORS`
+
+    .. note::
+        Specify the supported validation mode;
+
+        - `RETURN_n_ROWS`: validates the specified n rows if no errors are encountered; otherwise, fails at the first
+          error encountered in the rows.
+        - `RETURN_ERRORS`: returns all errors (parsing, conversion, etc.) across all files specified in the COPY
+          statement.
+        - `RETURN_ALL_ERRORS`: returns all errors across all files specified in the `COPY` statement, including files
+          with errors that were partially loaded during an earlier load because the `ON_ERROR` copy option was set
+          to `CONTINUE` during the load.
+
+        Read more at: https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#optional-parameters
     """
 
     file_options: dict = attr.field(init=True, factory=dict)

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -59,12 +59,14 @@ class SnowflakeLoadOptions(LoadOptions):
         https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
     :param storage_integration: Specify the previously created Snowflake storage integration
     :param validation_mode: Specify the supported validation mode; RETURN_n_ROWS | RETURN_ERRORS | RETURN_ALL_ERRORS
-        Read more at: https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#optional-parameters
+        This instructs the COPY command to validate the data files instead of loading them into the specified table;
+        i.e. the COPY command tests the files for errors but does not load them. Read more at:
+        https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#optional-parameters
     """
 
     file_options: dict = attr.field(init=True, factory=dict)
     copy_options: dict = attr.field(init=True, factory=dict)
-    validation_mode: str = attr.field(default="RETURN_ALL_ERRORS")
+    validation_mode: Optional[str] = attr.field(default="RETURN_ERRORS")
     storage_integration: str = attr.field(default=None)
 
     def empty(self):

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -57,10 +57,14 @@ class SnowflakeLoadOptions(LoadOptions):
         https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#format-type-options-formattypeoptions
     :param copy_options: Specify one or more of the copy option as key-value pair. Read more at:
         https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
+    :param storage_integration: Specify the previously created Snowflake storage integration
+    :param validation_mode: Specify the supported validation mode; RETURN_n_ROWS | RETURN_ERRORS | RETURN_ALL_ERRORS
+        Read more at: https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#optional-parameters
     """
 
     file_options: dict = attr.field(init=True, factory=dict)
     copy_options: dict = attr.field(init=True, factory=dict)
+    validation_mode: str = attr.field(default="RETURN_ALL_ERRORS")
     storage_integration: str = attr.field(default=None)
 
     def empty(self):

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -66,7 +66,7 @@ class SnowflakeLoadOptions(LoadOptions):
 
     file_options: dict = attr.field(init=True, factory=dict)
     copy_options: dict = attr.field(init=True, factory=dict)
-    validation_mode: Optional[str] = attr.field(default="RETURN_ERRORS")
+    validation_mode: Optional[str] = attr.field(default=None)
     storage_integration: str = attr.field(default=None)
 
     def empty(self):

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -66,7 +66,7 @@ class SnowflakeLoadOptions(LoadOptions):
 
     file_options: dict = attr.field(init=True, factory=dict)
     copy_options: dict = attr.field(init=True, factory=dict)
-    validation_mode: Optional[str] = attr.field(default=None)
+    validation_mode: str = attr.field(default=None)
     storage_integration: str = attr.field(default=None)
 
     def empty(self):

--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -94,6 +94,10 @@ def test_load_file_to_table_natively_for_fallback_raises_exception_if_not_enable
         metadata=Metadata(database="SNOWFLAKE_DATABASE", schema="SNOWFLAKE_SCHEMA"),
     )
     database = SnowflakeDatabase()
+    database.load_options = SnowflakeLoadOptions(
+        copy_options={"ON_ERROR": "CONTINUE"},
+        file_options={"TYPE": "CSV", "TRIM_SPACE": True},
+    )
     with pytest.raises(DatabaseCustomError):
         database.load_file_to_table_natively_with_fallback(
             source_file=File(str(pathlib.Path(CWD.parent, "data/sample.csv"))),

--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -124,7 +124,7 @@ def test_snowflake_load_options():
             storage_integration="foo",
         )
     assert "FILE_FORMAT=(foo=bar, TYPE=CSV, TRIM_SPACE=TRUE)" in database.run_sql.call_args[0][0]
-    assert "COPY_OPTIONS=(ON_ERROR=CONTINUE)" in database.run_sql.call_args[0][0]
+    assert "COPY_OPTIONS=()" in database.run_sql.call_args[0][0]
 
 
 def test_snowflake_load_options_default():
@@ -143,7 +143,7 @@ def test_snowflake_load_options_default():
             storage_integration="foo",
         )
     assert "FILE_FORMAT=(TYPE=CSV, TRIM_SPACE=TRUE)" in database.run_sql.call_args[0][0]
-    assert "COPY_OPTIONS=(ON_ERROR=CONTINUE)" in database.run_sql.call_args[0][0]
+    assert "COPY_OPTIONS=()" in database.run_sql.call_args[0][0]
 
 
 def test_snowflake_load_options_wrong_options():

--- a/python-sdk/tests_integration/databases/test_snowflake.py
+++ b/python-sdk/tests_integration/databases/test_snowflake.py
@@ -10,9 +10,14 @@ from sqlalchemy.exc import ProgrammingError
 
 from astro.constants import Database, FileLocation, FileType
 from astro.databases import create_database
-from astro.databases.snowflake import SnowflakeDatabase, SnowflakeStage
+from astro.databases.snowflake import (
+    ProgrammingError as SnowflakeProgrammingError,
+    SnowflakeDatabase,
+    SnowflakeStage,
+)
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File
+from astro.options import SnowflakeLoadOptions
 from astro.settings import SCHEMA, SNOWFLAKE_STORAGE_INTEGRATION_AMAZON, SNOWFLAKE_STORAGE_INTEGRATION_GOOGLE
 from astro.table import Metadata, Table
 from astro.utils.load import copy_remote_file_to_local
@@ -213,10 +218,12 @@ def test_load_file_to_table(database_table_fixture):
 def test_load_file_from_cloud_to_table(database_table_fixture):
     """Test loading on files to snowflake database"""
     database, target_table = database_table_fixture
+    database.load_options = SnowflakeLoadOptions(
+        copy_options={"ON_ERROR": "CONTINUE"}, file_options={"TYPE": "CSV", "TRIM_SPACE": True}
+    )
     database.load_file_to_table(
         input_file=File("s3://astro-sdk/data/", conn_id="aws_conn", filetype=FileType.CSV),
         output_table=target_table,
-        use_native_support=False,
     )
 
     df = database.hook.get_pandas_df(f"SELECT * FROM {database.get_table_qualified_name(target_table)}")
@@ -478,8 +485,14 @@ def test_load_file_to_table_natively(remote_files_fixture, database_table_fixtur
     """Load a file to a Snowflake table using the native optimisation."""
     filepath = remote_files_fixture[0]
     database, target_table = database_table_fixture
-    database.load_file_to_table(File(filepath), target_table, {}, use_native_support=False)
-
+    database.load_options = SnowflakeLoadOptions(
+        copy_options={"ON_ERROR": "CONTINUE"}, file_options={"TYPE": "CSV", "TRIM_SPACE": True}
+    )
+    database.load_file_to_table(
+        File(filepath),
+        target_table,
+        use_native_support=True,
+    )
     df = database.hook.get_pandas_df(f"SELECT * FROM {target_table.name}")
     assert len(df) == 3
     expected = pd.DataFrame(
@@ -517,6 +530,159 @@ def test_export_table_to_file_file_already_exists_raises_exception(
         database.export_table_to_file(source_table, File(str(filepath)))
     err_msg = exception_info.value.args[0]
     assert err_msg.endswith(f"The file {filepath} already exists.")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {"database": Database.SNOWFLAKE},
+    ],
+    indirect=True,
+    ids=["snowflake"],
+)
+@pytest.mark.parametrize(
+    "remote_files_fixture",
+    [
+        {"provider": "amazon", "filetype": FileType.CSV},
+    ],
+    indirect=True,
+    ids=["amazon_csv"],
+)
+def test_load_file_to_table_natively_with_validation_mode(remote_files_fixture, database_table_fixture):
+    """Load a file to a Snowflake table using the native optimisation with validation mode."""
+    filepath = remote_files_fixture[0]
+    database, target_table = database_table_fixture
+    database.load_options = SnowflakeLoadOptions(
+        copy_options={"ON_ERROR": "CONTINUE"},
+        file_options={"TYPE": "CSV", "TRIM_SPACE": True, "SKIP_HEADER": 1, "SKIP_BLANK_LINES": True},
+        validation_mode="RETURN_ROWS",
+    )
+    database.load_file_to_table(
+        File(filepath),
+        target_table,
+        use_native_support=True,
+    )
+    df = database.hook.get_pandas_df(f"SELECT * FROM {target_table.name}")
+    assert len(df) == 3
+    expected = pd.DataFrame(
+        [
+            {"id": 1, "name": "First"},
+            {"id": 2, "name": "Second"},
+            {"id": 3, "name": "Third with unicode पांचाल"},
+        ]
+    )
+    test_utils.assert_dataframes_are_equal(df, expected)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {"database": Database.SNOWFLAKE},
+    ],
+    indirect=True,
+    ids=["snowflake"],
+)
+@pytest.mark.parametrize(
+    "remote_files_fixture",
+    [
+        {"provider": "amazon", "filetype": FileType.CSV},
+    ],
+    indirect=True,
+    ids=["amazon_csv"],
+)
+def test_load_file_to_table_natively_with_validation_mode_for_error(
+    remote_files_fixture, database_table_fixture
+):
+    """
+    Load a file to a Snowflake table using the native path with validation mode for error as header is not skipped.
+    """
+    filepath = remote_files_fixture[0]
+    database, target_table = database_table_fixture
+    database.load_options = SnowflakeLoadOptions(
+        copy_options={"ON_ERROR": "CONTINUE"},
+        file_options={"TYPE": "CSV", "TRIM_SPACE": True},
+        validation_mode="RETURN_ROWS",
+    )
+    with pytest.raises(SnowflakeProgrammingError) as err:
+        database.load_file_to_table(
+            File(filepath),
+            target_table,
+            use_native_support=True,
+        )
+    assert "Numeric value 'id' is not recognized" in str(err.value)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {"database": Database.SNOWFLAKE},
+    ],
+    indirect=True,
+    ids=["snowflake"],
+)
+@pytest.mark.parametrize(
+    "remote_files_fixture",
+    [
+        {"provider": "amazon", "filetype": FileType.CSV},
+    ],
+    indirect=True,
+    ids=["amazon_csv"],
+)
+def test_load_file_to_table_natively_with_error_on_continue(remote_files_fixture, database_table_fixture):
+    """Load a file to a Snowflake table using the native path when ON_ERROR=CONTINUE is not passed."""
+    filepath = remote_files_fixture[0]
+    database, target_table = database_table_fixture
+    database.load_options = SnowflakeLoadOptions(
+        file_options={"TYPE": "CSV", "TRIM_SPACE": True},
+    )
+    with pytest.raises(SnowflakeProgrammingError) as err:
+        database.load_file_to_table(
+            File(filepath),
+            target_table,
+            use_native_support=True,
+        )
+    assert "use other values such as 'SKIP_FILE' or 'CONTINUE' for the ON_ERROR option" in str(err.value)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {"database": Database.SNOWFLAKE},
+    ],
+    indirect=True,
+    ids=["snowflake"],
+)
+@pytest.mark.parametrize(
+    "remote_files_fixture",
+    [
+        {"provider": "amazon", "filetype": FileType.CSV},
+    ],
+    indirect=True,
+    ids=["amazon_csv"],
+)
+def test_load_file_to_table_natively_with_validation_mode_for_returning_all_error(
+    remote_files_fixture, database_table_fixture
+):
+    """Load a file to a Snowflake table using the native path with validation mode for returning all errors"""
+    filepath = remote_files_fixture[0]
+    database, target_table = database_table_fixture
+    database.load_options = SnowflakeLoadOptions(
+        validation_mode="RETURN_ALL_ERRORS",
+    )
+    with pytest.raises(SnowflakeProgrammingError) as err:
+        database.load_file_to_table(
+            File(filepath),
+            target_table,
+            use_native_support=True,
+        )
+    assert (
+        "If you would like to continue loading when an error is encountered, use "
+        "other values such as 'SKIP_FILE' or 'CONTINUE' for the ON_ERROR option" in str(err.value)
+    )
 
 
 @pytest.mark.integration

--- a/python-sdk/tests_integration/databases/test_snowflake.py
+++ b/python-sdk/tests_integration/databases/test_snowflake.py
@@ -214,9 +214,9 @@ def test_load_file_from_cloud_to_table(database_table_fixture):
     """Test loading on files to snowflake database"""
     database, target_table = database_table_fixture
     database.load_file_to_table(
-        File("s3://astro-sdk/data/", conn_id="aws_conn", filetype=FileType.CSV),
-        target_table,
-        {},
+        input_file=File("s3://astro-sdk/data/", conn_id="aws_conn", filetype=FileType.CSV),
+        output_table=target_table,
+        use_native_support=False,
     )
 
     df = database.hook.get_pandas_df(f"SELECT * FROM {database.get_table_qualified_name(target_table)}")

--- a/python-sdk/tests_integration/databases/test_snowflake.py
+++ b/python-sdk/tests_integration/databases/test_snowflake.py
@@ -478,7 +478,7 @@ def test_load_file_to_table_natively(remote_files_fixture, database_table_fixtur
     """Load a file to a Snowflake table using the native optimisation."""
     filepath = remote_files_fixture[0]
     database, target_table = database_table_fixture
-    database.load_file_to_table(File(filepath), target_table, {}, use_native_support=True)
+    database.load_file_to_table(File(filepath), target_table, {}, use_native_support=False)
 
     df = database.hook.get_pandas_df(f"SELECT * FROM {target_table.name}")
     assert len(df) == 3


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Currently, the load_file operator can hide errors when doing native Snowflake transfers. We should raise an exception and display the errors to the users, not hide this problem.

As it stands, a user may be loading 10k rows into a table, end up with five rows, and not realise there is an issue.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #581


## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- Add validation mode as part of the `COPY INTO` command. Specify the supported validation mode; `RETURN_n_ROWS` or `RETURN_ERRORS` or  `RETURN_ALL_ERRORS`. This instructs the COPY command to validate the data files instead of loading them into the specified table; i.e. the COPY command tests the files for errors but does not load them. Read more at:
        https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#optional-parameters
- Remove the `ON_ERROR=Continue` hardcoded for CSV file types
- Add an option for the user to pass `ON_ERROR=Continue` as part of `copy_options`

Example:
```
aql.load_file(
        input_file=File("s3://astro-sdk/python_sdk/example_dags/data/sample.csv", conn_id="aws_conn"),
        output_table=Table(
            conn_id=SNOWFLAKE_CONN_ID,
        ),
        load_options=[
            SnowflakeLoadOptions(
                file_options={"SKIP_HEADER": 1, "SKIP_BLANK_LINES": True},
                copy_options={"ON_ERROR": "CONTINUE"},
                validation_mode="RETURN_ALL_ERRORS",
            )
        ],
    )
```

## Does this introduce a breaking change?
Yes

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
