### PR TITLE
Fix database to file issue

### DIFF
--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/base.py
@@ -68,11 +68,14 @@ class DataProviders(ABC, Generic[DatasetType]):
         return Location(source_connection_type) in self.transfer_mapping
 
     def read(self) -> Iterator[pd.DataFrame] | Iterator[FileStream]:
-        """Read the dataset and write to local reference location"""
+        """Read from filesystem dataset or databases dataset and write to local reference locations or dataframes"""
         raise NotImplementedError
 
-    def write(self, source_ref) -> str:  # type: ignore
-        """Write the data from local reference location to the dataset"""
+    def write(self, source_ref: pd.DataFrame | FileStream) -> str:  # type: ignore
+        """Write the data from local reference location or a dataframe to the database dataset or filesystem dataset
+
+        :param source_ref: Stream of data to be loaded into output table or a pandas dataframe.
+        """
         raise NotImplementedError
 
     @property

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/base.py
@@ -18,7 +18,7 @@ DatasetType = TypeVar("DatasetType", File, Table)
 
 
 @attr.define
-class FileStream:
+class DataStream:
     remote_obj_buffer: io.IOBase
     actual_filename: Path
     actual_file: File
@@ -67,11 +67,11 @@ class DataProviders(ABC, Generic[DatasetType]):
         source_connection_type = get_dataset_connection_type(source_dataset)
         return Location(source_connection_type) in self.transfer_mapping
 
-    def read(self) -> Iterator[pd.DataFrame] | Iterator[FileStream]:
+    def read(self) -> Iterator[pd.DataFrame] | Iterator[DataStream]:
         """Read from filesystem dataset or databases dataset and write to local reference locations or dataframes"""
         raise NotImplementedError
 
-    def write(self, source_ref: pd.DataFrame | FileStream) -> str:  # type: ignore
+    def write(self, source_ref: pd.DataFrame | DataStream) -> str:  # type: ignore
         """Write the data from local reference location or a dataframe to the database dataset or filesystem dataset
 
         :param source_ref: Stream of data to be loaded into output table or a pandas dataframe.

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
@@ -464,7 +464,7 @@ class DatabaseDataProvider(DataProviders[Table]):
         use_native_support: bool = True,
     ):
         """
-        Checks if the autodetect schema exists for native support else creates the schema and table
+        Creates the schema and table from dataframe
         :param table: Table to create
         :param file: File path and conn_id for object stores
         :param normalize_config: pandas json_normalize params config

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
@@ -193,6 +193,10 @@ class DatabaseDataProvider(DataProviders[Table]):
         Write the data from local reference location to the dataset.
         :param source_ref: Stream of data to be loaded into output table.
         """
+        # `source_ref` can be a dataframe for all the filetypes we can create a dataframe for like -
+        # CSV, JSON, NDJSON, and Parquet or SQL Tables. This gives us the option to perform various
+        # functions on the data on the fly, like filtering or changing the file format altogether. For other
+        # files whose content cannot be converted to dataframe like - zip or image, we get a Filestream object.
         if isinstance(source_ref, FileStream):
             return self.load_file_to_table(input_file=source_ref.actual_file, output_table=self.dataset)
         return self.load_dataframe_to_table(input_dataframe=source_ref, output_table=self.dataset)

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
@@ -185,7 +185,7 @@ class DatabaseDataProvider(DataProviders[Table]):
         source_connection_type = get_dataset_connection_type(source_dataset)
         return Location(source_connection_type) in self.transfer_mapping
 
-    def read(self):
+    def read(self) -> pd.DataFrame:
         """Read the dataset and write to local reference location"""
         yield self.export_table_to_pandas_dataframe()
 

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
@@ -185,13 +185,13 @@ class DatabaseDataProvider(DataProviders[Table]):
         return Location(source_connection_type) in self.transfer_mapping
 
     def read(self) -> Iterator[pd.DataFrame]:
-        """Read the dataset and write to local reference location"""
+        """Read database dataset and convert them to dataframes"""
         yield self.export_table_to_pandas_dataframe()
 
     def write(self, source_ref: FileStream | pd.DataFrame) -> str:
         """
-        Write the data from local reference location to the dataset.
-        :param source_ref: Stream of data to be loaded into output table.
+        Write the data from local reference location or dataframe to the database dataset or filesystem dataset.
+        :param source_ref: Stream of data to be loaded into output table or a pandas dataframe.
         """
         # `source_ref` can be a dataframe for all the filetypes we can create a dataframe for like -
         # CSV, JSON, NDJSON, and Parquet or SQL Tables. This gives us the option to perform various

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
@@ -191,6 +191,7 @@ class DatabaseDataProvider(DataProviders[Table]):
     def write(self, source_ref: FileStream | pd.DataFrame) -> str:
         """
         Write the data from local reference location or dataframe to the database dataset or filesystem dataset.
