### PR TITLE
Add missing copy_options and file_options for snowflake native transfers

### DIFF
--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -1390,7 +1390,11 @@ def test_load_file_snowflake_azure_native_path(sample_dag, database_table_fixtur
             input_file=File(path),
             output_table=test_table,
             load_options=[
-                SnowflakeLoadOptions(storage_integration="AZURE_INT_PYTHON_SDK"),
+                SnowflakeLoadOptions(
+                    storage_integration="AZURE_INT_PYTHON_SDK",
+                    copy_options={"ON_ERROR": "CONTINUE"},
+                    file_options={"TYPE": "CSV", "TRIM_SPACE": True},
+                ),
                 WASBLocationLoadOptions(storage_account="astrosdk"),
             ],
             enable_native_fallback=False,


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
This PR missed the native transfers arguments for snowflake to azure transfers in main

<!--Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1708


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add missing copy_options and file_options for snowflake native transfers for azure tests


## Does this introduce a breaking change?
No

### Checklist
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
