### PR TITLE
Update config for SQL CLI 0.4.1 and Astro CLI 1.12

### DIFF
--- a/sql-cli/config/astro-cli.json
+++ b/sql-cli/config/astro-cli.json
@@ -25,7 +25,7 @@
       "sqlCliVersion": ">0.2, <0.3"
     },
     "default": {
-      "preRelease": false,
+      "preRelease": true,
       "sqlCliVersion": ">0.2.2"
     }
   },

--- a/sql-cli/config/astro-cli.json
+++ b/sql-cli/config/astro-cli.json
@@ -16,6 +16,10 @@
       "preRelease": false,
       "sqlCliVersion": ">0.3.2"
     },
+    "1.12": {
+      "preRelease": false,
+      "sqlCliVersion": ">0.3.2"
+    },
     "1.8.0": {
       "preRelease": false,
       "sqlCliVersion": ">0.2, <0.3"

--- a/sql-cli/config/astro-cli.json
+++ b/sql-cli/config/astro-cli.json
@@ -8,11 +8,11 @@
       "preRelease": false,
       "sqlCliVersion": ">0.2.2"
     },
-    "1.11.0": {
+    "1.11": {
       "preRelease": false,
       "sqlCliVersion": ">0.3.2"
     },
-    "1.11": {
+    "1.11.0": {
       "preRelease": false,
       "sqlCliVersion": ">0.3.2"
     },
@@ -44,6 +44,10 @@
       "astroSDKPythonVersion": ">=1.3.1,<1.5"
     },
     "0.4.0": {
+      "astroRuntimeVersion": ">=7.2.0",
+      "astroSDKPythonVersion": ">=1.3.1,<1.5"
+    },
+    "0.4.1-rc1": {
       "astroRuntimeVersion": ">=7.2.0",
       "astroSDKPythonVersion": ">=1.3.1,<1.5"
     },

--- a/sql-cli/config/astro-cli.json
+++ b/sql-cli/config/astro-cli.json
@@ -25,7 +25,7 @@
       "sqlCliVersion": ">0.2, <0.3"
     },
     "default": {
-      "preRelease": true,
+      "preRelease": false,
       "sqlCliVersion": ">0.2.2"
     }
   },
@@ -47,7 +47,7 @@
       "astroRuntimeVersion": ">=7.2.0",
       "astroSDKPythonVersion": ">=1.3.1,<1.5"
     },
-    "0.4.1rc1": {
+    "0.4.1": {
       "astroRuntimeVersion": ">=7.2.0",
       "astroSDKPythonVersion": ">=1.3.1,<1.5"
     },

--- a/sql-cli/config/astro-cli.json
+++ b/sql-cli/config/astro-cli.json
@@ -47,7 +47,7 @@
       "astroRuntimeVersion": ">=7.2.0",
       "astroSDKPythonVersion": ">=1.3.1,<1.5"
     },
-    "0.4.1-rc1": {
+    "0.4.1rc1": {
       "astroRuntimeVersion": ">=7.2.0",
       "astroSDKPythonVersion": ">=1.3.1,<1.5"
     },


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Entries for SQL CLI upto 0.4.0 and Astro CLI 1.11 are available in the config

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
related: #1825 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Add config map entries to be used in Astro CLI for SQL CLI 0.4.1 and Astro CLI 1.12 versions

## Does this introduce a breaking change?
No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
