### PR TITLE
Use handler in run_sql

### DIFF
--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -424,7 +424,7 @@ class BaseDatabase(ABC):
         statement = f"SELECT * FROM {self.get_table_qualified_name(table)}"
         if row_limit > -1:
             statement = statement + f" LIMIT {row_limit}"
-        response = self.run_sql(statement, handler=lambda x: x.fetchall())  # type: ignore
+        response: list = self.run_sql(statement, handler=lambda x: x.fetchall())
         return response
 
     def load_file_to_table(

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -14,7 +14,7 @@ from sqlalchemy import column, insert, select
 from astro.dataframes.pandas import PandasDataframe
 
 if TYPE_CHECKING:  # pragma: no cover
-    from sqlalchemy.engine.cursor import CursorResult
+    pass
 
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
@@ -63,8 +63,6 @@ class BaseDatabase(ABC):
     # illegal_column_name_chars[0] will be replaced by value in illegal_column_name_chars_replacement[0]
     illegal_column_name_chars: list[str] = []
     illegal_column_name_chars_replacement: list[str] = []
-    # In run_raw_sql operator decides if we want to return results directly or process them by handler provided
-    IGNORE_HANDLER_IN_RUN_RAW_SQL: bool = False
     NATIVE_PATHS: dict[Any, Any] = {}
     DEFAULT_SCHEMA = SCHEMA
     NATIVE_LOAD_EXCEPTIONS: Any = DatabaseCustomError
@@ -109,7 +107,7 @@ class BaseDatabase(ABC):
         parameters: dict | None = None,
         handler: Callable | None = None,
         **kwargs,
-    ) -> list:
+    ) -> Any:
         """
         Return the results to running a SQL statement.
 
@@ -142,14 +140,7 @@ class BaseDatabase(ABC):
             result = self.connection.execute(sql, parameters)
         if handler:
             return handler(result)
-        return []
-
-    def get_wrapped_handler(self, conversion_func: Callable, result: CursorResult):
-        try:
-            return conversion_func(result)
-        except Exception as e:  # skipcq: PYL-W0703
-            logging.info("Exception %s handled since sqlalchemy failing when there are no results", str(e))
-            return None
+        return None
 
     def columns_exist(self, table: BaseTable, columns: list[str]) -> bool:
         """

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -117,6 +117,10 @@ class BaseDatabase(ABC):
         :param sql: Contains SQL query to be run against database
         :param parameters: Optional parameters to be used to render the query
         :param autocommit: Optional autocommit flag
+        :param handler: function that takes in a cursor as an argument.
+
+        Args:
+            handler:
         """
         if parameters is None:
             parameters = {}
@@ -408,7 +412,7 @@ class BaseDatabase(ABC):
                 use_native_support=use_native_support,
             )
 
-    def fetch_all_rows(self, table: BaseTable, row_limit: int = -1) -> list:
+    def fetch_all_rows(self, table: BaseTable, row_limit: int = -1) -> Any:
         """
         Fetches all rows for a table and returns as a list. This is needed because some
         databases have different cursors that require different methods to fetch rows

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -3,19 +3,13 @@ from __future__ import annotations
 import logging
 import warnings
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Callable, Mapping
+from typing import Any, Callable, Mapping
 
 import pandas as pd
 import sqlalchemy
 from airflow.hooks.dbapi import DbApiHook
 from pandas.io.sql import SQLDatabase
 from sqlalchemy import column, insert, select
-
-from astro.dataframes.pandas import PandasDataframe
-
-if TYPE_CHECKING:  # pragma: no cover
-    pass
-
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.elements import ColumnClause
 from sqlalchemy.sql.schema import Table as SqlaTable
@@ -29,6 +23,7 @@ from astro.constants import (
     LoadExistStrategy,
     MergeConflictStrategy,
 )
