### PR TITLE
Raise error when remote storage connection is unset for large dataframes

### DIFF
--- a/python-sdk/src/astro/dataframes/pandas.py
+++ b/python-sdk/src/astro/dataframes/pandas.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from pandas import DataFrame, read_json
 
 from astro import settings
+from astro.exceptions import AstroSDKConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,13 @@ class PandasDataframe(DataFrame):
             logger.info("Dataframe size: %s bytes. Storing it in Airflow's metadata DB", df_size)
             return {"data": self.to_json()}
         else:
+            if settings.DATAFRAME_STORAGE_CONN_ID is None:
+                raise AstroSDKConfigError(
+                    "Dataframe size exceeds allowed limit for storing in Airflow's metadata DB. "
+                    "Airflow config variable AIRFLOW__ASTRO_SDK__XCOM_STORAGE_CONN_ID needs to "
+                    "be set for remote storage of the dataframe."
+                )
+
             # Avoid cyclic dependency
             from astro.utils.dataframe import convert_dataframe_to_file
 

--- a/python-sdk/src/astro/exceptions.py
+++ b/python-sdk/src/astro/exceptions.py
@@ -24,3 +24,7 @@ class DatabaseCustomError(ValueError, AttributeError):
 
 class PermissionNotSetError(Exception):
     """Raised if a permission to files present in locations are not accessible"""
+
+
+class AstroSDKConfigError(Exception):
+    """Raised if a configuration parameter required for Astro SDK is not set correctly"""

--- a/python-sdk/tests/dataframes/test_pandas.py
+++ b/python-sdk/tests/dataframes/test_pandas.py
@@ -2,7 +2,7 @@ from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import pandas as pd
-import pytest as pytest
+import pytest
 
 from astro import settings
 from astro.dataframes.pandas import PandasDataframe

--- a/python-sdk/tests/dataframes/test_pandas.py
+++ b/python-sdk/tests/dataframes/test_pandas.py
@@ -1,9 +1,12 @@
+from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import pandas as pd
+import pytest as pytest
 
 from astro import settings
 from astro.dataframes.pandas import PandasDataframe
+from astro.exceptions import AstroSDKConfigError
 
 
 def test_from_pandas_df():
@@ -26,7 +29,14 @@ def test_from_pandas_df_returns_pandas_type():
     assert df.equals(astro_df)
 
 
-def test_serialize_deserialize_with_larger_df(tmp_path):
+@pytest.mark.parametrize(
+    "expectation,conn_id",
+    [
+        [does_not_raise(), "df_storage_conn_id"],
+        [pytest.raises(AstroSDKConfigError), None],
+    ],
+)
+def test_serialize_deserialize_with_larger_df(tmp_path, expectation, conn_id):
     """
     Test that we do not store the entire dataframe in DB if it is greater and we can correctly
     serialize and deserialize it
@@ -35,33 +45,36 @@ def test_serialize_deserialize_with_larger_df(tmp_path):
     temp_dir.mkdir()
     assert [f for f in temp_dir.iterdir() if f.is_file()] == []
 
-    # Set the max size to allow storing Dataframe in DB to be 50kb
-    with mock.patch("astro.dataframes.pandas.settings.MAX_DATAFRAME_MEMORY_FOR_XCOM_DB", new=50), mock.patch(
-        "astro.utils.dataframe.settings.DATAFRAME_STORAGE_URL", new=str(temp_dir)
-    ):
-        # Create dataframe that is greater than 50kb
-        records = [{"id": i, "name": "xyz"} for i in range(1000)]
-        df = PandasDataframe(records)
-        # Assert that size of DF> 50kb
-        assert df.memory_usage(deep=True).sum() > (50 * 1024)
-        # Test that the serialize method will not serialize all the dataframe records to string
-        # and instead create a file object and store the records in a file
-        s_df = df.serialize()
-        assert s_df == {
-            "class": "File",
-            "conn_id": None,
-            "path": mock.ANY,
-            "filetype": "parquet",
-            "normalize_config": None,
-            "is_dataframe": True,
-        }
+    with expectation:
+        # Set the max size to allow storing Dataframe in DB to be 50kb
+        with mock.patch(
+            "astro.dataframes.pandas.settings.MAX_DATAFRAME_MEMORY_FOR_XCOM_DB", new=50
+        ), mock.patch("astro.utils.dataframe.settings.DATAFRAME_STORAGE_URL", new=str(temp_dir)), mock.patch(
+            "astro.utils.dataframe.settings.DATAFRAME_STORAGE_CONN_ID", new=conn_id
+        ):
+            # Create dataframe that is greater than 50kb
+            records = [{"id": i, "name": "xyz"} for i in range(1000)]
+            df = PandasDataframe(records)
+            # Assert that size of DF> 50kb
+            assert df.memory_usage(deep=True).sum() > (50 * 1024)
+            # Test that the serialize method will not serialize all the dataframe records to string
+            # and instead create a file object and store the records in a file
+            s_df = df.serialize()
+            assert s_df == {
+                "class": "File",
+                "conn_id": conn_id,
+                "path": mock.ANY,
+                "filetype": "parquet",
+                "normalize_config": None,
+                "is_dataframe": True,
+            }
 
-        # Test that a parquet file is created
-        file_in_dir = [f for f in temp_dir.iterdir() if f.is_file() and f.name.endswith(".parquet")]
-        assert file_in_dir
+            # Test that a parquet file is created
+            file_in_dir = [f for f in temp_dir.iterdir() if f.is_file() and f.name.endswith(".parquet")]
+            assert file_in_dir
 
-        # Test that we are able to get a dataframe back
-        assert df.equals(PandasDataframe.deserialize(s_df, version=1))
+            # Test that we are able to get a dataframe back
+            assert df.equals(PandasDataframe.deserialize(s_df, version=1))
 
 
 def test_serialize_deserialize_with_smaller_df():


### PR DESCRIPTION
# Description
## What is the current behavior?
With aql.dataframe, in case of large dataframes that cannot be stored in Airflow metadata DB, they are silently 
stored on local machines without warning and are unavailable for subsequent tasks via XCOM.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->
closes: #1839 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Astro SDK allows setting an Airflow config variable AIRFLOW__ASTRO_SDK__XCOM_STORAGE_CONN_ID
to allow dataframes to be stored in a remote location using the connection and hence making it possible
for subsequent tasks to use that remotely stored dataframe for it's inputs. However, if this connection ID is
not set, we were not alerting the user to set it and were instead silently storing the dataframe on the local machine.
We now raise an exception in case the dataframe is large enough that it cannot be stored in Airflow's Metadata DB and 
that the remote storage connection ID is unset.

## Does this introduce a breaking change?
No.

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