+
         :param source_ref: Stream of data to be loaded into output table or a pandas dataframe.
         """
         # `source_ref` can be a dataframe for all the filetypes we can create a dataframe for like -
@@ -467,9 +468,9 @@ class DatabaseDataProvider(DataProviders[Table]):
     ):
         """
         Creates the schema and table from dataframe
+
         :param table: Table to create
-        :param file: File path and conn_id for object stores
-        :param normalize_config: pandas json_normalize params config
+        :param dataframe: dataframe object to be used as a source of data
         :param columns_names_capitalization:  determines whether to convert all columns to lowercase/uppercase
         :param if_exists:  Overwrite file if exists
         :param use_native_support: Use native support for data transfer if available on the destination

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 import pandas as pd
 import sqlalchemy
@@ -185,7 +185,7 @@ class DatabaseDataProvider(DataProviders[Table]):
         source_connection_type = get_dataset_connection_type(source_dataset)
         return Location(source_connection_type) in self.transfer_mapping
 
-    def read(self) -> pd.DataFrame:
+    def read(self) -> Iterator[pd.DataFrame]:
         """Read the dataset and write to local reference location"""
         yield self.export_table_to_pandas_dataframe()
 

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
@@ -23,7 +23,7 @@ from universal_transfer_operator.constants import (
     Location,
     TransferMode,
 )
-from universal_transfer_operator.data_providers.base import DataProviders, FileStream
+from universal_transfer_operator.data_providers.base import DataProviders, DataStream
 from universal_transfer_operator.data_providers.filesystem import resolve_file_path_pattern
 from universal_transfer_operator.datasets.dataframe.pandas import PandasDataframe
 from universal_transfer_operator.datasets.file.base import File
@@ -188,7 +188,7 @@ class DatabaseDataProvider(DataProviders[Table]):
         """Read database dataset and convert them to dataframes"""
         yield self.export_table_to_pandas_dataframe()
 
-    def write(self, source_ref: FileStream | pd.DataFrame) -> str:
+    def write(self, source_ref: DataStream | pd.DataFrame) -> str:
         """
         Write the data from local reference location or dataframe to the database dataset or filesystem dataset.
 
@@ -197,8 +197,8 @@ class DatabaseDataProvider(DataProviders[Table]):
         # `source_ref` can be a dataframe for all the filetypes we can create a dataframe for like -
         # CSV, JSON, NDJSON, and Parquet or SQL Tables. This gives us the option to perform various
         # functions on the data on the fly, like filtering or changing the file format altogether. For other
-        # files whose content cannot be converted to dataframe like - zip or image, we get a Filestream object.
-        if isinstance(source_ref, FileStream):
+        # files whose content cannot be converted to dataframe like - zip or image, we get a DataStream object.
+        if isinstance(source_ref, DataStream):
             return self.load_file_to_table(input_file=source_ref.actual_file, output_table=self.dataset)
         return self.load_dataframe_to_table(input_dataframe=source_ref, output_table=self.dataset)
 

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/database/base.py
@@ -185,7 +185,7 @@ class DatabaseDataProvider(DataProviders[Table]):
         return Location(source_connection_type) in self.transfer_mapping
 
     def read(self) -> Iterator[pd.DataFrame]:
-        """Read database dataset and convert them to dataframes"""
+        """Convert a Table into a Pandas DataFrame"""
         yield self.export_table_to_pandas_dataframe()
 
     def write(self, source_ref: DataStream | pd.DataFrame) -> str:

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
@@ -4,6 +4,7 @@ import io
 import os
 from abc import abstractmethod
 from pathlib import Path
+from typing import Iterator
 
 import attr
 import pandas as pd
@@ -91,17 +92,17 @@ class BaseFilesystemProviders(DataProviders[File]):
         source_connection_type = get_dataset_connection_type(source_dataset)
         return Location(source_connection_type) in self.transfer_mapping
 
-    def read(self):
+    def read(self) -> Iterator[FileStream]:
         """ ""Read the dataset and write to local reference location"""
         return self.read_using_smart_open()
 
-    def read_using_smart_open(self):
+    def read_using_smart_open(self) -> Iterator[FileStream]:
         """Read the file dataset using smart open returns i/o buffer"""
         files = self.paths
         for file in files:
             yield FileStream(
                 remote_obj_buffer=self._convert_remote_file_to_byte_stream(file),
-                actual_filename=file,
+                actual_filename=Path(file),
                 actual_file=self.dataset,
             )
 

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
@@ -116,6 +116,7 @@ class BaseFilesystemProviders(DataProviders[File]):
     def write(self, source_ref: FileStream | pd.DataFrame) -> str:
         """
         Write the data from local reference location or a dataframe to the filesystem dataset or database dataset
