### PR TITLE
Refactor `assume_schema_exists` and expose it in `aql.transform`

### DIFF
--- a/python-sdk/conftest.py
+++ b/python-sdk/conftest.py
@@ -82,7 +82,7 @@ def database_table_fixture(request):
     file = params.get("file")
 
     database.populate_table_metadata(table)
-    database.create_schema_if_needed(table.metadata.schema)
+    database.create_schema_if_applicable(table.metadata.schema)
 
     if file:
         database.load_file_to_table(file, table)

--- a/python-sdk/docs/CHANGELOG.md
+++ b/python-sdk/docs/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 1.7.0a1
+## 1.7.0a2
 
 ### Feature
+- Allow users to disable schema check and creation on `transform` [#1925](https://github.com/astronomer/astro-sdk/pull/1925)
 - Allow users to disable schema check and creation on `load_file` [#1922](https://github.com/astronomer/astro-sdk/pull/1922)
 
 ## 1.6.0

--- a/python-sdk/docs/astro/sql/operators/load_file.rst
+++ b/python-sdk/docs/astro/sql/operators/load_file.rst
@@ -43,7 +43,7 @@ Parameters to use when loading a file to a database table
 
     Note that if you use ``if_exists='replace'``, the existing table will be dropped and the schema of the new data will be used.
 
-#. **schema_exists** (default is False) - By default, the SDK checks if the schema of the target table exists, and if not, it tries to create it. This query can be costly. This argument makes the SDK skip this check, since the user is informing the schema already exists.
+#. **assume_schema_exists** (default is False) - By default, the SDK checks if the schema of the target table exists, and if not, it tries to create it. This query can be costly. This argument makes the SDK skip this check, since the user is informing the schema already exists.
 
 #. **output_table** - This parameter defines the output table to load data to, which should be an instance of ``astro.sql.table.Table``. You can specify the schema of the table by providing a list of the instance of ``sqlalchemy.Column <https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.Column>`` to the ``columns`` parameter. If you don't specify a schema, it will be inferred using Pandas.
 

--- a/python-sdk/docs/configurations.rst
+++ b/python-sdk/docs/configurations.rst
@@ -48,11 +48,11 @@ or by updating Airflow's configuration
 Configuring if schemas existence should be checked and if the SDK should create them
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, during ``aql.load_file``, the SDK checks if the schema of the target table exists, and if not, it tries to create it. This type of check can be costly.
+By default, during ``aql.load_file`` and ``aql.transform``, the SDK checks if the schema of the target table exists, and if not, it tries to create it. This type of check can be costly.
 
-The configuration ``AIRFLOW__ASTRO_SDK__LOAD_TABLE_SCHEMA_EXISTS`` allows users to inform the SDK that the schema already exists, skipping this check for all ``load_file`` tasks.
+The configuration ``AIRFLOW__ASTRO_SDK__ASSUME_SCHEMA_EXISTS`` allows users to inform the SDK that the schema already exists, skipping this check for all ``load_file`` and ``transform`` tasks.
 
-The user can also have a more granular control, by defining the ``load_file`` argument ``schema_exists`` on a per-task basis :ref:load_file.
+The user can also have a more granular control, by defining the ``load_file`` argument ``assume_schema_exists`` on a per-task basis :ref:load_file.
 
 Example of how to disable schema existence check using environment variables:
 

--- a/python-sdk/docs/configurations.rst
+++ b/python-sdk/docs/configurations.rst
@@ -58,14 +58,14 @@ Example of how to disable schema existence check using environment variables:
 
 .. code:: ini
 
-   AIRFLOW__ASTRO_SDK__LOAD_TABLE_SCHEMA_EXISTS = True
+   AIRFLOW__ASTRO_SDK__ASSUME_SCHEMA_EXISTS = True
 
 Or using Airflow's configuration file:
 
 .. code:: ini
 
    [astro_sdk]
-   load_table_schema_exists = True
+   assume_schema_exists = True
 
 
 Configuring the unsafe dataframe storage

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -13,13 +13,13 @@ from astro.options import SnowflakeLoadOptions
 from astro.table import Metadata, Table
 
 
-@aql.transform()
+@aql.transform(assume_schema_exists=True)
 def combine_data(center_1: Table, center_2: Table):
     return """SELECT * FROM {{center_1}}
     UNION SELECT * FROM {{center_2}}"""
 
 
-@aql.transform()
+@aql.transform(assume_schema_exists=True)
 def clean_data(input_table: Table):
     return """SELECT *
     FROM {{input_table}} WHERE type NOT LIKE 'Guinea Pig'

--- a/python-sdk/example_dags/example_snowflake_partial_table_with_append.py
+++ b/python-sdk/example_dags/example_snowflake_partial_table_with_append.py
@@ -85,7 +85,7 @@ def example_snowflake_partial_table_with_append():
                 schema=os.getenv("SNOWFLAKE_SCHEMA"),
             ),
         ),
-        schema_exists=True,  # Skip queries that check if the table schema exist
+        assume_schema_exists=True,  # Skip queries that check if the table schema exist
     )
 
     homes_data2 = load_file(
@@ -97,7 +97,7 @@ def example_snowflake_partial_table_with_append():
                 schema=os.getenv("SNOWFLAKE_SCHEMA"),
             ),
         ),
-        schema_exists=True,
+        assume_schema_exists=True,
     )
 
     # Define task dependencies

--- a/python-sdk/src/astro/__init__.py
+++ b/python-sdk/src/astro/__init__.py
@@ -1,6 +1,6 @@
 """A decorator that allows users to run SQL queries natively in Airflow."""
 
-__version__ = "1.7.0a1"
+__version__ = "1.7.0a2"
 
 
 # This is needed to allow Airflow to pick up specific metadata fields it needs

--- a/python-sdk/src/astro/databases/databricks/delta.py
+++ b/python-sdk/src/astro/databases/databricks/delta.py
@@ -22,7 +22,7 @@ from astro.dataframes.pandas import PandasDataframe
 from astro.files import File
 from astro.options import LoadOptions
 from astro.query_modifier import QueryModifier
-from astro.settings import LOAD_TABLE_SCHEMA_EXISTS
+from astro.settings import ASSUME_SCHEMA_EXISTS
 from astro.table import BaseTable, Metadata
 
 
@@ -124,10 +124,17 @@ class DeltaDatabase(BaseDatabase):
         native_support_kwargs: dict | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
         enable_native_fallback: bool | None = None,
-        schema_exists: bool = LOAD_TABLE_SCHEMA_EXISTS,
+        assume_schema_exists: bool = ASSUME_SCHEMA_EXISTS,
         databricks_job_name: str = "",
         **kwargs,
     ):
+        load_file_to_delta(
+            input_file=input_file,
+            delta_table=output_table,
+            databricks_job_name=databricks_job_name,
+            delta_load_options=self.load_options,  # type: ignore
+            if_exists=if_exists,
+        )
         """
         Load content of multiple files in output_table.
         Multiple files are sourced from the file path, which can also be path pattern.
@@ -144,15 +151,8 @@ class DeltaDatabase(BaseDatabase):
         :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
         :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
-        :param schema_exists: Declare the table schema already exists and that load_file should not check if it exists
+        :param assume_schema_exists: If True, skips check to see if output_table schema exists
         """
-        load_file_to_delta(
-            input_file=input_file,
-            delta_table=output_table,
-            databricks_job_name=databricks_job_name,
-            delta_load_options=self.load_options,  # type: ignore
-            if_exists=if_exists,
-        )
 
     def openlineage_dataset_name(self, table: BaseTable) -> str:
         return ""

--- a/python-sdk/src/astro/databases/databricks/delta.py
+++ b/python-sdk/src/astro/databases/databricks/delta.py
@@ -95,7 +95,9 @@ class DeltaDatabase(BaseDatabase):
         # Schemas do not need to be created for delta, so we can assume this is true
         return True
 
-    def create_schema_if_needed(self, schema: str | None) -> None:  # skipcq: PYL-W0613
+    def create_schema_if_applicable(
+        self, schema: str | None, assume_exists: bool = ASSUME_SCHEMA_EXISTS
+    ) -> None:  # skipcq: PYL-W0613
         # Schemas do not need to be created for delta, so we don't need to do anything here
         return None
 
@@ -128,13 +130,6 @@ class DeltaDatabase(BaseDatabase):
         databricks_job_name: str = "",
         **kwargs,
     ):
-        load_file_to_delta(
-            input_file=input_file,
-            delta_table=output_table,
-            databricks_job_name=databricks_job_name,
-            delta_load_options=self.load_options,  # type: ignore
-            if_exists=if_exists,
-        )
         """
         Load content of multiple files in output_table.
         Multiple files are sourced from the file path, which can also be path pattern.
@@ -153,6 +148,13 @@ class DeltaDatabase(BaseDatabase):
         :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
         :param assume_schema_exists: If True, skips check to see if output_table schema exists
         """
+        load_file_to_delta(
+            input_file=input_file,
+            delta_table=output_table,
+            databricks_job_name=databricks_job_name,
+            delta_load_options=self.load_options,  # type: ignore
+            if_exists=if_exists,
+        )
 
     def openlineage_dataset_name(self, table: BaseTable) -> str:
         return ""

--- a/python-sdk/src/astro/databases/postgres.py
+++ b/python-sdk/src/astro/databases/postgres.py
@@ -103,7 +103,7 @@ class PostgresDatabase(BaseDatabase):
         """
         self._assert_not_empty_df(source_dataframe)
 
-        self.create_schema_if_needed(target_table.metadata.schema)
+        self.create_schema_if_applicable(target_table.metadata.schema)
         if not self.table_exists(table=target_table) or if_exists == "replace":
             self.create_table(table=target_table, dataframe=source_dataframe)
 

--- a/python-sdk/src/astro/settings.py
+++ b/python-sdk/src/astro/settings.py
@@ -75,15 +75,15 @@ RAW_SQL_MAX_RESPONSE_SIZE = conf.getint(section=SECTION_KEY, key="run_raw_sql_re
 # Should Astro SDK automatically add inlets/outlets to take advantage of Airflow 2.4 Data-aware scheduling
 AUTO_ADD_INLETS_OUTLETS = conf.getboolean(SECTION_KEY, "auto_add_inlets_outlets", fallback=True)
 
-LOAD_TABLE_SCHEMA_EXISTS = False
+ASSUME_SCHEMA_EXISTS = False
 
 
 def reload():
     """
     Reload settings from environment variable during runtime.
     """
-    global LOAD_TABLE_SCHEMA_EXISTS  # skipcq: PYL-W0603
-    LOAD_TABLE_SCHEMA_EXISTS = conf.getboolean(SECTION_KEY, "load_table_schema_exists", fallback=False)
+    global ASSUME_SCHEMA_EXISTS  # skipcq: PYL-W0603
+    ASSUME_SCHEMA_EXISTS = conf.getboolean(SECTION_KEY, "assume_schema_exists", fallback=False)
 
 
 reload()

--- a/python-sdk/src/astro/sql/operators/load_file.py
+++ b/python-sdk/src/astro/sql/operators/load_file.py
@@ -47,7 +47,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
     :param columns_names_capitalization: determines whether to convert all columns to lowercase/uppercase
             in the resulting dataframe
     :param enable_native_fallback: Use enable_native_fallback=True to fall back to default transfer
-    :param schema_exists: Declare the table schema already exists and that load_file should not check if it exists
+    :param assume_schema_exists: If True, skips check to see if output_table schema exists
 
     :return: If ``output_table`` is passed this operator returns a Table object. If not
         passed, returns a dataframe.
@@ -67,7 +67,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         load_options: LoadOptions | list[LoadOptions] | None = None,
         columns_names_capitalization: ColumnCapitalization = "original",
         enable_native_fallback: bool | None = settings.LOAD_FILE_ENABLE_NATIVE_FALLBACK,
-        schema_exists: bool = settings.LOAD_TABLE_SCHEMA_EXISTS,
+        assume_schema_exists: bool = settings.ASSUME_SCHEMA_EXISTS,
         **kwargs,
     ) -> None:
         kwargs.setdefault("task_id", get_unique_task_id("load_file"))
@@ -114,7 +114,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
         self.native_support_kwargs: dict[str, Any] = native_support_kwargs or {}
         self.columns_names_capitalization = columns_names_capitalization
         self.enable_native_fallback = enable_native_fallback
-        self.schema_exists = schema_exists
+        self.assume_schema_exists = assume_schema_exists
         self.load_options_list = LoadOptionsList(load_options)
 
     def execute(self, context: Context) -> BaseTable | File:  # skipcq: PYL-W0613
@@ -162,7 +162,7 @@ class LoadFileOperator(AstroSQLBaseOperator):
             native_support_kwargs=self.native_support_kwargs,
             columns_names_capitalization=self.columns_names_capitalization,
             enable_native_fallback=self.enable_native_fallback,
-            schema_exists=self.schema_exists,
+            assume_schema_exists=self.assume_schema_exists,
             databricks_job_name=f"Load data {self.dag_id}_{self.task_id}",
         )
         self.log.info("Completed loading the data into %s.", self.output_table)

--- a/python-sdk/tests/databases/test_mssql.py
+++ b/python-sdk/tests/databases/test_mssql.py
@@ -5,7 +5,7 @@ from astro.databases.mssql import MssqlDatabase
 
 @mock.patch("astro.databases.mssql.MssqlDatabase.schema_exists", return_value=False)
 @mock.patch("astro.databases.mssql.MssqlDatabase.run_sql")
-def test_create_schema_if_needed(mock_run_sql, mock_schema_exists):
+def test_create_schema_if_applicable(mock_run_sql, mock_schema_exists):
     """
     Test that run_sql is called with expected arguments when
     create_schema_if_needed method is called when the schema is not available
@@ -18,6 +18,5 @@ def test_create_schema_if_needed(mock_run_sql, mock_schema_exists):
     BEGIN
         EXEC( 'CREATE SCHEMA non-existing-schema' );
     END
-    """,
-        autocommit=True,
+    """
     )

--- a/python-sdk/tests/databases/test_mssql.py
+++ b/python-sdk/tests/databases/test_mssql.py
@@ -11,7 +11,7 @@ def test_create_schema_if_needed(mock_run_sql, mock_schema_exists):
     create_schema_if_needed method is called when the schema is not available
     """
     db = MssqlDatabase(conn_id="fake_conn_id")
-    db.create_schema_if_needed("non-existing-schema")
+    db.create_schema_if_applicable("non-existing-schema")
     mock_run_sql.assert_called_once_with(
         """
     IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'non-existing-schema')

--- a/python-sdk/tests/databases/test_snowflake.py
+++ b/python-sdk/tests/databases/test_snowflake.py
@@ -236,5 +236,5 @@ def test_load_file_to_table_skips_schema_check():
 
     file_ = File(path=LOCAL_CSV_FILE)
     table = Table(conn_id="fake-conn", metadata=Metadata(schema="abc"))
-    database.load_file_to_table(input_file=file_, output_table=table, schema_exists=True)
+    database.load_file_to_table(input_file=file_, output_table=table, assume_schema_exists=True)
     assert not database.hook.run.call_count

--- a/python-sdk/tests/test_settings.py
+++ b/python-sdk/tests/test_settings.py
@@ -11,7 +11,7 @@ def test_settings_load_table_schema_exists_default():
     from astro.sql import LoadFileOperator
 
     load_file = LoadFileOperator(input_file=File("dummy.csv"))
-    assert not load_file.schema_exists
+    assert not load_file.assume_schema_exists
 
 
 @patch.dict(os.environ, {"AIRFLOW__ASTRO_SDK__ASSUME_SCHEMA_EXISTS": "True"})
@@ -19,4 +19,4 @@ def test_settings_load_table_schema_exists_override():
     settings.reload()
     importlib.reload(astro.sql.operators.load_file)
     load_file = astro.sql.operators.load_file.LoadFileOperator(input_file=File("dummy.csv"))
-    assert load_file.schema_exists
+    assert load_file.assume_schema_exists

--- a/python-sdk/tests/test_settings.py
+++ b/python-sdk/tests/test_settings.py
@@ -14,7 +14,7 @@ def test_settings_load_table_schema_exists_default():
     assert not load_file.schema_exists
 
 
-@patch.dict(os.environ, {"AIRFLOW__ASTRO_SDK__LOAD_TABLE_SCHEMA_EXISTS": "True"})
+@patch.dict(os.environ, {"AIRFLOW__ASTRO_SDK__ASSUME_SCHEMA_EXISTS": "True"})
 def test_settings_load_table_schema_exists_override():
     settings.reload()
     importlib.reload(astro.sql.operators.load_file)

--- a/python-sdk/tests_integration/conftest.py
+++ b/python-sdk/tests_integration/conftest.py
@@ -88,7 +88,7 @@ def database_temp_table_fixture(request):
     temp_table = TempTable(conn_id=database.conn_id)
 
     database.populate_table_metadata(temp_table)
-    database.create_schema_if_needed(temp_table.metadata.schema)
+    database.create_schema_if_applicable(temp_table.metadata.schema)
     yield database, temp_table
     database.drop_table(temp_table)
 
@@ -136,7 +136,7 @@ def multiple_tables_fixture(request, database_table_fixture):
         file = item.get("file")
 
         database.populate_table_metadata(table)
-        database.create_schema_if_needed(table.metadata.schema)
+        database.create_schema_if_applicable(table.metadata.schema)
         if file:
             database.load_file_to_table(
                 file,

--- a/python-sdk/tests_integration/databases/test_base_database.py
+++ b/python-sdk/tests_integration/databases/test_base_database.py
@@ -92,7 +92,7 @@ def test_load_file_to_table_natively(sample_dag, database_table_fixture, remote_
 
 @pytest.mark.integration
 @mock.patch("astro.databases.base.BaseDatabase.drop_table")
-@mock.patch("astro.databases.base.BaseDatabase.create_schema_if_needed")
+@mock.patch("astro.databases.base.BaseDatabase.create_schema_if_applicable")
 @mock.patch("astro.databases.base.BaseDatabase.create_table")
 @mock.patch("astro.databases.base.BaseDatabase.load_file_to_table_natively_with_fallback")
 @mock.patch("astro.databases.base.resolve_file_path_pattern")

--- a/python-sdk/tests_integration/sql/operators/test_load_file.py
+++ b/python-sdk/tests_integration/sql/operators/test_load_file.py
@@ -1520,7 +1520,7 @@ def test_load_file_snowflake_azure_native_path(sample_dag, database_table_fixtur
 )
 @mock.patch("astro.databases.base.BaseDatabase.load_file_to_table_using_pandas")
 @mock.patch("astro.databases.base.resolve_file_path_pattern")
-@mock.patch("astro.databases.base.BaseDatabase.create_schema_if_needed")
+@mock.patch("astro.databases.base.BaseDatabase.create_schema_if_applicable")
 @mock.patch("astro.databases.base.BaseDatabase.drop_table")
 @mock.patch("astro.databases.snowflake.SnowflakeDatabase.create_table_using_schema_autodetection")
 @mock.patch("astro.databases.base.BaseDatabase.is_native_autodetect_schema_available")
@@ -1528,7 +1528,7 @@ def test_table_creation_and_population_done_via_pandas_path(
     is_native_autodetect_schema_available,
     load_file_to_table_using_pandas,
     resolve_file_path_pattern,
-    create_schema_if_needed,
+    create_schema_if_applicable,
     drop_table,
     create_table_using_schema_autodetection,
     sample_dag,


### PR DESCRIPTION
This is a follow-up for #1922. In that PR we allowed users to skip schema check & creation for `aql.load_file`, but we missed the fact that `aql.transform` and `aql.transform_file` had the same issue. This PR aims to address this limitation.

Changes included in this PR:
* Rename config `load_table_schema_exists` to `assume_schema_exists`
* Rename (`load_file`) argument `schema_exists` to `assume_schema_exists`
* Refactor where the check for `assume_schema_exists` happens. Before, it happened only inside the `load_file_to_table`. Now, it is part of `create_schema_if_applicable`. This makes this feature available in the `aql.transform` task as well
* Rename `Database.create_schema_if_needed` to `Database.create_schema_if_applicable`
* Expose `assume_schema_exists` in `aql.transform`
* Release 1.7.0a2