### PR TITLE
Fix Snowflake QueryModifier issue

### DIFF
--- a/python-sdk/docs/CHANGELOG.md
+++ b/python-sdk/docs/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## 1.7.0a2
+## 1.7.0a3
 
 ### Feature
 - Allow users to disable schema check and creation on `transform` [#1925](https://github.com/astronomer/astro-sdk/pull/1925)
 - Allow users to disable schema check and creation on `load_file` [#1922](https://github.com/astronomer/astro-sdk/pull/1922)
 
+### Bug fixes
+- Fix QueryModifier issue on Snowflake [#1962](https://github.com/astronomer/astro-sdk/pull/1962)
 
 ## 1.6.1
 

--- a/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
+++ b/python-sdk/example_dags/example_amazon_s3_snowflake_transform.py
@@ -10,6 +10,7 @@ from airflow.decorators import dag
 from astro import sql as aql
 from astro.files import File
 from astro.options import SnowflakeLoadOptions
+from astro.query_modifier import QueryModifier
 from astro.table import Metadata, Table
 
 
@@ -19,7 +20,10 @@ def combine_data(center_1: Table, center_2: Table):
     UNION SELECT * FROM {{center_2}}"""
 
 
-@aql.transform(assume_schema_exists=True)
+@aql.transform(
+    assume_schema_exists=True,
+    query_modifier=QueryModifier(pre_queries=["ALTER SESSION SET query_tag='not_guinea_pig';"]),
+)
 def clean_data(input_table: Table):
     return """SELECT *
     FROM {{input_table}} WHERE type NOT LIKE 'Guinea Pig'

--- a/python-sdk/src/astro/__init__.py
+++ b/python-sdk/src/astro/__init__.py
@@ -1,6 +1,6 @@
 """A decorator that allows users to run SQL queries natively in Airflow."""
 
-__version__ = "1.7.0a2"
+__version__ = "1.7.0a3"
 
 
 # This is needed to allow Airflow to pick up specific metadata fields it needs

--- a/python-sdk/tests/sql/operators/test_run_raw_sql.py
+++ b/python-sdk/tests/sql/operators/test_run_raw_sql.py
@@ -74,7 +74,9 @@ def test_run_sql_calls_with_query_tag(run_sql, sample_dag):
         dummy_method()
 
     test_utils.run_dag(sample_dag)
-    assert run_sql.method_calls[0].args[0].text == "ALTER team_1;ALTER team_2;SELECT 1+1"
+    assert run_sql.method_calls[0].args[0].text == "ALTER team_1"
+    assert run_sql.method_calls[1].args[0].text == "ALTER team_2"
+    assert run_sql.method_calls[2].args[0].text == "SELECT 1+1"
 
 
 @mock.patch("astro.sql.operators.raw_sql.RawSQLOperator.results_as_pandas_dataframe")

--- a/python-sdk/tests/sql/operators/test_transform.py
+++ b/python-sdk/tests/sql/operators/test_transform.py
@@ -32,9 +32,10 @@ def test_transform_calls_with_query_tag(run_sql, sample_dag):
         dummy_method()
 
     test_utils.run_dag(sample_dag)
-    enriched_query = run_sql.method_calls[1].args[0].text
-    assert enriched_query.startswith("ALTER team_1;ALTER team_2;CREATE TABLE IF NOT EXISTS ")
-    assert enriched_query.endswith("AS SELECT 1+1")
+    run_sql.method_calls[1].args[0].text.startswith("ALTER team_1")
+    run_sql.method_calls[2].args[0].text.startswith("ALTER team_2")
+    run_sql.method_calls[3].args[0].text.startswith("CREATE TABLE IF NOT EXISTS")
+    run_sql.method_calls[3].args[0].text.endswith("AS SELECT 1+1")
 
 
 @mock.patch("astro.databases.base.BaseDatabase.connection")
@@ -56,9 +57,9 @@ def test_transform_file_calls_with_query_tag(run_sql, sample_dag):
         test_utils.run_dag(sample_dag)
 
         assert run_sql.method_calls[1].args[0].text.startswith("ALTER team_1")
-        assert run_sql.method_calls[2].args[1].text.startswith("ALTER team_2")
-        assert run_sql.method_calls[3].args[2].text.startswith("CREATE TABLE IF NOT EXISTS")
-        assert run_sql.method_calls[3].args[2].text.endswith("AS SELECT 1+1")
+        assert run_sql.method_calls[2].args[0].text.startswith("ALTER team_2")
+        assert run_sql.method_calls[3].args[0].text.startswith("CREATE TABLE IF NOT EXISTS")
+        assert run_sql.method_calls[3].args[0].text.endswith("AS SELECT 1+1")
 
 
 @mock.patch("astro.databases.snowflake.SnowflakeDatabase.connection")

--- a/python-sdk/tests/sql/operators/test_transform.py
+++ b/python-sdk/tests/sql/operators/test_transform.py
@@ -55,9 +55,10 @@ def test_transform_file_calls_with_query_tag(run_sql, sample_dag):
             )
         test_utils.run_dag(sample_dag)
 
-        enriched_query = run_sql.method_calls[1].args[0].text
-        assert enriched_query.startswith("ALTER team_1;ALTER team_2;CREATE TABLE IF NOT EXISTS ")
-        assert enriched_query.endswith("AS SELECT 1+1")
+        assert run_sql.method_calls[1].args[0].text.startswith("ALTER team_1")
+        assert run_sql.method_calls[2].args[1].text.startswith("ALTER team_2")
+        assert run_sql.method_calls[3].args[2].text.startswith("CREATE TABLE IF NOT EXISTS")
+        assert run_sql.method_calls[3].args[2].text.endswith("AS SELECT 1+1")
 
 
 @mock.patch("astro.databases.snowflake.SnowflakeDatabase.connection")


### PR DESCRIPTION
Add a DAG to illustrate how users can set `query_tags` in Snowflake using the Python SDK.

Before this PR, it would fail with:
```
E       sqlalchemy.exc.ProgrammingError: (snowflake.connector.errors.ProgrammingError) 000008 (0A000): 01acd6d5-0607-a92d-0000-68213eeeebda: Actual statement count 2 did not match the desired statement count 1.
E       [SQL: ALTER SESSION SET query_tag='not_guinea_pig';;CREATE TABLE IF NOT EXISTS SANDBOX.ASTROFLOW_CI._tmp_ksimu2ab9s9kbatbtrexodw6q9alcskhfcumxpxuvi2ir60ew81a3st3k AS SELECT *
E           FROM IDENTIFIER(%(input_table)s) WHERE type NOT LIKE 'Guinea Pig'
E           ]
E       [parameters: ***'input_table': 'SANDBOX.ASTROFLOW_CI._tmp_tddzk0vrcf3lbt1nxucnv3ejyx1ds3su84fvdqpoa4p69yguysppti2mo'***]
E       (Background on this error at: https://sqlalche.me/e/14/f405)
```

Note: the failing Redshift tests are unrelated to the change introduced in this PR. They are being investigated by PR #1959 . So far, they don't happen when we use a newer version of Redshift, they don't happen, but the costs are higher. Therefore, I suggest we open an exception and merge this PR disregarding them.