### PR TITLE
Add minor version and default match keys to compatibility matrix

### DIFF
--- a/sql-cli/config/astro-cli.json
+++ b/sql-cli/config/astro-cli.json
@@ -4,6 +4,10 @@
       "preRelease": false,
       "sqlCliVersion": ">0.2.2"
     },
+    "1.10.0": {
+      "preRelease": false,
+      "sqlCliVersion": ">0.2.2"
+    },
     "1.8.0": {
       "preRelease": false,
       "sqlCliVersion": ">0.2, <0.3"

--- a/sql-cli/config/astro-cli.json
+++ b/sql-cli/config/astro-cli.json
@@ -1,6 +1,6 @@
 {
   "astroCliCompatibility": {
-    "1.10.0": {
+    "1.10": {
       "preRelease": false,
       "sqlCliVersion": ">0.2.2"
     },
@@ -11,6 +11,10 @@
     "1.9.0": {
       "preRelease": false,
       "sqlCliVersion": ">0.2, <0.3"
+    },
+    "default": {
+      "preRelease": false,
+      "sqlCliVersion": ">0.2.2"
     }
   },
   "baseDockerImage": "quay.io/astronomer/astro-runtime:6.0.4-base",


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Currently, Astro CLI version does not allow minor version match keys and need an exact match of
the format <MAJOR_VERSION>.<MINOR_VERSION>.<PATCH_VERSION>

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
related: #1673 

## What is the new behavior?
The plan is that Astro CLI integration should allow version match as per the below steps:
1. Try to find an exact match in the compatibility matrix e.g. 1.10.0
2. If no exact match is found, trim the version to remove the patch version and match until the minor version e.g. 1.10
3. If still does not match, match a key named 'default' which is set to install the latest SQL CLI version.

For the same reason, we're adding the required keys in the compatibility matrix with this PR.

## Does this introduce a breaking change?
Yes

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
