### PR TITLE
Add support of openlineage for mssql

### DIFF
--- a/python-sdk/src/astro/databases/mssql.py
+++ b/python-sdk/src/astro/databases/mssql.py
@@ -408,7 +408,7 @@ class MssqlDatabase(BaseDatabase):
         """
         Returns the open lineage dataset namespace as per
         https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
-        Example: postgresql://localhost:5432
+        Example: mysql://localhost:5432
         """
         conn = self.hook.get_connection(self.conn_id)
         return f"{self.sql_type}://{conn.host}:{conn.port}"

--- a/python-sdk/src/astro/databases/mssql.py
+++ b/python-sdk/src/astro/databases/mssql.py
@@ -408,7 +408,7 @@ class MssqlDatabase(BaseDatabase):
         """
         Returns the open lineage dataset namespace as per
         https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
-        Example: mysql://localhost:5432
+        Example: mssql://localhost:3306
         """
         conn = self.hook.get_connection(self.conn_id)
         return f"{self.sql_type}://{conn.host}:{conn.port}"

--- a/python-sdk/src/astro/databases/mssql.py
+++ b/python-sdk/src/astro/databases/mssql.py
@@ -392,6 +392,34 @@ class MssqlDatabase(BaseDatabase):
         }
         return statement, params
 
+    def openlineage_dataset_name(self, table: BaseTable) -> str:
+        """
+        Returns the open lineage dataset name as per
+        https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
+        Example: schema_name.table_name
+        """
+        database = self.hook.get_connection(self.conn_id).schema
+        schema = "dbo"
+        if table.metadata and table.metadata.schema:
+            schema = table.metadata.schema
+        return f"{database}.{schema}.{table.name}"
+
+    def openlineage_dataset_namespace(self) -> str:
+        """
+        Returns the open lineage dataset namespace as per
+        https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
+        Example: postgresql://localhost:5432
+        """
+        conn = self.hook.get_connection(self.conn_id)
+        return f"{self.sql_type}://{conn.host}:{conn.port}"
+
+    def openlineage_dataset_uri(self, table: BaseTable) -> str:
+        """
+        Returns the open lineage dataset uri as per
+        https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
+        """
+        return f"{self.openlineage_dataset_namespace()}/{self.openlineage_dataset_name(table=table)}"
+
 
 def wrap_identifier(inp: str) -> str:
     return f"{inp}"

--- a/python-sdk/src/astro/databases/mssql.py
+++ b/python-sdk/src/astro/databases/mssql.py
@@ -396,7 +396,7 @@ class MssqlDatabase(BaseDatabase):
         """
         Returns the open lineage dataset name as per
         https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md
-        Example: schema_name.table_name
+        Example: database.schema.table.name
         """
         database = self.hook.get_connection(self.conn_id).schema
         schema = "dbo"

--- a/python-sdk/tests_integration/sql/test_table.py
+++ b/python-sdk/tests_integration/sql/test_table.py
@@ -79,6 +79,20 @@ from astro.table import Metadata, Table
             f"file://{socket.gethostbyname(socket.gethostname())}:22",
             f"file://{socket.gethostbyname(socket.gethostname())}:22/tmp/duckdb.db.test_tb",
         ),
+        (
+            Connection(
+                conn_id="test_mssql",
+                conn_type="mssql",
+                host="astroserver.database.windows.net",
+                schema="astrodb",
+                port=1433,
+                login="username",
+                password="password",
+            ),
+            "astrodb.dataset.test_tb",
+            "mssql://astroserver.database.windows.net:1433",
+            "mssql://astroserver.database.windows.net:1433/astrodb.dataset.test_tb",
+        ),
     ],
 )
 @mock.patch("airflow.providers.google.cloud.utils.credentials_provider.get_credentials_and_project_id")

--- a/python-sdk/tests_integration/sql/test_table.py
+++ b/python-sdk/tests_integration/sql/test_table.py
@@ -83,15 +83,15 @@ from astro.table import Metadata, Table
             Connection(
                 conn_id="test_mssql",
                 conn_type="mssql",
-                host="astroserver.database.windows.net",
+                host="someserver.com",
                 schema="astrodb",
                 port=1433,
                 login="username",
                 password="password",
             ),
             "astrodb.dataset.test_tb",
-            "mssql://astroserver.database.windows.net:1433",
-            "mssql://astroserver.database.windows.net:1433/astrodb.dataset.test_tb",
+            "mssql://someserver.com:1433",
+            "mssql://someserver.com:1433/astrodb.dataset.test_tb",
         ),
     ],
 )


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, we are missing Openlineage name and namespace for mssql:
- Add Openlineage name and namespace mssql
- Add the tests 

Follow: https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md

closes: #1745 


## What is the new behavior?
Added support and testcases

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