+
         :param source_ref: Source FileStream object which will be used to read data
         """
         return self.write_using_smart_open(source_ref=source_ref)

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
@@ -12,7 +12,7 @@ import smart_open
 from airflow.hooks.base import BaseHook
 
 from universal_transfer_operator.constants import FileType, Location
-from universal_transfer_operator.data_providers.base import DataProviders, FileStream
+from universal_transfer_operator.data_providers.base import DataProviders, DataStream
 from universal_transfer_operator.datasets.file.base import File
 from universal_transfer_operator.datasets.file.types import create_file_type
 from universal_transfer_operator.universal_transfer_operator import TransferIntegrationOptions
@@ -85,15 +85,15 @@ class BaseFilesystemProviders(DataProviders[File]):
         source_connection_type = get_dataset_connection_type(source_dataset)
         return Location(source_connection_type) in self.transfer_mapping
 
-    def read(self) -> Iterator[FileStream]:
+    def read(self) -> Iterator[DataStream]:
         """Read the remote or local file dataset and returns i/o buffers"""
         return self.read_using_smart_open()
 
-    def read_using_smart_open(self) -> Iterator[FileStream]:
+    def read_using_smart_open(self) -> Iterator[DataStream]:
         """Read the file dataset using smart open returns i/o buffer"""
         files = self.paths
         for file in files:
-            yield FileStream(
+            yield DataStream(
                 remote_obj_buffer=self._convert_remote_file_to_byte_stream(file),
                 actual_filename=Path(file),
                 actual_file=self.dataset,
@@ -113,15 +113,15 @@ class BaseFilesystemProviders(DataProviders[File]):
             remote_obj_buffer.seek(0)
             return remote_obj_buffer
 
-    def write(self, source_ref: FileStream | pd.DataFrame) -> str:
+    def write(self, source_ref: DataStream | pd.DataFrame) -> str:
         """
         Write the data from local reference location or a dataframe to the filesystem dataset or database dataset
 
