### PR TITLE
Add temporary dependencies

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -56,9 +56,11 @@ tests = [
 ]
 google = [
     "protobuf<=3.20", # Google bigquery client require protobuf <= 3.20.0. We can remove the limitation when this limitation is removed
-    "apache-airflow-providers-google>=6.4.0",
+    "apache-airflow-providers-google>6.4.0", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
     "sqlalchemy-bigquery>=1.3.0",
-    "smart-open[gcs]>=5.2.1"
+    "smart-open[gcs]>=5.2.1",
+    "pandas-gbq>=0.15.0", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
+    "protobuf>2.5.0" # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
 ]
 snowflake = [
     "apache-airflow-providers-snowflake",
@@ -101,7 +103,7 @@ duckdb = [
 
 all = [
     "apache-airflow-providers-amazon",
-    "apache-airflow-providers-google>=6.4.0",
+    "apache-airflow-providers-google>6.4.0", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
     "apache-airflow-providers-ftp",
     "apache-airflow-providers-postgres",
     "apache-airflow-providers-snowflake",
@@ -119,6 +121,8 @@ all = [
     "azure-storage-blob",
     "apache-airflow-providers-microsoft-mssql>=3.2",
     "airflow-provider-duckdb>=0.0.2",
+    "pandas-gbq>=0.15.0", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
+    "protobuf>2.5.0" # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
 ]
 doc = [
     "myst-parser>=0.17",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -59,7 +59,7 @@ google = [
     "apache-airflow-providers-google>6.4.0", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
     "sqlalchemy-bigquery>=1.3.0",
     "smart-open[gcs]>=5.2.1",
-    "pandas-gbq>=0.15.0", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
+    "pandas-gbq", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
     "protobuf>2.5.0" # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
 ]
 snowflake = [
@@ -121,7 +121,7 @@ all = [
     "azure-storage-blob",
     "apache-airflow-providers-microsoft-mssql>=3.2",
     "airflow-provider-duckdb>=0.0.2",
-    "pandas-gbq>=0.15.0", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
+    "pandas-gbq", # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
     "protobuf>2.5.0" # look at PR description for more information - https://github.com/astronomer/astro-sdk/pull/1757
 ]
 doc = [


### PR DESCRIPTION
# Description
## What is the current behavior?
**Added temporary dependencies**

**1. pandas-gbq**

It is a dependency of the [apache-airflow-providers-google](https://pypi.org/project/apache-airflow-providers-google/8.9.0/) and it does set an upper limit on it in version [apache-airflow-providers-google - 6.4.0](https://pypi.org/project/apache-airflow-providers-google/6.4.0/) of < 0.15.0, but [pandas - 1.5.3](https://pypi.org/project/pandas/1.5.3/) require a greater version of `pandas-gbq > 0.15.0` 
ref : https://github.com/pandas-dev/pandas/blame/0e12bfcd4b4d4e6f5ebe6cc6f99c0a5836df4478/pandas/compat/_optional.py#L31

So, we installed a greater version of apache-airflow-providers-google, but since [apache-airflow-providers-google](https://pypi.org/project/apache-airflow-providers-google/8.9.0/) don't have any version requirement of `pandas-gbq` we have to explicitly pass `pandas-gbq>0.15.0`


**2. protobuf**
While trying to install `protobuf` pip was trying to install version [2.5.0](https://pypi.org/project/protobuf/2.5.0/) which was released in 2013 and not compatible with the python version >= 3.0. 

ref: https://github.com/astronomer/astro-sdk/actions/runs/4173078408/jobs/7224985886

To prevent pip from trying that option we need to add a min dep `protobuf>2.5.0`




## What is the new behavior?
Added `protobuf>2.5.0` and `pandas-gbq > 0.15.0` dependencies but they are not our direct dependencies and should be moved to the provider.


## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