+from astro.dataframes.pandas import PandasDataframe
 from astro.exceptions import DatabaseCustomError, NonExistentTableException
 from astro.files import File, resolve_file_path_pattern
 from astro.files.types import create_file_type

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -113,9 +113,6 @@ class BaseDatabase(ABC):
         :param parameters: Optional parameters to be used to render the query
         :param autocommit: Optional autocommit flag
         :param handler: function that takes in a cursor as an argument.
-
-        Args:
-            handler:
         """
         if parameters is None:
             parameters = {}

--- a/python-sdk/src/astro/databases/databricks/delta.py
+++ b/python-sdk/src/astro/databases/databricks/delta.py
@@ -4,6 +4,7 @@ import tempfile
 import uuid
 import warnings
 from textwrap import dedent
+from typing import Any, Callable
 
 import pandas as pd
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
@@ -25,9 +26,6 @@ from astro.table import BaseTable, Metadata
 
 class DeltaDatabase(BaseDatabase):
     LOAD_OPTIONS_CLASS_NAME = "DeltaLoadOptions"
-    # In run_raw_sql operator decides if we want to return results directly or process them by handler provided
-    # For delta tables we ignore the handler
-    IGNORE_HANDLER_IN_RUN_RAW_SQL: bool = True
     _create_table_statement: str = "CREATE TABLE IF NOT EXISTS {} USING DELTA AS {} "
 
     def __init__(self, conn_id: str, table: BaseTable | None = None, load_options: LoadOptions | None = None):
@@ -197,9 +195,9 @@ class DeltaDatabase(BaseDatabase):
         self,
         sql: str | ClauseElement = "",
         parameters: dict | None = None,
-        handler=None,
+        handler: Callable | None = None,
         **kwargs,
-    ):
+    ) -> Any:
         """
         Run SQL against a delta table using spark SQL.
 

--- a/python-sdk/src/astro/databases/mssql.py
+++ b/python-sdk/src/astro/databases/mssql.py
@@ -241,7 +241,7 @@ class MssqlDatabase(BaseDatabase):
         statement = f"SELECT * FROM {self.get_table_qualified_name(table)}"  # skipcq: BAN-B608
         if row_limit > -1:
             statement = f"SELECT TOP {row_limit} * FROM {self.get_table_qualified_name(table)}"
-        response = self.run_sql(statement, handler=lambda x: x.fetchall())  # type: ignore
+        response: list = self.run_sql(statement, handler=lambda x: x.fetchall())
         return response
 
     def load_pandas_dataframe_to_table(

--- a/python-sdk/src/astro/databases/mssql.py
+++ b/python-sdk/src/astro/databases/mssql.py
@@ -155,6 +155,7 @@ class MssqlDatabase(BaseDatabase):
 
         :param sql: Contains SQL query to be run against database
         :param parameters: Optional parameters to be used to render the query
+        :param handler: function that takes in a cursor as an argument.
         """
         if parameters is None:
             parameters = {}
@@ -228,7 +229,7 @@ class MssqlDatabase(BaseDatabase):
         statement = self._drop_table_statement.format(self.get_table_qualified_name(table))
         self.run_sql(statement, autocommit=True)
 
-    def fetch_all_rows(self, table: BaseTable, row_limit: int = -1) -> list:
+    def fetch_all_rows(self, table: BaseTable, row_limit: int = -1) -> Any:
         """
         Fetches all rows for a table and returns as a list. This is needed because some
         databases have different cursors that require different methods to fetch rows

--- a/python-sdk/src/astro/databases/mssql.py
+++ b/python-sdk/src/astro/databases/mssql.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 import pandas as pd
 import sqlalchemy
@@ -17,8 +17,6 @@ from astro.table import BaseTable, Metadata
 from astro.utils.compat.functools import cached_property
 
 DEFAULT_CONN_ID = MsSqlHook.default_conn_name
-if TYPE_CHECKING:  # pragma: no cover
-    pass
 
 
 class MssqlDatabase(BaseDatabase):

--- a/python-sdk/src/astro/databases/mssql.py
+++ b/python-sdk/src/astro/databases/mssql.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import pandas as pd
 import sqlalchemy
@@ -147,7 +147,7 @@ class MssqlDatabase(BaseDatabase):
         parameters: dict | None = None,
         handler: Callable | None = None,
         **kwargs,
-    ) -> list:
+    ) -> Any:
         """
         Return the results to running a SQL statement.
         Whenever possible, this method should be implemented using Airflow Hooks,
@@ -183,7 +183,7 @@ class MssqlDatabase(BaseDatabase):
             result = self.connection.execute(sql, parameters)
         if handler:
             return handler(result)
-        return []
+        return None
 
     def create_schema_if_needed(self, schema: str | None) -> None:
         """

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -23,10 +23,10 @@ def test_make_row_serializable(rows):
 
 
 @mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_list")
