### PR TITLE
Azure test cleanup

### DIFF
--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -94,7 +94,7 @@ connections:
     password: $DATABRICKS_TOKEN
     extra:
       http_path: /sql/1.0/warehouses/cf414a2206dfb397
-  - conn_id: wasb_default_conn
+  - conn_id: wasb_default
     conn_type: wasb
     description: null
     extra:

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -333,7 +333,7 @@ with dag:
 
     # [START load_file_example_25]
     aql.load_file(
-        input_file=File("wasb://astro-sdk/sample.csv", conn_id="wasb_default_conn"),
+        input_file=File("wasb://astro-sdk/sample.csv"),
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
             metadata=Metadata(

--- a/python-sdk/tests_integration/files/locations/test_wasb.py
+++ b/python-sdk/tests_integration/files/locations/test_wasb.py
@@ -9,13 +9,13 @@ from astro.files.locations.azure.wasb import WASBLocation
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "remote_files_fixture",
-    [{"provider": "azure", "file_count": 2, "conn_id": "wasb_default_conn"}],
+    [{"provider": "azure", "file_count": 2}],
     indirect=True,
     ids=["azure_wasb"],
 )
 def test_remote_object_store_connection(remote_files_fixture):
     """integration test to confirm if location is able to access blob storage"""
-    location = create_file_location("wasb://astro-sdk/", conn_id="wasb_default_conn")
+    location = create_file_location("wasb://astro-sdk/")
     expected_blobs_list = [Path(item).name for item in remote_files_fixture]
     actual_blobs_list = location.hook.get_blobs_list(container_name="astro-sdk", prefix="test/")
     actual_blobs_list = [Path(item).name for item in actual_blobs_list]
@@ -31,5 +31,5 @@ def test_remote_object_store_connection(remote_files_fixture):
 )
 def test_size(remote_files_fixture):
     """Test get_size() of for Blob Storage file."""
-    location = WASBLocation(path=remote_files_fixture[0], conn_id="wasb_default_conn")
+    location = WASBLocation(path=remote_files_fixture[0])
     assert location.size == 65

--- a/python-sdk/tests_integration/sql/operators/test_export_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_export_file.py
@@ -75,10 +75,7 @@ def test_export_to_file_dbs_to_remote_file(sample_dag, database_table_fixture, r
     _, test_table = database_table_fixture
     file_uri = remote_files_fixture[0]
 
-    if file_uri.startswith("wasb"):
-        file_ = File(file_uri, conn_id="wasb_default_conn")
-    else:
-        file_ = File(file_uri)
+    file_ = File(file_uri)
 
     assert not file_.exists()
 

--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -132,10 +132,7 @@ def test_aql_load_remote_file_to_dbs(sample_dag, database_table_fixture, remote_
     db, test_table = database_table_fixture
     file_uri = remote_files_fixture[0]
 
-    if file_uri.startswith("wasb"):
-        file_ = File(file_uri, conn_id="wasb_default_conn")
-    else:
-        file_ = File(file_uri)
+    file_ = File(file_uri)
 
     with sample_dag:
         load_file(


### PR DESCRIPTION
# Description
## What is the current behavior?
Right now we are not using airflow's default connection for `wasb_default` leading to explicitly checking and passing of conn_id.

related: #1446 


## What is the new behavior?
Have a way to override conn_id in airflow's db with one specified in `test-connection.yaml`. With this, we can pass the required connection string needed to auth with azure.

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
