### PR TITLE
Fix failing test - test_aql_load_file_local_file_pattern_dataframe on CI

### DIFF
--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -174,4 +174,5 @@ Contributors and maintainers should abide by the [Contributor Code of Conduct](C
 
 ## License
 
+
 [Apache Licence 2.0](LICENSE)

--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -174,5 +174,4 @@ Contributors and maintainers should abide by the [Contributor Code of Conduct](C
 
 ## License
 
-
 [Apache Licence 2.0](LICENSE)

--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -356,7 +356,8 @@ def test_aql_load_file_local_file_pattern_dataframe(sample_dag):
     def validate(input_df):
         assert isinstance(input_df, pd.DataFrame)
         assert test_df.shape == input_df.shape
-        assert test_df.sort_values("sell").equals(input_df.sort_values("sell"))
+        # assert test_df.sort_values("sell").equals(input_df.sort_values("sell"))
+        assert test_df.equals(input_df)
         print(input_df)
 
     with sample_dag:

--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -356,7 +356,6 @@ def test_aql_load_file_local_file_pattern_dataframe(sample_dag):
     def validate(input_df):
         assert isinstance(input_df, pd.DataFrame)
         assert test_df.shape == input_df.shape
-        # assert test_df.sort_values("sell").equals(input_df.sort_values("sell"))
         assert test_df.equals(input_df)
         print(input_df)
 

--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -356,7 +356,9 @@ def test_aql_load_file_local_file_pattern_dataframe(sample_dag):
     def validate(input_df):
         assert isinstance(input_df, pd.DataFrame)
         assert test_df.shape == input_df.shape
-        assert test_df.equals(input_df)
+        assert test_df.sort_values("sell", ignore_index=True).equals(
+            input_df.sort_values("sell", ignore_index=True)
+        )
         print(input_df)
 
     with sample_dag:


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, the test case is failing on the main branch - `test_aql_load_file_local_file_pattern_dataframe`. 

## What is the new behavior?
A test case is failing because the index was considered in the equality test when using `sort_value()`. With this change we are ignoring the index. Since we are concatenating two files, if the files are concatenated in the right order we have a test passing if they don't it fails. 

## Does this introduce a breaking change?
Nope

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