-@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+@mock.patch("astro.databases.base.BaseDatabase.connection")
 def test_run_sql_calls_list_handler(run_sql, results_as_list, sample_dag):
     results_as_list.return_value = []
-    run_sql.return_value = []
+    run_sql.execute.return_value = []
     with sample_dag:
 
         @aql.run_raw_sql(results_format="list", conn_id="sqlite_default")
@@ -40,10 +40,10 @@ def test_run_sql_calls_list_handler(run_sql, results_as_list, sample_dag):
 
 
 @mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")
-@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+@mock.patch("astro.databases.base.BaseDatabase.connection")
 def test_run_sql_calls_pandas_dataframe_handler(run_sql, results_as_pandas_dataframe, sample_dag):
     results_as_pandas_dataframe.return_value = []
-    run_sql.return_value = []
+    run_sql.execute.return_value = []
     with sample_dag:
 
         @aql.run_raw_sql(results_format="pandas_dataframe", conn_id="sqlite_default")
@@ -57,13 +57,13 @@ def test_run_sql_calls_pandas_dataframe_handler(run_sql, results_as_pandas_dataf
 
 
 @mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")
-@mock.patch("astro.databases.base.BaseDatabase.run_sql")
+@mock.patch("astro.databases.base.BaseDatabase.connection")
 def test_run_sql_gives_priority_to_pandas_dataframe_handler(run_sql, results_as_pandas_dataframe, sample_dag):
     """
     Test that run_sql calls `results_format` specified handler over handler passed in decorator.
     """
     results_as_pandas_dataframe.return_value = []
-    run_sql.return_value = []
+    run_sql.execute.return_value = []
     with sample_dag:
 
         @aql.run_raw_sql(
@@ -103,14 +103,11 @@ def test_run_sql_called_handler(run_sql, results_as_pandas_dataframe, sample_dag
 
 
 @mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")
-@mock.patch("astro.databases.base.BaseDatabase.run_sql")
-def test_run_sql_should_raise_exception(run_sql, results_as_pandas_dataframe, sample_dag):
+def test_run_sql_should_raise_exception(results_as_pandas_dataframe, sample_dag):
     """
     Test that run_sql should raise an exception when fail_on_empty=False
     """
     results_as_pandas_dataframe.return_value = []
-    return_value = [1, 2, 3]
-    run_sql.return_value = return_value
 
     def raise_exception(result):
         raise ValueError("dummy exception")

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -153,7 +153,7 @@ def test_handlers():
 
     class Val:
         def __init__(self, val):
-            self.value = [val]
+            self.value: list = [val]
 
         def values(self) -> list:
             return self.value

--- a/python-sdk/tests_integration/databases/test_bigquery.py
+++ b/python-sdk/tests_integration/databases/test_bigquery.py
@@ -38,8 +38,8 @@ def test_bigquery_run_sql():
     """Test run_sql against bigquery database"""
     statement = "SELECT 1 + 1;"
     database = BigqueryDatabase(conn_id=DEFAULT_CONN_ID)
-    response = database.run_sql(statement)
-    assert response.first()[0] == 2
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response[0] == 2
 
 
 @pytest.mark.integration
@@ -77,12 +77,12 @@ def test_bigquery_create_table_with_columns(database_table_fixture):
         f"SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE "
         f"FROM {table.metadata.schema}.INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
     )
-    response = database.run_sql(statement)
-    assert response.first() is None
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response is None
 
     database.create_table(table)
-    response = database.run_sql(statement)
-    rows = response.fetchall()
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
+    rows = response
     assert len(rows) == 2
     assert rows[0] == (
         "astronomer-dag-authoring",
@@ -121,9 +121,9 @@ def test_load_pandas_dataframe_to_table(database_table_fixture):
     database.load_pandas_dataframe_to_table(pandas_dataframe, table)
 
     statement = f"SELECT * FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement)
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
 
-    rows = response.fetchall()
+    rows = response
     assert len(rows) == 2
     assert rows[0] == (1,)
     assert rows[1] == (2,)

--- a/python-sdk/tests_integration/databases/test_mssql.py
+++ b/python-sdk/tests_integration/databases/test_mssql.py
@@ -53,8 +53,8 @@ def test_mssql_run_sql():
     """Test run_sql against mssql database"""
     statement = "SELECT 1 + 1;"
     database = MssqlDatabase(conn_id=CUSTOM_CONN_ID)
-    response = database.run_sql(statement)
-    assert response.first()[0] == 2
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response[0] == 2
 
 
 @pytest.mark.integration
@@ -88,12 +88,12 @@ def test_mssql_create_table_with_columns(database_table_fixture):
     database, table = database_table_fixture
 
     statement = f"SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
-    response = database.run_sql(statement)
-    assert response.first() is None
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response is None
 
     database.create_table(table)
-    response = database.run_sql(statement)
-    rows = response.fetchall()
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
+    rows = response
     assert len(rows) == 2
     assert rows[0][0:4] == (
         "astrodb",
@@ -126,9 +126,9 @@ def test_load_pandas_dataframe_to_table(database_table_fixture):
     database.load_pandas_dataframe_to_table(pandas_dataframe, table)
 
     statement = f"SELECT * FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement)
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
 
-    rows = response.fetchall()
+    rows = response
     assert len(rows) == 2
     assert rows[0] == (1,)
     assert rows[1] == (2,)

--- a/python-sdk/tests_integration/databases/test_postgres.py
+++ b/python-sdk/tests_integration/databases/test_postgres.py
@@ -55,8 +55,8 @@ def test_postgres_run_sql():
     """Test run_sql against postgres database"""
     statement = "SELECT 1 + 1;"
     database = PostgresDatabase(conn_id=CUSTOM_CONN_ID)
-    response = database.run_sql(statement)
-    assert response.first()[0] == 2
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response[0] == 2
 
 
 @pytest.mark.integration
@@ -90,12 +90,12 @@ def test_postgres_create_table_with_columns(database_table_fixture):
     database, table = database_table_fixture
 
     statement = f"SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
-    response = database.run_sql(statement)
-    assert response.first() is None
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response is None
 
     database.create_table(table)
-    response = database.run_sql(statement)
-    rows = response.fetchall()
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
+    rows = response
     assert len(rows) == 2
     assert rows[0][0:4] == (
         "postgres",
@@ -128,9 +128,9 @@ def test_load_pandas_dataframe_to_table(database_table_fixture):
     database.load_pandas_dataframe_to_table(pandas_dataframe, table)
 
     statement = f"SELECT * FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement)
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
 
-    rows = response.fetchall()
+    rows = response
     assert len(rows) == 2
     assert rows[0] == (1,)
     assert rows[1] == (2,)

--- a/python-sdk/tests_integration/databases/test_redshift.py
+++ b/python-sdk/tests_integration/databases/test_redshift.py
@@ -38,8 +38,8 @@ def test_redshift_run_sql():
     """Test run_sql against redshift database"""
     statement = "SELECT 1 + 1;"
     database = RedshiftDatabase(conn_id=CUSTOM_CONN_ID)
-    response = database.run_sql(statement)
-    assert response.first()[0] == 2
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response[0] == 2
 
 
 @pytest.mark.integration
@@ -73,12 +73,12 @@ def test_redshift_create_table_with_columns(database_table_fixture):
     database, table = database_table_fixture
 
     statement = f"SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name='{table.name}'"
-    response = database.run_sql(statement)
-    assert response.first() is None
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response is None
 
     database.create_table(table)
-    response = database.run_sql(statement)
-    rows = response.fetchall()
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
+    rows = response
     assert len(rows) == 2
     assert rows[0][0:4] == (
         "dev",
@@ -111,9 +111,9 @@ def test_load_pandas_dataframe_to_table(database_table_fixture):
     database.load_pandas_dataframe_to_table(pandas_dataframe, table)
 
     statement = f"SELECT * FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement)
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
 
-    rows = response.fetchall()
+    rows = response
     assert len(rows) == 2
     assert rows[0] == (1,)
     assert rows[1] == (2,)

--- a/python-sdk/tests_integration/databases/test_snowflake.py
+++ b/python-sdk/tests_integration/databases/test_snowflake.py
@@ -39,8 +39,8 @@ def test_snowflake_run_sql():
     """Test run_sql against snowflake database"""
     statement = "SELECT 1 + 1;"
     database = SnowflakeDatabase(conn_id=CUSTOM_CONN_ID)
-    response = database.run_sql(statement)
-    assert response.first()[0] == 2
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response[0] == 2
 
 
 @pytest.mark.integration
@@ -79,8 +79,8 @@ def test_snowflake_create_table_with_columns(database_table_fixture):
     assert e.match("does not exist or not authorized")
 
     database.create_table(table)
-    response = database.run_sql(statement)
-    rows = response.fetchall()
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
+    rows = response
     assert len(rows) == 2
     assert rows[0] == (
         "ID",
@@ -137,11 +137,11 @@ def test_snowflake_create_table_using_native_schema_autodetection(
 
     file = File("s3://astro-sdk/sample.parquet", conn_id="aws_conn")
     database.create_table(table, file)
-    response = database.run_sql(statement)
-    rows = response.fetchall()
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
+    rows = response
     assert len(rows) == 2
     statement = f"SELECT COUNT(*) FROM {database.get_table_qualified_name(table)}"
-    count = database.run_sql(statement).scalar()
+    count = database.run_sql(statement, handler=lambda x: x.scalar())
     assert count == 0
 
 
@@ -165,9 +165,9 @@ def test_load_pandas_dataframe_to_table(database_table_fixture):
     database.load_pandas_dataframe_to_table(pandas_dataframe, table)
 
     statement = f"SELECT * FROM {database.get_table_qualified_name(table)}"
-    response = database.run_sql(statement)
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
 
-    rows = response.fetchall()
+    rows = response
     assert len(rows) == 2
     assert rows[0] == (1,)
     assert rows[1] == (2,)


### PR DESCRIPTION
**Please describe the feature you'd like to see**
Currently, the handler param in the run_sql() method is only used in data bricks all other databases are not using it, which leads to different response types since the handler is processed within `run_sql()` for data bricks and not for other databases. Also, the signature of `run_sql()` in data bricks deviates from the base. We need to standardize and when we do, we can remove the below check as well.

**Describe the solution you'd like**
Ideally, we should have the same signatures for all the run_sql() database implementations. This will prevent adding explicit conditions for data bricks in other parts of the code that should ideally be database agnostic. 
example: https://github.com/astronomer/astro-sdk/blob/2f8c8d0ccbff3cc13af78685cbefa39f473991c3/python-sdk/src/astro/sql/operators/raw_sql.py#L47

**Acceptance Criteria**
- [ ] Where ever we have used run_sql(), we shouldn't be having any database-specific checks.

closes #1664 