-        :param source_ref: Source FileStream object which will be used to read data
+        :param source_ref: Source DataStream object which will be used to read data
         """
         return self.write_using_smart_open(source_ref=source_ref)
 
-    def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame) -> str:
+    def write_using_smart_open(self, source_ref: DataStream | pd.DataFrame) -> str:
         """Write the source data from remote object i/o buffer to the dataset using smart open"""
         mode = "wb" if self.read_as_binary(self.dataset.path) else "w"
         destination_file = self.dataset.path
@@ -129,8 +129,8 @@ class BaseFilesystemProviders(DataProviders[File]):
             # `source_ref` can be a dataframe for all the filetypes we can create a dataframe for like -
             # CSV, JSON, NDJSON, and Parquet or SQL Tables. This gives us the option to perform various
             # functions on the data on the fly, like filtering or changing the file format altogether. For other
-            # files whose content cannot be converted to dataframe like - zip or image, we get a Filestream object.
-            if isinstance(source_ref, FileStream):
+            # files whose content cannot be converted to dataframe like - zip or image, we get a DataStream object.
+            if isinstance(source_ref, DataStream):
                 stream.write(source_ref.remote_obj_buffer.read())
             elif isinstance(source_ref, pd.DataFrame):
                 self.dataset.type.create_from_dataframe(stream=stream, df=source_ref)

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
@@ -12,7 +12,7 @@ import smart_open
 from airflow.hooks.base import BaseHook
 
 from universal_transfer_operator.constants import FileType, Location
-from universal_transfer_operator.data_providers.base import DataProviders
+from universal_transfer_operator.data_providers.base import DataProviders, FileStream
 from universal_transfer_operator.datasets.file.base import File
 from universal_transfer_operator.datasets.file.types import create_file_type
 from universal_transfer_operator.universal_transfer_operator import TransferIntegrationOptions
@@ -23,13 +23,6 @@ from universal_transfer_operator.utils import get_dataset_connection_type
 class TempFile:
     tmp_file: Path | None
     actual_filename: Path
-
-
-@attr.define
-class FileStream:
-    remote_obj_buffer: io.IOBase
-    actual_filename: Path
-    actual_file: File
 
 
 class BaseFilesystemProviders(DataProviders[File]):
@@ -120,14 +113,14 @@ class BaseFilesystemProviders(DataProviders[File]):
             remote_obj_buffer.seek(0)
             return remote_obj_buffer
 
-    def write(self, source_ref: FileStream | pd.DataFrame):
+    def write(self, source_ref: FileStream | pd.DataFrame) -> str:
         """
         Write the data from local reference location to the dataset
         :param source_ref: Source FileStream object which will be used to read data
         """
         return self.write_using_smart_open(source_ref=source_ref)
 
-    def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame):
+    def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame) -> str:
         """Write the source data from remote object i/o buffer to the dataset using smart open"""
         mode = "wb" if self.read_as_binary(self.dataset.path) else "w"
         destination_file = self.dataset.path

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
@@ -125,6 +125,10 @@ class BaseFilesystemProviders(DataProviders[File]):
         mode = "wb" if self.read_as_binary(self.dataset.path) else "w"
         destination_file = self.dataset.path
         with smart_open.open(destination_file, mode=mode, transport_params=self.transport_params) as stream:
+            # `source_ref` can be a dataframe for all the filetypes we can create a dataframe for like -
+            # CSV, JSON, NDJSON, and Parquet or SQL Tables. This gives us the option to perform various
+            # functions on the data on the fly, like filtering or changing the file format altogether. For other
+            # files whose content cannot be converted to dataframe like - zip or image, we get a Filestream object.
             if isinstance(source_ref, FileStream):
                 stream.write(source_ref.remote_obj_buffer.read())
             elif isinstance(source_ref, pd.DataFrame):

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/base.py
@@ -86,7 +86,7 @@ class BaseFilesystemProviders(DataProviders[File]):
         return Location(source_connection_type) in self.transfer_mapping
 
     def read(self) -> Iterator[FileStream]:
-        """ ""Read the dataset and write to local reference location"""
+        """Read the remote or local file dataset and returns i/o buffers"""
         return self.read_using_smart_open()
 
     def read_using_smart_open(self) -> Iterator[FileStream]:
@@ -115,7 +115,7 @@ class BaseFilesystemProviders(DataProviders[File]):
 
     def write(self, source_ref: FileStream | pd.DataFrame) -> str:
         """
-        Write the data from local reference location to the dataset
+        Write the data from local reference location or a dataframe to the filesystem dataset or database dataset
         :param source_ref: Source FileStream object which will be used to read data
         """
         return self.write_using_smart_open(source_ref=source_ref)

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/local.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/local.py
@@ -10,7 +10,7 @@ import pandas as pd
 import smart_open
 from airflow.hooks.base import BaseHook
 
-from universal_transfer_operator.data_providers.base import FileStream
+from universal_transfer_operator.data_providers.base import DataStream
 from universal_transfer_operator.data_providers.filesystem.base import BaseFilesystemProviders
 
 
@@ -65,11 +65,11 @@ class LocalDataProvider(BaseFilesystemProviders):
         """Return true if the dataset exists"""
         return exists(self.dataset.path)
 
-    def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame) -> str:
+    def write_using_smart_open(self, source_ref: DataStream | pd.DataFrame) -> str:
         """Write the source data from remote object i/o buffer to the dataset using smart open"""
         mode = "wb" if self.read_as_binary(self.dataset.path) else "w"
         with smart_open.open(self.dataset.path, mode=mode, transport_params=self.transport_params) as stream:
-            if isinstance(source_ref, FileStream):
+            if isinstance(source_ref, DataStream):
                 stream.write(source_ref.remote_obj_buffer.read())
             elif isinstance(source_ref, pd.DataFrame):
                 self.dataset.type.create_from_dataframe(stream=stream, df=source_ref)

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/local.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/local.py
@@ -10,7 +10,8 @@ import pandas as pd
 import smart_open
 from airflow.hooks.base import BaseHook
 
-from universal_transfer_operator.data_providers.filesystem.base import BaseFilesystemProviders, FileStream
+from universal_transfer_operator.data_providers.base import FileStream
+from universal_transfer_operator.data_providers.filesystem.base import BaseFilesystemProviders
 
 
 class LocalDataProvider(BaseFilesystemProviders):
@@ -64,7 +65,7 @@ class LocalDataProvider(BaseFilesystemProviders):
         """Return true if the dataset exists"""
         return exists(self.dataset.path)
 
-    def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame):
+    def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame) -> str:
         """Write the source data from remote object i/o buffer to the dataset using smart open"""
         mode = "wb" if self.read_as_binary(self.dataset.path) else "w"
         with smart_open.open(self.dataset.path, mode=mode, transport_params=self.transport_params) as stream:

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
@@ -119,6 +119,7 @@ class SFTPDataProvider(BaseFilesystemProviders):
         return urlunparse(final_url)
 
     def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame):
+        """Write the source data from remote object i/o buffer to the dataset using smart open"""
         if isinstance(source_ref, FileStream):
             return self.write_file_using_smart_open(source_ref=source_ref)
         elif isinstance(source_ref, pd.DataFrame):
@@ -136,7 +137,7 @@ class SFTPDataProvider(BaseFilesystemProviders):
         return complete_url
 
     def write_dataframe_using_smart_open(self, source_ref: pd.DataFrame) -> str:
-        """Write the source data from remote object i/o buffer to the dataset using smart open
+        """Write the source data from dataframe to the dataset using smart open
         :param source_ref: FileStream object of source dataset
         :return: File path that is the used for write pattern
         """

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
@@ -126,7 +126,7 @@ class SFTPDataProvider(BaseFilesystemProviders):
             return self.write_dataframe_using_smart_open(source_ref=source_ref)
 
     def write_file_using_smart_open(self, source_ref: FileStream) -> str:
