### PR TITLE
Allow pre-release candidates for fallback (default) version of Astro CLI

### DIFF
--- a/sql-cli/config/astro-cli.json
+++ b/sql-cli/config/astro-cli.json
@@ -17,7 +17,7 @@
       "sqlCliVersion": ">0.2, <0.3"
     },
     "default": {
-      "preRelease": false,
+      "preRelease": true,
       "sqlCliVersion": ">0.2.2"
     }
   },


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
We do not allow pre-release candidates for the fallback (default) version of Astro CLI

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
related: #1302 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Allow pre-release candidates for the fallback (default) version of Astro CLI

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
