### PR TITLE
updating tasks name in example_load_file DAG

### DIFF
--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -67,6 +67,7 @@ dag = DAG(
 with dag:
     # [START load_file_example_1]
     my_homes_table = aql.load_file(
+        task_id="s3_to_postgress",
         input_file=File(path="s3://astro-sdk/python_sdk/example_dags/data/sample.csv"),
         output_table=Table(
             conn_id=ASTRO_POSTGRESS_CONN_ID,
@@ -76,12 +77,14 @@ with dag:
 
     # [START load_file_example_2]
     dataframe = aql.load_file(
+        task_id="s3_to_dataframe",
         input_file=File(path="s3://astro-sdk/python_sdk/example_dags/data/sample.csv"),
     )
     # [END load_file_example_2]
 
     # [START load_file_example_3]
     sample_table = aql.load_file(
+        task_id="s3_to_postgress_ndjson",
         input_file=File(path="s3://astro-sdk/python_sdk/example_dags/data/sample.ndjson"),
         output_table=Table(
             conn_id=ASTRO_POSTGRESS_CONN_ID,
@@ -92,6 +95,7 @@ with dag:
 
     # [START load_file_example_4]
     new_table = aql.load_file(
+        task_id="s3_to_postgress_replace",
         input_file=File(path="s3://astro-sdk/python_sdk/example_dags/data/sample.csv"),
         output_table=Table(
             conn_id=ASTRO_POSTGRESS_CONN_ID,
@@ -102,6 +106,7 @@ with dag:
 
     # [START load_file_example_5]
     custom_schema_table = aql.load_file(
+        task_id="s3_to_postgress_specify_schema",
         input_file=File(path="s3://astro-sdk/python_sdk/example_dags/data/sample.csv"),
         output_table=Table(
             conn_id=ASTRO_POSTGRESS_CONN_ID,
@@ -115,6 +120,7 @@ with dag:
 
     # [START load_file_example_6]
     dataframe = aql.load_file(
+        task_id="s3_to_dataframe_capitalization_upper",
         input_file=File(path="s3://astro-sdk/python_sdk/example_dags/data/sample.csv"),
         columns_names_capitalization="upper",
     )
@@ -122,6 +128,7 @@ with dag:
 
     # [START load_file_example_7]
     aql.load_file(
+        task_id="s3_to_bigquery",
         input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
         output_table=Table(conn_id=ASTRO_GCP_CONN_ID, metadata=Metadata(schema="astro")),
         use_native_support=False,
@@ -130,6 +137,7 @@ with dag:
 
     # [START load_file_example_8]
     aql.load_file(
+        task_id="s3_to_bigquery_native_support",
         input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
         output_table=Table(conn_id=ASTRO_GCP_CONN_ID, metadata=Metadata(schema="astro")),
         use_native_support=True,
@@ -141,21 +149,9 @@ with dag:
     )
     # [END load_file_example_8]
 
-    # [START load_file_example_9]
-    aql.load_file(
-        input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
-        output_table=Table(conn_id=ASTRO_GCP_CONN_ID, metadata=Metadata(schema="astro")),
-        use_native_support=True,
-        native_support_kwargs={
-            "ignore_unknown_values": True,
-            "allow_jagged_rows": True,
-            "skip_leading_rows": "1",
-        },
-    )
-    # [END load_file_example_9]
-
     # [START load_file_example_10]
     my_homes_table = aql.load_file(
+        task_id="local_to_postgress_glob",
         input_file=File(path=str(CWD.parent) + "/tests/data/homes*", filetype=FileType.CSV),
         output_table=Table(
             conn_id=ASTRO_POSTGRESS_CONN_ID,
@@ -165,6 +161,7 @@ with dag:
 
     # [START load_file_example_11]
     aql.load_file(
+        task_id="s3_to_bigquery_pattern",
         input_file=File("s3://astro-sdk/sample_pattern", conn_id=AWS_CONN_ID, filetype=FileType.CSV),
         output_table=Table(conn_id=ASTRO_GCP_CONN_ID, metadata=Metadata(schema="astro")),
         use_native_support=False,
@@ -173,6 +170,7 @@ with dag:
 
     # [START load_file_example_12]
     aql.load_file(
+        task_id="gs_to_bigquery_pattern",
         input_file=File(
             "gs://astro-sdk/workspace/sample_pattern",
             conn_id=ASTRO_GCP_CONN_ID,
@@ -185,6 +183,7 @@ with dag:
 
     # [START load_file_example_13]
     aql.load_file(
+        task_id="s3_to_redshift_pattern",
         input_file=File(
             "s3://astro-sdk/sample_pattern",
             conn_id=AWS_CONN_ID,
@@ -197,6 +196,7 @@ with dag:
 
     # [START load_file_example_14]
     aql.load_file(
+        task_id="gs_to_redshift",
         input_file=File(
             "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id=ASTRO_GCP_CONN_ID,
@@ -207,17 +207,9 @@ with dag:
     )
     # [END load_file_example_14]
 
-    # [START load_file_example_15]
-    aql.load_file(
-        input_file=File(path=str(CWD.parent) + "/tests/data/homes*", filetype=FileType.CSV),
-        output_table=Table(
-            conn_id="postgres_conn",
-        ),
-    )
-    # [END load_file_example_15]
-
     # [START load_file_example_16]
     aql.load_file(
+        task_id="s3_to_redshift_native",
         input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
         output_table=Table(conn_id=ASTRO_REDSHIFT_CONN_ID, metadata=Metadata(schema="astro")),
         use_native_support=True,
@@ -231,6 +223,7 @@ with dag:
 
     # [START load_file_example_17]
     aql.load_file(
+        task_id="gs_to_bigquery_native",
         input_file=File(
             "gs://astro-sdk/workspace/sample_pattern.csv",
             conn_id=ASTRO_GCP_CONN_ID,
@@ -249,6 +242,7 @@ with dag:
 
     # [START load_file_example_18]
     dataframe = aql.load_file(
+        task_id="s3_to_dataframe_filetype",
         input_file=File(
             path="s3://astro-sdk/python_sdk/example_dags/data/sample_csv.data", filetype=FileType.CSV
         )
@@ -257,6 +251,7 @@ with dag:
 
     # [START load_file_example_19]
     aql.load_file(
+        task_id="gdrive_to_snowflake",
         input_file=File(path="gdrive://test-google-drive-support/sample.csv", conn_id="gdrive_conn"),
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
@@ -270,6 +265,7 @@ with dag:
 
     # [START load_file_example_20]
     aql.load_file(
+        task_id="sftp_to_snowflake",
         input_file=File(
             path="sftp://upload/ADOPTION_CENTER_1_unquoted.csv", conn_id="sftp_conn", filetype=FileType.CSV
         ),
@@ -285,6 +281,7 @@ with dag:
 
     # [START load_file_example_21]
     aql.load_file(
+        task_id="ftp_to_snowflake",
         input_file=File(
             path="ftp://upload/ADOPTION_CENTER_1_unquoted.csv",
             conn_id="ftp_conn",
@@ -302,6 +299,7 @@ with dag:
 
     # [START load_file_example_22]
     aql.load_file(
+        task_id="s3_to_snowflake_delimiter",
         input_file=File("s3://tmp9/delimiter_dollar.csv", conn_id=AWS_CONN_ID),
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
@@ -313,6 +311,7 @@ with dag:
 
     # [START load_file_example_23]
     aql.load_file(
+        task_id="s3_to_snowflake_native",
         input_file=File("s3://astro-sdk/python_sdk/example_dags/data/sample.csv", conn_id=AWS_CONN_ID),
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
@@ -328,6 +327,7 @@ with dag:
 
     # [START load_file_example_24]
     aql.load_file(
+        task_id="s3_to_databricks",
         input_file=File("s3://astro-sdk/python_sdk/example_dags/data/sample.csv", conn_id=AWS_CONN_ID),
         output_table=Table(
             conn_id=DATABRICKS_CONN_ID,
@@ -343,6 +343,7 @@ with dag:
 
     # [START load_file_example_25]
     aql.load_file(
+        task_id="azure_to_snowflake",
         input_file=File("wasb://astro-sdk/sample.csv"),
         output_table=Table(
             conn_id=SNOWFLAKE_CONN_ID,
@@ -356,6 +357,7 @@ with dag:
 
     # [START load_file_example_26]
     aql.load_file(
+        task_id="s3_to_mssql",
         input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
         output_table=Table(
             conn_id=MSSQL_CONN_ID,
@@ -365,6 +367,7 @@ with dag:
 
     # [START load_file_example_27]
     aql.load_file(
+        task_id="s3_to_duckdb",
         input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
         output_table=Table(
             conn_id=DUCKDB_CONN_ID,
@@ -374,6 +377,7 @@ with dag:
 
     # [START load_file_example_28]
     aql.load_file(
+        task_id="s3_to_mysql",
         input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
         output_table=Table(
             conn_id=MYSQL_CONN_ID,


### PR DESCRIPTION
# Description
## What is the current behavior?
Currently, task names in example_load_file DAG are not provided due to which there sequence changes at runtime also task names are not descriptive



## What is the new behavior?
1. adding task_id field in all the tasks
2. adding logical names for the tasks for better readability 
3. I Noticed a few tasks were duplicates, so I removed them