### PR TITLE
Add `pymssql` dependent libraries to dev `Dockerfile`

### DIFF
--- a/python-sdk/dev/Dockerfile
+++ b/python-sdk/dev/Dockerfile
@@ -8,10 +8,8 @@ RUN apt-get install -y --no-install-recommends \
         libsasl2-dev \
         libsasl2-modules \
         freetds-dev \
-        libssl-dev
-
-RUN apt-get update \
- && apt-get install libkrb5-dev -y
+        libssl-dev \
+        libkrb5-dev
 
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 

--- a/python-sdk/dev/Dockerfile
+++ b/python-sdk/dev/Dockerfile
@@ -6,7 +6,13 @@ RUN apt-get install -y --no-install-recommends \
         build-essential \
         libsasl2-2 \
         libsasl2-dev \
-        libsasl2-modules
+        libsasl2-modules \
+        freetds-dev \
+        libssl-dev
+
+RUN apt-get update \
+ && apt-get install libkrb5-dev -y
+
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 
 COPY ../pyproject.toml  ${AIRFLOW_HOME}/astro_sdk/


### PR DESCRIPTION
# Description
## What is the current behavior?
After including the SQL server support for astro-sdk in #1538 , we are unable to spin up the dev docker container using astro-runtime 7.2, with the below error.This error is due to the libraries required for `pymssql` successful installation on the container missing in the `dev/Dockerfile` 


```
#0 41.91   Building wheel for pymssql (pyproject.toml): started
#0 43.11   Building wheel for pymssql (pyproject.toml): finished with status 'error'
#0 43.11   error: subprocess-exited-with-error
#0 43.11   
#0 43.11   × Building wheel for pymssql (pyproject.toml) did not run successfully.
#0 43.11   │ exit code: 1
#0 43.11   ╰─> [25 lines of output]
#0 43.11       setup.py: platform.system() => Linux
#0 43.11       setup.py: platform.architecture() => ('64bit', '')
#0 43.11       setup.py: platform.libc_ver() => ('glibc', '2.31')
#0 43.11       setup.py: include_dirs => []
#0 43.11       setup.py: library_dirs => []
#0 43.11       running bdist_wheel
#0 43.11       running build
#0 43.11       running build_py
#0 43.11       creating build
#0 43.11       creating build/lib.linux-aarch64-3.9
#0 43.11       creating build/lib.linux-aarch64-3.9/pymssql
#0 43.11       copying src/pymssql/__init__.py -> build/lib.linux-aarch64-3.9/pymssql
#0 43.11       running build_ext
#0 43.11       cythoning src/pymssql/_mssql.pyx to src/pymssql/_mssql.c
#0 43.11       cythoning src/pymssql/_pymssql.pyx to src/pymssql/_pymssql.c
#0 43.11       building 'pymssql._mssql' extension
#0 43.11       creating build/temp.linux-aarch64-3.9
#0 43.11       creating build/temp.linux-aarch64-3.9/src
#0 43.11       creating build/temp.linux-aarch64-3.9/src/pymssql
#0 43.11       gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include/python3.9 -c src/pymssql/_mssql.c -o build/temp.linux-aarch64-3.9/src/pymssql/_mssql.o -DMSDBLIB
#0 43.11       src/pymssql/_mssql.c:747:10: fatal error: sqlfront.h: No such file or directory
#0 43.11         747 | #include "sqlfront.h"
#0 43.11             |          ^~~~~~~~~~~~
#0 43.11       compilation terminated.
#0 43.11       error: command '/usr/bin/gcc' failed with exit code 1
#0 43.11       [end of output]

```

<!-- Please describe the current behavior that you are modifying. -->


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Include the missing libraries for successful `pymssql` installation in the `dev/Dockerfile` 


## Does this introduce a breaking change?
No
