### PR TITLE
Move load_options out from the File object

### DIFF
--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -45,7 +45,7 @@ class File(LoggingMixin, Dataset):
 
     @property
     def load_options(self):
-        return self._load_options
+        return getattr(self, "_load_options", [])
 
     @load_options.setter
     def load_options(self, value):

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -267,16 +267,15 @@ def resolve_file_path_pattern(
     location = create_file_location(path_pattern, conn_id)
     files = []
     for path in location.paths:
-        if path.endswith("/"):
-            continue
-        file = File(
-            path=path,
-            conn_id=conn_id,
-            filetype=filetype,
-            normalize_config=normalize_config,
-        )
-        file.load_options = load_options
-        files.append(file)
+        if not path.endswith("/"):
+            file = File(
+                path=path,
+                conn_id=conn_id,
+                filetype=filetype,
+                normalize_config=normalize_config,
+            )
+            file.load_options = load_options
+            files.append(file)
     if len(files) == 0:
         raise FileNotFoundError(f"File(s) not found for path/pattern '{path_pattern}'")
 

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -45,10 +45,18 @@ class File(LoggingMixin, Dataset):
 
     @property
     def load_options(self):
+        """
+        Getter of all the load_options. load_options is a container with for the custom option passed by user for a
+         third-party integrations like pandas, azure etc.
+        """
         return getattr(self, "_load_options", [])
 
     @load_options.setter
-    def load_options(self, value):
+    def load_options(self, value: LoadOptionsList):
+        """
+        Setter of all the load_options. load_options is a container with for the custom option passed by user for a
+         third-party integrations like pandas, azure etc.
+        """
         self._load_options = value
 
     @property

--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -57,7 +57,7 @@ class File(LoggingMixin, Dataset):
 
     @property
     def load_options_list(self):
-        return LoadOptionsList(self._load_options)
+        return LoadOptionsList(self.load_options)
 
     @property
     def type(self) -> FileType:  # noqa: A003

--- a/python-sdk/tests/files/test_file.py
+++ b/python-sdk/tests/files/test_file.py
@@ -248,11 +248,11 @@ def test_file_object_picks_load_options(file_type, file_location):
     location_path, location_expected_class = file_location.values()
     file = File(
         path=location_path + f".{type_name}",
-        load_options=[
-            PandasLoadOptions(delimiter="$"),
-            SnowflakeLoadOptions(copy_options={}),
-            WASBLocationLoadOptions(storage_account="some_account"),
-        ],
     )
+    file.load_options = [
+        PandasLoadOptions(delimiter="$"),
+        SnowflakeLoadOptions(copy_options={}),
+        WASBLocationLoadOptions(storage_account="some_account"),
+    ]
     assert type(file.type.load_options) is type_expected_class
     assert file.location.load_options is location_expected_class

--- a/python-sdk/tests/files/type/test_base.py
+++ b/python-sdk/tests/files/type/test_base.py
@@ -11,7 +11,7 @@ def test_repr():
     file = File(path="astro", conn_id="local", filetype=FileType.CSV)
     assert file.__repr__() == (
         "File(path='astro', conn_id='local', filetype=<FileType.CSV: 'csv'>, "
-        "normalize_config=None, is_dataframe=False, is_bytes=False, load_options=None, "
+        "normalize_config=None, is_dataframe=False, is_bytes=False, "
         "uri='astro+file://local@/astro?filetype=csv', extra={})"
     )
 


### PR DESCRIPTION
# Description
## What is the current behavior?
load_options exposed to the user in File location/type added in the following PR - https://github.com/astronomer/astro-sdk/pull/1540. Since it's a derived property and not something the user should set.

Concerns
load_options shouldn't be exposed to the end users in the File class.
load_options is specific to load_file() and should not be part of File/Databases.

closes: https://github.com/astronomer/astro-sdk/issues/1719


## What is the new behavior?
We added a getter/setter property on the File class such that the load_option interface is not exposed to the end user.

## Does this introduce a breaking change?
Yes

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
