### PR TITLE
Add `mysql` dependences  in dev Dockerfile

### DIFF
--- a/python-sdk/dev/Dockerfile
+++ b/python-sdk/dev/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get install -y --no-install-recommends \
         libsasl2-modules \
         freetds-dev \
         libssl-dev \
-        libkrb5-dev
+        libkrb5-dev \
+        libmariadb-dev
 
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 


### PR DESCRIPTION
The command `make container target=build-run` is failing due to below error on local dev environment.
This PR resolves it by adding the dependency to the dev Dockerfile

#0 27.87         File "/tmp/pip-install-dbzietu6/mysqlclient_5cc72f3ff0094519a046c7f1ebeebee2/setup_posix.py", line 31, in mysql_config
#0 27.87           raise OSError("{} not found".format(_mysql_config_path))
#0 27.87       OSError: mysql_config not found