-        """Write the source data from remote object i/o buffer to the dataset using smart open
+        """Write the remote object i/o buffer to the dataset using smart open
         :param source_ref: FileStream object of source dataset
         :return: File path that is the used for write pattern
         """
@@ -137,7 +137,7 @@ class SFTPDataProvider(BaseFilesystemProviders):
         return self.dataset.path
 
     def write_dataframe_using_smart_open(self, source_ref: pd.DataFrame) -> str:
-        """Write the source data from dataframe to the dataset using smart open
+        """Write the dataframe to the SFTP dataset using smart open
         :param source_ref: FileStream object of source dataset
         :return: File path that is the used for write pattern
         """

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
@@ -9,7 +9,7 @@ import smart_open
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 
 from universal_transfer_operator.constants import Location, TransferMode
-from universal_transfer_operator.data_providers.base import FileStream
+from universal_transfer_operator.data_providers.base import DataStream
 from universal_transfer_operator.data_providers.filesystem.base import BaseFilesystemProviders
 from universal_transfer_operator.datasets.file.base import File
 from universal_transfer_operator.integrations.base import TransferIntegrationOptions
@@ -118,16 +118,16 @@ class SFTPDataProvider(BaseFilesystemProviders):
 
         return urlunparse(final_url)
 
-    def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame):
+    def write_using_smart_open(self, source_ref: DataStream | pd.DataFrame):
         """Write the source data from remote object i/o buffer to the dataset using smart open"""
-        if isinstance(source_ref, FileStream):
+        if isinstance(source_ref, DataStream):
             return self.write_from_file(source_ref=source_ref)
         elif isinstance(source_ref, pd.DataFrame):
             return self.write_from_dataframe(source_ref=source_ref)
 
-    def write_from_file(self, source_ref: FileStream) -> str:
+    def write_from_file(self, source_ref: DataStream) -> str:
         """Write the remote object i/o buffer to the dataset using smart open
-        :param source_ref: FileStream object of source dataset
+        :param source_ref: DataStream object of source dataset
         :return: File path that is the used for write pattern
         """
         mode = "wb" if self.read_as_binary(source_ref.actual_file.path) else "w"
@@ -138,7 +138,7 @@ class SFTPDataProvider(BaseFilesystemProviders):
 
     def write_from_dataframe(self, source_ref: pd.DataFrame) -> str:
         """Write the dataframe to the SFTP dataset using smart open
-        :param source_ref: FileStream object of source dataset
+        :param source_ref: DataStream object of source dataset
         :return: File path that is the used for write pattern
         """
         mode = "wb" if self.read_as_binary(self.dataset.path) else "w"

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
@@ -121,11 +121,11 @@ class SFTPDataProvider(BaseFilesystemProviders):
     def write_using_smart_open(self, source_ref: FileStream | pd.DataFrame):
         """Write the source data from remote object i/o buffer to the dataset using smart open"""
         if isinstance(source_ref, FileStream):
