### PR TITLE
Fix databricks broken tests

### DIFF
--- a/python-sdk/src/astro/databases/databricks/delta.py
+++ b/python-sdk/src/astro/databases/databricks/delta.py
@@ -232,7 +232,7 @@ class DeltaDatabase(BaseDatabase):
             )
             return True
         except ServerOperationError as s:
-            if "Table or view not found" in s.message:
+            if "TABLE_OR_VIEW_NOT_FOUND" in s.message:
                 return False
             else:
                 raise s

--- a/python-sdk/tests_integration/databases/databricks_tests/test_delta.py
+++ b/python-sdk/tests_integration/databases/databricks_tests/test_delta.py
@@ -149,10 +149,9 @@ def test_export_table_to_pandas_dataframe_non_existent_table_raises_exception(
     database, non_existent_table = database_table_fixture
     from databricks.sql.exc import ServerOperationError
 
-    with pytest.raises(ServerOperationError) as exc_info:
+    with pytest.raises(ServerOperationError):
         database.export_table_to_pandas_dataframe(non_existent_table)
-    error_message = exc_info.value.args[0]
-    assert error_message.startswith("Table or view not found:")
+    assert not database.table_exists(non_existent_table)
 
 
 # TODO: uncomment these tests as we add functions


### PR DESCRIPTION
Databricks changed their error message when a table does not exist.
This leads our main branch to fail.