### PR TITLE
Fix AWS ecs instance issue

### DIFF
--- a/python-sdk/tests_integration/astro_deploy/master_dag.py
+++ b/python-sdk/tests_integration/astro_deploy/master_dag.py
@@ -122,7 +122,9 @@ def start_sftp_ftp_services_method():
     instance_id = instance[0].instance_id
     ti = get_current_context()["ti"]
     ti.xcom_push(key=EC2_INSTANCE_ID_KEY, value=instance_id)
-    time.sleep(120)  # Need to wait for ecs instance to be up otherwise the `boto3's describe_instances` call fails.
+    time.sleep(
+        120
+    )  # Need to wait for ecs instance to be up otherwise the `boto3's describe_instances` call fails.
     while get_instances_status(instance_id) != "running":
         logging.info("Waiting for Instance to be available in running state. Sleeping for 30 seconds.")
         time.sleep(30)

--- a/python-sdk/tests_integration/astro_deploy/master_dag.py
+++ b/python-sdk/tests_integration/astro_deploy/master_dag.py
@@ -122,7 +122,7 @@ def start_sftp_ftp_services_method():
     instance_id = instance[0].instance_id
     ti = get_current_context()["ti"]
     ti.xcom_push(key=EC2_INSTANCE_ID_KEY, value=instance_id)
-    time.sleep(120)  # Need to delay to this to prevent error of unknown instance_id.
+    time.sleep(120)  # Need to wait for ecs instance to be up otherwise the `boto3's describe_instances` call fails.
     while get_instances_status(instance_id) != "running":
         logging.info("Waiting for Instance to be available in running state. Sleeping for 30 seconds.")
         time.sleep(30)

--- a/python-sdk/tests_integration/astro_deploy/master_dag.py
+++ b/python-sdk/tests_integration/astro_deploy/master_dag.py
@@ -122,6 +122,7 @@ def start_sftp_ftp_services_method():
     instance_id = instance[0].instance_id
     ti = get_current_context()["ti"]
     ti.xcom_push(key=EC2_INSTANCE_ID_KEY, value=instance_id)
+    time.sleep(120)  # Need to delay to this to prevent error of unknown instance_id.
     while get_instances_status(instance_id) != "running":
         logging.info("Waiting for Instance to be available in running state. Sleeping for 30 seconds.")
         time.sleep(30)


### PR DESCRIPTION
Fix the AWS ECS unknown instance issue by adding waiting time. 

```
[2023-06-07, 07:09:03 UTC] {logging_mixin.py:149} WARNING - TypeError: object of type 'NoneType' has no len()
[2023-06-07, 07:09:03 UTC] {taskinstance.py:1824} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/airflow/operators/python.py", line 181, in execute
    return_value = self.execute_callable()
  File "/usr/local/lib/python3.10/site-packages/airflow/operators/python.py", line 198, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/usr/local/airflow/dags/master_dag.py", line 124, in start_sftp_ftp_services_method
    while get_instances_status(instance_id) != "running":
  File "/usr/local/airflow/dags/master_dag.py", line 134, in get_instances_status
    response = client.describe_instances(
  File "/usr/local/lib/python3.10/site-packages/botocore/client.py", line 530, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.10/site-packages/botocore/client.py", line 960, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidInstanceID.NotFound) when calling the DescribeInstances operation: The instance ID 'i-034a0829d215c3db0' does not exist
```