-            return self.write_file_using_smart_open(source_ref=source_ref)
+            return self.write_from_file(source_ref=source_ref)
         elif isinstance(source_ref, pd.DataFrame):
-            return self.write_dataframe_using_smart_open(source_ref=source_ref)
+            return self.write_from_dataframe(source_ref=source_ref)
 
-    def write_file_using_smart_open(self, source_ref: FileStream) -> str:
+    def write_from_file(self, source_ref: FileStream) -> str:
         """Write the remote object i/o buffer to the dataset using smart open
         :param source_ref: FileStream object of source dataset
         :return: File path that is the used for write pattern
@@ -136,7 +136,7 @@ class SFTPDataProvider(BaseFilesystemProviders):
             stream.write(source_ref.remote_obj_buffer.read())
         return self.dataset.path
 
-    def write_dataframe_using_smart_open(self, source_ref: pd.DataFrame) -> str:
+    def write_from_dataframe(self, source_ref: pd.DataFrame) -> str:
         """Write the dataframe to the SFTP dataset using smart open
         :param source_ref: FileStream object of source dataset
         :return: File path that is the used for write pattern

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
@@ -9,7 +9,8 @@ import smart_open
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 
 from universal_transfer_operator.constants import Location, TransferMode
-from universal_transfer_operator.data_providers.filesystem.base import BaseFilesystemProviders, FileStream
+from universal_transfer_operator.data_providers.base import FileStream
+from universal_transfer_operator.data_providers.filesystem.base import BaseFilesystemProviders
 from universal_transfer_operator.datasets.file.base import File
 from universal_transfer_operator.integrations.base import TransferIntegrationOptions
 

--- a/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
+++ b/universal_transfer_operator/src/universal_transfer_operator/data_providers/filesystem/sftp.py
@@ -134,7 +134,7 @@ class SFTPDataProvider(BaseFilesystemProviders):
         complete_url = self.get_complete_url(self.dataset.path, source_ref.actual_file.path)
         with smart_open.open(complete_url, mode=mode, transport_params=self.transport_params) as stream:
             stream.write(source_ref.remote_obj_buffer.read())
-        return complete_url
+        return self.dataset.path
 
     def write_dataframe_using_smart_open(self, source_ref: pd.DataFrame) -> str:
         """Write the source data from dataframe to the dataset using smart open
@@ -145,7 +145,7 @@ class SFTPDataProvider(BaseFilesystemProviders):
         complete_url = self.get_complete_url(self.dataset.path, "")
         with smart_open.open(complete_url, mode=mode, transport_params=self.transport_params) as stream:
             self.dataset.type.create_from_dataframe(stream=stream, df=source_ref)
-        return complete_url
+        return self.dataset.path
 
     @property
     def openlineage_dataset_namespace(self) -> str:

--- a/universal_transfer_operator/tests/test_data_provider/test_filesystem/test_sftp.py
+++ b/universal_transfer_operator/tests/test_data_provider/test_filesystem/test_sftp.py
@@ -42,9 +42,9 @@ def download_file_from_sftp(conn_id: str, local_path: str, remote_path: str):
     )
 
 
-def test_sftp_write():
+def test_sftp_write_with_FileStream():
     """
-    Test to validate working of SFTPDataProvider.write() method
+    Test to validate working of SFTPDataProvider.write() method with FileStream object
     """
     local_filepath = DATA_DIR + "sample.csv"
     file_name = f"{create_unique_str(10)}.csv"
@@ -57,6 +57,28 @@ def test_sftp_write():
         actual_file=File(local_filepath),
     )
     dataprovider.write(source_ref=fs)
+
+    downloaded_file = f"/tmp/{file_name}"
+    download_file_from_sftp(
+        conn_id="sftp_conn", local_path=downloaded_file, remote_path=f"{remote_filepath.split('sftp:/')[1]}"
+    )
+
+    sftp_df = pd.read_csv(downloaded_file)
+    true_df = pd.read_csv(local_filepath)
+    assert sftp_df.equals(true_df)
+
+
+def test_sftp_write_with_dataframe():
+    """
+    Test to validate working of SFTPDataProvider.write() method with dataframe
+    """
+    local_filepath = DATA_DIR + "sample.csv"
+    file_name = f"{create_unique_str(10)}.csv"
+    remote_filepath = f"sftp://upload/{file_name}"
+
+    dataprovider = create_dataprovider(dataset=File(path=remote_filepath, conn_id="sftp_conn"))
+    df = pd.read_csv(local_filepath)
+    dataprovider.write(source_ref=df)
 
     downloaded_file = f"/tmp/{file_name}"
     download_file_from_sftp(

--- a/universal_transfer_operator/tests/test_data_provider/test_filesystem/test_sftp.py
+++ b/universal_transfer_operator/tests/test_data_provider/test_filesystem/test_sftp.py
@@ -5,7 +5,7 @@ from airflow.providers.sftp.hooks.sftp import SFTPHook
 from utils.test_utils import create_unique_str
 
 from universal_transfer_operator.data_providers import create_dataprovider
-from universal_transfer_operator.data_providers.base import FileStream
+from universal_transfer_operator.data_providers.base import DataStream
 from universal_transfer_operator.datasets.file.base import File
 
 CWD = pathlib.Path(__file__).parent
@@ -42,16 +42,16 @@ def download_file_from_sftp(conn_id: str, local_path: str, remote_path: str):
     )
 
 
-def test_sftp_write_with_FileStream():
+def test_sftp_write_with_DataStream():
     """
