### PR TITLE
Add the ability to access context variables via function parameters in sql and pandas functions

### DIFF
--- a/python-sdk/src/astro/utils/table.py
+++ b/python-sdk/src/astro/utils/table.py
@@ -49,8 +49,8 @@ def _find_first_table_from_op_kwargs(
     """
     kwargs = [
         op_kwargs[kwarg.name].resolve(context)
-        if isinstance(op_kwargs[kwarg.name], XComArg)
-        else op_kwargs[kwarg.name]
+        if isinstance(op_kwargs.get(kwarg.name), XComArg)
+        else op_kwargs.get(kwarg.name)
         for kwarg in inspect.signature(python_callable).parameters.values()
     ]
     tables = [kwarg for kwarg in kwargs if isinstance(kwarg, BaseTable)]

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pandas
 import pytest
+from airflow.operators.python import get_current_context
 
 from astro import sql as aql
 
@@ -98,6 +99,23 @@ def test_run_sql_called_handler(run_sql, results_as_pandas_dataframe, sample_dag
         def dummy_method():
             return "SELECT 1+1"
 
+        dummy_method()
+    test_utils.run_dag(sample_dag)
+
+
+def test_run_sql_parameters(sample_dag):
+    """
+    Test that run_sql can access Airflow parameters
+    """
+
+    @aql.run_raw_sql(conn_id="sqlite_default")
+    def dummy_method(ds=None, execution_date=None):
+        context = get_current_context()
+        assert ds == context["ds"]
+        assert execution_date == context["execution_date"]
+        return "SELECT 1+1"
+
+    with sample_dag:
         dummy_method()
     test_utils.run_dag(sample_dag)
 


### PR DESCRIPTION
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

Currently, users cannot access Airflow context variables directly via function parameters. 
To access context variables, users must rely on the `get_current_context()` method.

CLOSES: #812 
## What is the new behavior?

This PR enables users to access Airflow context variables directly via function parameters, making it more consistent with the Taskflow API. Users can now pass context variables as function parameters, as shown in the example below:

```python
@aql.dataframe
def validate_file_and_context(df: pandas.DataFrame, ds=None, execution_date=None):  # skipcq: PY-D0003
    context = get_current_context()
    assert ds == context["ds"]
    assert execution_date == context["execution_date"]
```

## Does this introduce a breaking change?

No

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
