### PR TITLE
Allow `aql.transform` to receive `sql` filepath (fix breaking change)

### DIFF
--- a/python-sdk/src/astro/sql/operators/base_decorator.py
+++ b/python-sdk/src/astro/sql/operators/base_decorator.py
@@ -214,6 +214,7 @@ class BaseSQLDecoratedOperator(UpstreamTaskMixin, DecoratedOperator):
         if self.sql.endswith(".sql"):
             with open(self.sql) as file:
                 self.sql = file.read().replace("\n", " ")
+        self.op_kwargs.pop("sql", None)
 
     def move_function_params_into_sql_params(self, context: dict) -> None:
         """

--- a/python-sdk/tests_integration/sql/operators/transform/test_transform.py
+++ b/python-sdk/tests_integration/sql/operators/transform/test_transform.py
@@ -315,17 +315,19 @@ def test_transform_astro_data_team(database_table_fixture, sample_dag):
         temp_file.flush()
 
         with sample_dag:
-            table_from_inline_sql = aql.transform(
-               conn_id="sqlite_default",
-               task_id="table_from_inline_sql",
-            )(query)(sql=sample_query)
+            aql.transform(
+                conn_id="sqlite_default",
+                task_id="table_from_inline_sql",
+            )(
+                query
+            )(sql=sample_query)
 
-            table_from_sql_file = aql.transform(
+            aql.transform(
                 conn_id="sqlite_default",
                 task_id="table_from_sql_file",
-            )(query)(sql=temp_file.name)
-
-            table_from_inline_sql >> table_from_sql_file
+            )(
+                query
+            )(sql=temp_file.name)
 
         test_utils.run_dag(sample_dag)
 


### PR DESCRIPTION
Fix `aql.transform` breaking change (pass a `.sql` file to the `sql` argument).

This PR contains:
1) Test case which illustrates data team's usage of `aql.transform`, which raises an exception in 1.5.3 (and used to work in 1.3.3)
2) Bug fix that allows users to continue using the Python SDK as they used with Python SDK 1.3.3.

Astronomer's Data team raised this issue in an internal slack: https://astronomer.slack.com/archives/C02B.8SPT93K/p1680202480707669

The alternative to this solution is to use `aql.transform_file`. However, since this feature was working before and stopped working between minor releases, we opted to fix it as well.