### PR TITLE
Add argument `skip_on_failure` to `CleanupOperator`

### DIFF
--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -107,7 +107,7 @@ class CleanupOperator(AstroSQLBaseOperator):
         if self.skip_on_failure:
             task_instances = context["dag_run"].get_task_instances()
             if self._is_task_failed(task_instances=task_instances):
-                pass
+                return None
         temp_tables = filter_for_temp_tables(self.tables_to_cleanup)
         self.log.info(
             "Tables found for cleanup: %s",

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -106,7 +106,7 @@ class CleanupOperator(AstroSQLBaseOperator):
             self.tables_to_cleanup = self.get_all_task_outputs(context=context)
         if self.skip_on_failure:
             task_instances = context["dag_run"].get_task_instances()
-            if self._is_task_failed(task_instances=task_instances):
+            if self._has_task_failed(task_instances=task_instances):
                 return None
         temp_tables = filter_for_temp_tables(self.tables_to_cleanup)
         self.log.info(
@@ -121,7 +121,7 @@ class CleanupOperator(AstroSQLBaseOperator):
         self.log.info("Dropping table %s", table.name)
         db.drop_table(table)
 
-    def _is_task_failed(self, task_instances: list[TaskInstance]) -> bool:
+    def _has_task_failed(self, task_instances: list[TaskInstance]) -> bool:
         """
         Given a list of task instances, return True if at least one task has failed.
 

--- a/python-sdk/src/astro/sql/operators/cleanup.py
+++ b/python-sdk/src/astro/sql/operators/cleanup.py
@@ -131,8 +131,7 @@ class CleanupOperator(AstroSQLBaseOperator):
         failed_tasks = [
             (ti.task_id, ti.state)
             for ti in task_instances
-            if ti.task_id != self.task_id
-            and ti.state == State.FAILED
+            if ti.task_id != self.task_id and ti.state == State.FAILED
         ]
         if failed_tasks:
             self.log.info(
@@ -142,7 +141,6 @@ class CleanupOperator(AstroSQLBaseOperator):
             return True
         else:
             return False
-
 
     def _is_dag_running(self, task_instances: list[TaskInstance]) -> bool:
         """

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -49,6 +49,17 @@ def test_is_dag_running():
     task_instances[0].state = State.RUNNING
     assert cleanup_op._is_dag_running(task_instances=task_instances)
 
+def test_is_task_failed():
+    cleanup_op = CleanupOperator(task_id="cleanup")
+
+    task_instances = []
+    for i in range(4):
+        op = BashOperator(task_id=f"foo_task_{i}", bash_command="")
+        ti = TaskInstance(task=op, state=State.SUCCESS)
+        task_instances.append(ti)
+    assert not cleanup_op._is_task_failed(task_instances=task_instances)
+    task_instances[0].state = State.FAILED
+    assert cleanup_op._is_task_failed(task_instances=task_instances)
 
 @pytest.mark.parametrize("single_worker_mode", [True, False])
 @mock.patch("astro.sql.operators.cleanup.CleanupOperator._is_single_worker_mode")

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -50,7 +50,7 @@ def test_is_dag_running():
     assert cleanup_op._is_dag_running(task_instances=task_instances)
 
 
-def test_is_task_failed():
+def test_has_task_failed():
     cleanup_op = CleanupOperator(task_id="cleanup")
 
     task_instances = []
@@ -58,9 +58,9 @@ def test_is_task_failed():
         op = BashOperator(task_id=f"foo_task_{i}", bash_command="")
         ti = TaskInstance(task=op, state=State.SUCCESS)
         task_instances.append(ti)
-    assert not cleanup_op._is_task_failed(task_instances=task_instances)
+    assert not cleanup_op._has_task_failed(task_instances=task_instances)
     task_instances[0].state = State.FAILED
-    assert cleanup_op._is_task_failed(task_instances=task_instances)
+    assert cleanup_op._has_task_failed(task_instances=task_instances)
 
 
 @pytest.mark.parametrize("single_worker_mode", [True, False])

--- a/python-sdk/tests/sql/operators/test_cleanup.py
+++ b/python-sdk/tests/sql/operators/test_cleanup.py
@@ -49,6 +49,7 @@ def test_is_dag_running():
     task_instances[0].state = State.RUNNING
     assert cleanup_op._is_dag_running(task_instances=task_instances)
 
+
 def test_is_task_failed():
     cleanup_op = CleanupOperator(task_id="cleanup")
 
@@ -60,6 +61,7 @@ def test_is_task_failed():
     assert not cleanup_op._is_task_failed(task_instances=task_instances)
     task_instances[0].state = State.FAILED
     assert cleanup_op._is_task_failed(task_instances=task_instances)
+
 
 @pytest.mark.parametrize("single_worker_mode", [True, False])
 @mock.patch("astro.sql.operators.cleanup.CleanupOperator._is_single_worker_mode")


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, `astro.sql.cleanup` deletes temporary tables once upstream tasks are done, whether or not the DAG succeeded. 

While usually desirable, more detailed control is sometimes useful. For example, during DAG development, I may not want to keep regenerating all temporary tables while bugfixing failing tasks.

## What is the new behavior?

- `CleanupOperator` has a new optional argument `skip_on_failure` that prevents table cleanup if any upstream task fails.
- To mimic current behavior, `skip_on_failure=False` by default.

This PR closes issue #1826. 

## Does this introduce a breaking change?
No

### Checklist
[x ] Created tests which fail without the change (if possible)
[ ] Extended the README / documentation, if necessary
