### PR TITLE
Override redshift default conn

### DIFF
--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -82,6 +82,18 @@ connections:
     port: 5439
     login: $REDSHIFT_USERNAME
     password: $REDSHIFT_PASSWORD
+  - conn_id: redshift_default
+    conn_type: redshift
+    host: $REDSHIFT_HOST
+    port: 5439
+    extra:
+      iam: false
+      cluster_identifier: <REDSHIFT_CLUSTER_IDENTIFIER>
+      profile: default
+      db_user: awsuser
+      port: 5439,
+      database: dev
+      region: 'us-east-1'
   - conn_id: s3_conn_benchmark
     conn_type: aws
     description: null

--- a/.github/ci-test-connections.yaml
+++ b/.github/ci-test-connections.yaml
@@ -84,7 +84,6 @@ connections:
     password: $REDSHIFT_PASSWORD
   - conn_id: redshift_default
     conn_type: redshift
-    host: $REDSHIFT_HOST
     port: 5439
     extra:
       iam: false


### PR DESCRIPTION
Since there was a recent change introduced on OSS - https://github.com/apache/airflow/pull/28187 we are calling the `get_iam_token` method even for the default redshift connection which doesn't have a host by default, therefore failing in CI. In this PR we are overriding the default connection - `redshift_conn` with `iam: false` so that the `get_iam_token` is not called. 

Once this issue if fixed in the OSS Airflow we can remove this change.