### PR TITLE
Allow users to disable schema check and creation on `load_file`

### DIFF
--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -359,7 +359,7 @@ class BaseDatabase(ABC):
     # Table load methods
     # ---------------------------------------------------------
 
-    def create_schema_and_table_if_needed(
+    def create_table_if_needed(
         self,
         table: BaseTable,
         file: File,
@@ -393,7 +393,6 @@ class BaseDatabase(ABC):
         ):
             return
 
-        self.create_schema_if_needed(table.metadata.schema)
         if if_exists == "replace" or not self.table_exists(table):
             files = resolve_file_path_pattern(
                 file.path,
@@ -474,7 +473,9 @@ class BaseDatabase(ABC):
             )
             use_native_support = False
 
-        self.create_schema_and_table_if_needed(
+        self.create_schema_if_needed(output_table.metadata.schema)
+
+        self.create_table_if_needed(
             file=input_file,
             table=output_table,
             columns_names_capitalization=columns_names_capitalization,


### PR DESCRIPTION
Support running `load_file` without checking if the table schema exists or trying to create it.

Introduces the argument `schema_exists`. This argument is `False` by default, and the Python SDK will behave as of 1.6 (running schema check & creation queries if needed). When this argument is `True`, the SDK will not run any checks.

Recently a user reported that the cost of checking if the schema exists is very high for Snowflake:
"I have a (`load_file`) task that took 1:36 minutes to run, and it was 1:30 running the information schema query."
This is likely happening for other databases as well.

Closes: #1921