### PR TITLE
Fix CI  - pandas-gbq dependency issue

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -64,6 +64,9 @@ snowflake = [
     "apache-airflow-providers-snowflake",
     "snowflake-sqlalchemy>=1.2.0",
     "snowflake-connector-python[pandas]<3.0.0",
+    # pinning snowflake-connector-python[pandas]<3.0.0 due to a conflict in snowflake-connector-python/pyarrow/google
+    # packages and pandas-gbq/google packages which is forcing pandas-gbq of version 0.13.2 installed, which is not
+    # compatible with pandas 1.5.3
 ]
 postgres = [
     "apache-airflow-providers-postgres",
@@ -108,6 +111,9 @@ all = [
     "apache-airflow-providers-sftp",
     "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]<3.0.0",
+    # pinning snowflake-connector-python[pandas]<3.0.0 due to a conflict in snowflake-connector-python/pyarrow/google
+    # packages and pandas-gbq/google packages which is forcing pandas-gbq of version 0.13.2 installed, which is not
+    # compatible with pandas 1.5.3
     "snowflake-sqlalchemy>=1.2.0",
     "sqlalchemy-bigquery>=1.3.0",
     "databricks-cli",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -63,7 +63,7 @@ google = [
 snowflake = [
     "apache-airflow-providers-snowflake",
     "snowflake-sqlalchemy>=1.2.0",
-    "snowflake-connector-python[pandas]",
+    "snowflake-connector-python[pandas]<3.0.0",
 ]
 postgres = [
     "apache-airflow-providers-postgres",
@@ -107,7 +107,7 @@ all = [
     "apache-airflow-providers-snowflake",
     "apache-airflow-providers-sftp",
     "smart-open[all]>=5.2.1",
-    "snowflake-connector-python[pandas]",
+    "snowflake-connector-python[pandas]<3.0.0",
     "snowflake-sqlalchemy>=1.2.0",
     "sqlalchemy-bigquery>=1.3.0",
     "databricks-cli",


### PR DESCRIPTION
# Description
## What is the current behavior?
version: 0.13.2 of pandas-gbq is installed on CI containers causing it to fail.
1. Exception not found
2. pandas - 1.5.3 is not compatible 0.13.2

closes: #1761

## What is the new behavior?
We found out that the snowflake-connector-python is using pyarrow which uses google packages and pandas-gbq uses the same google packages due to which the 0.13.2 of pandas was getting installed.


## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