-    Test to validate working of SFTPDataProvider.write() method with FileStream object
+    Test to validate working of SFTPDataProvider.write() method with DataStream object
     """
     local_filepath = DATA_DIR + "sample.csv"
     file_name = f"{create_unique_str(10)}.csv"
     remote_filepath = f"sftp://upload/{file_name}"
 
     dataprovider = create_dataprovider(dataset=File(path=remote_filepath, conn_id="sftp_conn"))
-    fs = FileStream(
+    fs = DataStream(
         remote_obj_buffer=open(local_filepath),
         actual_filename=local_filepath,
         actual_file=File(local_filepath),

--- a/universal_transfer_operator/tests/test_data_provider/test_filesystem/test_sftp.py
+++ b/universal_transfer_operator/tests/test_data_provider/test_filesystem/test_sftp.py
@@ -5,7 +5,7 @@ from airflow.providers.sftp.hooks.sftp import SFTPHook
 from utils.test_utils import create_unique_str
 
 from universal_transfer_operator.data_providers import create_dataprovider
-from universal_transfer_operator.data_providers.filesystem.base import FileStream
+from universal_transfer_operator.data_providers.base import FileStream
 from universal_transfer_operator.datasets.file.base import File
 
 CWD = pathlib.Path(__file__).parent

--- a/universal_transfer_operator/tests_integration/test_data_provider/test_databases/test_base.py
+++ b/universal_transfer_operator/tests_integration/test_data_provider/test_databases/test_base.py
@@ -121,3 +121,86 @@ def get_complete_url(dataset_provider):
     cred_url = cred_url._replace(netloc=url_netloc, path=url_path)
     path = urlunparse(cred_url)
     return path
+
+
+@pytest.mark.parametrize(
+    "dst_dataset_fixture",
+    [
+        {"name": "SqliteDataProvider"},
+        {"name": "SnowflakeDataProvider"},
+        {"name": "BigqueryDataProvider"},
+    ],
+    indirect=True,
+    ids=lambda db: db["name"],
+)
+def test_load_pandas_dataframe_to_table_with_replace(dst_dataset_fixture):
+    """Load Pandas Dataframe to a SQL table with replace strategy"""
+    dst_dp, dataset = dst_dataset_fixture
+
+    pandas_dataframe = pd.DataFrame(data={"id": [1, 2, 3]})
+    dst_dp.load_pandas_dataframe_to_table(
+        source_dataframe=pandas_dataframe,
+        target_table=dataset,
+    )
+
+    rows = dst_dp.fetch_all_rows(dataset)
+    assert len(rows) == 3
+    assert rows[0] == (1,)
+    assert rows[1] == (2,)
+
+    pandas_dataframe = pd.DataFrame(data={"id": [3, 4]})
+    dst_dp.load_pandas_dataframe_to_table(
+        source_dataframe=pandas_dataframe,
+        target_table=dataset,
+    )
+
+    rows = dst_dp.fetch_all_rows(dataset)
+    assert len(rows) == 2
+    assert rows[0] == (3,)
+    assert rows[1] == (4,)
+
+    dst_dp.drop_table(dataset)
+
+
+@pytest.mark.parametrize(
+    "dst_dataset_fixture",
+    [
+        {"name": "SqliteDataProvider"},
+        {
+            "name": "SnowflakeDataProvider",
+        },
+        {
+            "name": "BigqueryDataProvider",
+        },
+    ],
+    indirect=True,
+    ids=lambda db: db["name"],
+)
+def test_load_pandas_dataframe_to_table_with_append(dst_dataset_fixture):
+    """Load Pandas Dataframe to a SQL table with append strategy"""
+    dst_dp, dataset = dst_dataset_fixture
+
+    pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
+    dst_dp.load_pandas_dataframe_to_table(
+        source_dataframe=pandas_dataframe,
+        target_table=dataset,
+        if_exists="append",
+    )
+
+    rows = dst_dp.fetch_all_rows(dataset)
+    assert len(rows) == 2
+    assert rows[0] == (1,)
+    assert rows[1] == (2,)
+
+    dst_dp.load_pandas_dataframe_to_table(
+        source_dataframe=pandas_dataframe,
+        target_table=dataset,
+        if_exists="append",
+    )
+
+    rows = dst_dp.fetch_all_rows(dataset)
+    assert len(rows) == 4
+    assert rows[0] == (1,)
+    assert rows[1] == (2,)
+
+    dst_dp.drop_table(dataset)

--- a/universal_transfer_operator/tests_integration/test_data_provider/test_databases/test_base.py
+++ b/universal_transfer_operator/tests_integration/test_data_provider/test_databases/test_base.py
@@ -61,13 +61,13 @@ CWD = pathlib.Path(__file__).parent
         {
             "name": "SnowflakeDataProvider",
         },
-        {"name": "S3DataProvider", "object": File(path=f"s3://tmp9/{create_unique_str(10)}")},
+        {"name": "S3DataProvider", "object": File(path=f"s3://tmp9/{create_unique_str(10)}.csv")},
         {
             "name": "GCSDataProvider",
-            "object": File(path=f"gs://uto-test/{create_unique_str(10)}"),
+            "object": File(path=f"gs://uto-test/{create_unique_str(10)}.csv"),
         },
-        {"name": "LocalDataProvider", "object": File(path=f"/tmp/{create_unique_str(10)}")},
-        {"name": "SFTPDataProvider", "object": File(path=f"sftp://upload/{create_unique_str(10)}")},
+        {"name": "LocalDataProvider", "object": File(path=f"/tmp/{create_unique_str(10)}.csv")},
+        {"name": "SFTPDataProvider", "object": File(path=f"sftp://upload/{create_unique_str(10)}.csv")},
     ],
     indirect=True,
     ids=lambda dp: dp["name"],

--- a/universal_transfer_operator/tests_integration/test_data_provider/test_databases/test_snowflake.py
+++ b/universal_transfer_operator/tests_integration/test_data_provider/test_databases/test_snowflake.py
@@ -8,7 +8,7 @@ import sqlalchemy
 from sqlalchemy.exc import ProgrammingError
 
 from universal_transfer_operator.constants import TransferMode
-from universal_transfer_operator.data_providers.base import FileStream
+from universal_transfer_operator.data_providers.base import DataStream
 from universal_transfer_operator.data_providers.database.snowflake import SnowflakeDataProvider
 from universal_transfer_operator.datasets.file.base import File
 from universal_transfer_operator.datasets.table import Metadata, Table
@@ -145,7 +145,7 @@ def test_write_method(dataset_table_fixture):
     """Test write() for snowflake"""
     dp, table = dataset_table_fixture
     file_path = f"{str(CWD)}/../../data/sample.csv"
-    fs = FileStream(
+    fs = DataStream(
         remote_obj_buffer=file_path,
         actual_file=File(
             path=file_path,

--- a/universal_transfer_operator/tests_integration/test_data_provider/test_databases/test_snowflake.py
+++ b/universal_transfer_operator/tests_integration/test_data_provider/test_databases/test_snowflake.py
@@ -8,8 +8,8 @@ import sqlalchemy
 from sqlalchemy.exc import ProgrammingError
 
 from universal_transfer_operator.constants import TransferMode
+from universal_transfer_operator.data_providers.base import FileStream
 from universal_transfer_operator.data_providers.database.snowflake import SnowflakeDataProvider
-from universal_transfer_operator.data_providers.filesystem.base import FileStream
 from universal_transfer_operator.datasets.file.base import File
 from universal_transfer_operator.datasets.table import Metadata, Table
 from universal_transfer_operator.settings import SNOWFLAKE_SCHEMA


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, when loading data from a database we are saving data in a parquet file. Due to which the data when transferring data from the database to the filesystem, we were limited to the parquet file type.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
Now, we have to change the interface of read() also to give an output of data frame and write() to consume data frame for csv, JSON, ndjson, and parquet file type. This gives us the freedom to convert the data in any format we prefer csv, Json, Ndjson or Parquet. 

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
