### PR TITLE
Skip redshift test cases in CI

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -319,7 +319,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.6.0')" -- tests_integration/ -k "test_load_file.py" --splits 3 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.6.0')" -- tests_integration/ -k "test_load_file.py and not redshift" --splits 3 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - run: cat /tmp/durations-${{ matrix.group }}
       - name: Upload coverage
         uses: actions/upload-artifact@v2
@@ -415,7 +415,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.6.0')" -- tests_integration/ -k "test_example_dags.py" --splits 3 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.6.0')" -- tests_integration/ -k "test_example_dags.py and not redshift" --splits 3 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - run: cat /tmp/durations-${{ matrix.group }}
       - name: Upload coverage
         uses: actions/upload-artifact@v2
@@ -511,7 +511,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.6.0')" -- tests_integration/ -k "not test_load_file.py and not test_example_dags.py" --splits 11 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
+      - run: nox -s "test-3.8(airflow='2.6.0')" -- tests_integration/ -k "not test_load_file.py and not test_example_dags.py and not redshift" --splits 11 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - run: cat /tmp/durations-${{ matrix.group }}
       - name: Upload coverage
         uses: actions/upload-artifact@v2
@@ -605,7 +605,7 @@ jobs:
       - run: python -c 'import os; print(os.getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", "").strip())' > ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}
       - run: sqlite3 /tmp/sqlite_default.db "VACUUM;"
       - run: pip3 install nox
-      - run: nox -s "test-3.8(airflow='2.2.5')" -- "tests_integration/test_example_dags.py" "tests_integration/integration_test_dag.py"
+      - run: nox -s "test-3.8(airflow='2.2.5')" -- "tests_integration/test_example_dags.py" "tests_integration/integration_test_dag.py" -k "not redshift"
     env:
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json

--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -182,43 +182,46 @@ with dag:
     # [END load_file_example_12]
 
     # [START load_file_example_13]
-    aql.load_file(
-        task_id="s3_to_redshift_pattern",
-        input_file=File(
-            "s3://astro-sdk/sample_pattern",
-            conn_id=AWS_CONN_ID,
-            filetype=FileType.CSV,
-        ),
-        output_table=Table(conn_id=ASTRO_REDSHIFT_CONN_ID, metadata=Metadata(schema="astro")),
-        use_native_support=False,
-    )
+    # Redshift tests are broken due to AWS issue.
+    # aql.load_file(
+    #     task_id="s3_to_redshift_pattern",
+    #     input_file=File(
+    #         "s3://astro-sdk/sample_pattern",
+    #         conn_id=AWS_CONN_ID,
+    #         filetype=FileType.CSV,
+    #     ),
+    #     output_table=Table(conn_id=ASTRO_REDSHIFT_CONN_ID, metadata=Metadata(schema="astro")),
+    #     use_native_support=False,
+    # )
     # [END load_file_example_13]
 
     # [START load_file_example_14]
-    aql.load_file(
-        task_id="gs_to_redshift",
-        input_file=File(
-            "gs://astro-sdk/workspace/sample_pattern.csv",
-            conn_id=ASTRO_GCP_CONN_ID,
-            filetype=FileType.CSV,
-        ),
-        output_table=Table(conn_id=ASTRO_REDSHIFT_CONN_ID, metadata=Metadata(schema="astro")),
-        use_native_support=False,
-    )
+    # Redshift tests are broken due to AWS issue.
+    # aql.load_file(
+    #     task_id="gs_to_redshift",
+    #     input_file=File(
+    #         "gs://astro-sdk/workspace/sample_pattern.csv",
+    #         conn_id=ASTRO_GCP_CONN_ID,
+    #         filetype=FileType.CSV,
+    #     ),
+    #     output_table=Table(conn_id=ASTRO_REDSHIFT_CONN_ID, metadata=Metadata(schema="astro")),
+    #     use_native_support=False,
+    # )
     # [END load_file_example_14]
 
     # [START load_file_example_16]
-    aql.load_file(
-        task_id="s3_to_redshift_native",
-        input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
-        output_table=Table(conn_id=ASTRO_REDSHIFT_CONN_ID, metadata=Metadata(schema="astro")),
-        use_native_support=True,
-        native_support_kwargs={
-            "IGNOREHEADER": 1,
-            "REGION": "us-west-2",
-            "IAM_ROLE": REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN,
-        },
-    )
+    # Redshift tests are broken due to AWS issue.
+    # aql.load_file(
+    #     task_id="s3_to_redshift_native",
+    #     input_file=File("s3://tmp9/homes_main.csv", conn_id=AWS_CONN_ID),
+    #     output_table=Table(conn_id=ASTRO_REDSHIFT_CONN_ID, metadata=Metadata(schema="astro")),
+    #     use_native_support=True,
+    #     native_support_kwargs={
+    #         "IGNOREHEADER": 1,
+    #         "REGION": "us-west-2",
+    #         "IAM_ROLE": REDSHIFT_NATIVE_LOAD_IAM_ROLE_ARN,
+    #     },
+    # )
     # [END load_file_example_16]
 
     # [START load_file_example_17]

--- a/python-sdk/tests_integration/databases/test_mysql.py
+++ b/python-sdk/tests_integration/databases/test_mysql.py
@@ -1,105 +1,105 @@
-# """Tests specific to the MySql Database implementation."""
-# import pathlib
-#
-# import pandas as pd
-# import pytest
-# import sqlalchemy
-#
-# from astro.constants import Database
-# from astro.databases.mysql import MysqlDatabase
-# from astro.settings import SCHEMA
-# from astro.table import Metadata, Table
-#
-# DEFAULT_CONN_ID = "mysql_default"
-# CUSTOM_CONN_ID = "mysql_conn"
-# SUPPORTED_CONN_IDS = [DEFAULT_CONN_ID, CUSTOM_CONN_ID]
-# CWD = pathlib.Path(__file__).parent
-#
-# TEST_TABLE = Table()
-#
-#
-# @pytest.mark.integration
-# def test_mysql_run_sql():
-#     """Test run_sql against mysql database"""
-#     statement = "SELECT 1 + 1;"
-#     database = MysqlDatabase(conn_id=CUSTOM_CONN_ID)
-#     response = database.run_sql(statement, handler=lambda x: x.first())
-#     assert response[0] == 2
-#
-#
-# @pytest.mark.integration
-# def test_table_exists_raises_exception():
-#     """Test if table exists in mysql database"""
-#     database = MysqlDatabase(conn_id=CUSTOM_CONN_ID)
-#     table = Table(name="non-existing-table", metadata=Metadata(schema=SCHEMA))
-#     assert not database.table_exists(table)
-#
-#
-# @pytest.mark.integration
-# @pytest.mark.parametrize(
-#     "database_table_fixture",
-#     [
-#         {
-#             "database": Database.MYSQL,
-#             "table": Table(
-#                 metadata=Metadata(database=SCHEMA, schema=SCHEMA),
-#                 columns=[
-#                     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-#                     sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
-#                 ],
-#             ),
-#         }
-#     ],
-#     indirect=True,
-#     ids=["mysql"],
-# )
-# def test_mysql_create_table_with_columns(database_table_fixture):
-#     """Test table creation with columns data"""
-#     database, table = database_table_fixture
-#
-#     statement = (
-#         f"SELECT TABLE_SCHEMA,TABLE_NAME,COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
-#         f"WHERE table_name='{table.name}'"
-#     )
-#     response = database.run_sql(statement, handler=lambda x: x.first())
-#     assert response is None
-#
-#     database.create_table(table)
-#     response = database.run_sql(statement, handler=lambda x: x.fetchall())
-#     rows = response
-#     assert len(rows) == 2
-#     assert rows[0][:3] == (
-#         SCHEMA,
-#         f"{table.name}",
-#         "id",
-#     )
-#     assert rows[1][:3] == (
-#         SCHEMA,
-#         f"{table.name}",
-#         "name",
-#     )
-#
-#
-# @pytest.mark.integration
-# @pytest.mark.parametrize(
-#     "database_table_fixture",
-#     [
-#         {"database": Database.MYSQL},
-#     ],
-#     indirect=True,
-#     ids=["mysql"],
-# )
-# def test_load_pandas_dataframe_to_table(database_table_fixture):
-#     """Test load_pandas_dataframe_to_table against mysql"""
-#     database, table = database_table_fixture
-#
-#     pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
-#     database.load_pandas_dataframe_to_table(pandas_dataframe, table)
-#
-#     statement = f"SELECT id FROM {database.get_table_qualified_name(table)};"
-#     response = database.run_sql(statement, handler=lambda x: x.fetchall())
-#
-#     rows = response
-#     assert len(rows) == 2
-#     assert rows[0] == (1,)
-#     assert rows[1] == (2,)
+"""Tests specific to the MySql Database implementation."""
+import pathlib
+
+import pandas as pd
+import pytest
+import sqlalchemy
+
+from astro.constants import Database
+from astro.databases.mysql import MysqlDatabase
+from astro.settings import SCHEMA
+from astro.table import Metadata, Table
+
+DEFAULT_CONN_ID = "mysql_default"
+CUSTOM_CONN_ID = "mysql_conn"
+SUPPORTED_CONN_IDS = [DEFAULT_CONN_ID, CUSTOM_CONN_ID]
+CWD = pathlib.Path(__file__).parent
+
+TEST_TABLE = Table()
+
+
+@pytest.mark.integration
+def test_mysql_run_sql():
+    """Test run_sql against mysql database"""
+    statement = "SELECT 1 + 1;"
+    database = MysqlDatabase(conn_id=CUSTOM_CONN_ID)
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response[0] == 2
+
+
+@pytest.mark.integration
+def test_table_exists_raises_exception():
+    """Test if table exists in mysql database"""
+    database = MysqlDatabase(conn_id=CUSTOM_CONN_ID)
+    table = Table(name="non-existing-table", metadata=Metadata(schema=SCHEMA))
+    assert not database.table_exists(table)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {
+            "database": Database.MYSQL,
+            "table": Table(
+                metadata=Metadata(database=SCHEMA, schema=SCHEMA),
+                columns=[
+                    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+                    sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
+                ],
+            ),
+        }
+    ],
+    indirect=True,
+    ids=["mysql"],
+)
+def test_mysql_create_table_with_columns(database_table_fixture):
+    """Test table creation with columns data"""
+    database, table = database_table_fixture
+
+    statement = (
+        f"SELECT TABLE_SCHEMA,TABLE_NAME,COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+        f"WHERE table_name='{table.name}'"
+    )
+    response = database.run_sql(statement, handler=lambda x: x.first())
+    assert response is None
+
+    database.create_table(table)
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
+    rows = response
+    assert len(rows) == 2
+    assert rows[0][:3] == (
+        SCHEMA,
+        f"{table.name}",
+        "id",
+    )
+    assert rows[1][:3] == (
+        SCHEMA,
+        f"{table.name}",
+        "name",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "database_table_fixture",
+    [
+        {"database": Database.MYSQL},
+    ],
+    indirect=True,
+    ids=["mysql"],
+)
+def test_load_pandas_dataframe_to_table(database_table_fixture):
+    """Test load_pandas_dataframe_to_table against mysql"""
+    database, table = database_table_fixture
+
+    pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
+    database.load_pandas_dataframe_to_table(pandas_dataframe, table)
+
+    statement = f"SELECT id FROM {database.get_table_qualified_name(table)};"
+    response = database.run_sql(statement, handler=lambda x: x.fetchall())
+
+    rows = response
+    assert len(rows) == 2
+    assert rows[0] == (1,)
+    assert rows[1] == (2,)

--- a/python-sdk/tests_integration/databases/test_mysql.py
+++ b/python-sdk/tests_integration/databases/test_mysql.py
@@ -1,105 +1,105 @@
-"""Tests specific to the MySql Database implementation."""
-import pathlib
-
-import pandas as pd
-import pytest
-import sqlalchemy
-
-from astro.constants import Database
-from astro.databases.mysql import MysqlDatabase
-from astro.settings import SCHEMA
-from astro.table import Metadata, Table
-
-DEFAULT_CONN_ID = "mysql_default"
-CUSTOM_CONN_ID = "mysql_conn"
-SUPPORTED_CONN_IDS = [DEFAULT_CONN_ID, CUSTOM_CONN_ID]
-CWD = pathlib.Path(__file__).parent
-
-TEST_TABLE = Table()
-
-
-@pytest.mark.integration
-def test_mysql_run_sql():
-    """Test run_sql against mysql database"""
-    statement = "SELECT 1 + 1;"
-    database = MysqlDatabase(conn_id=CUSTOM_CONN_ID)
-    response = database.run_sql(statement, handler=lambda x: x.first())
-    assert response[0] == 2
-
-
-@pytest.mark.integration
-def test_table_exists_raises_exception():
-    """Test if table exists in mysql database"""
-    database = MysqlDatabase(conn_id=CUSTOM_CONN_ID)
-    table = Table(name="non-existing-table", metadata=Metadata(schema=SCHEMA))
-    assert not database.table_exists(table)
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize(
-    "database_table_fixture",
-    [
-        {
-            "database": Database.MYSQL,
-            "table": Table(
-                metadata=Metadata(database=SCHEMA, schema=SCHEMA),
-                columns=[
-                    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-                    sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
-                ],
-            ),
-        }
-    ],
-    indirect=True,
-    ids=["mysql"],
-)
-def test_mysql_create_table_with_columns(database_table_fixture):
-    """Test table creation with columns data"""
-    database, table = database_table_fixture
-
-    statement = (
-        f"SELECT TABLE_SCHEMA,TABLE_NAME,COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
-        f"WHERE table_name='{table.name}'"
-    )
-    response = database.run_sql(statement, handler=lambda x: x.first())
-    assert response is None
-
-    database.create_table(table)
-    response = database.run_sql(statement, handler=lambda x: x.fetchall())
-    rows = response
-    assert len(rows) == 2
-    assert rows[0][:3] == (
-        SCHEMA,
-        f"{table.name}",
-        "id",
-    )
-    assert rows[1][:3] == (
-        SCHEMA,
-        f"{table.name}",
-        "name",
-    )
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize(
-    "database_table_fixture",
-    [
-        {"database": Database.MYSQL},
-    ],
-    indirect=True,
-    ids=["mysql"],
-)
-def test_load_pandas_dataframe_to_table(database_table_fixture):
-    """Test load_pandas_dataframe_to_table against mysql"""
-    database, table = database_table_fixture
-
-    pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
-    database.load_pandas_dataframe_to_table(pandas_dataframe, table)
-
-    statement = f"SELECT id FROM {database.get_table_qualified_name(table)};"
-    response = database.run_sql(statement, handler=lambda x: x.fetchall())
-
-    rows = response
-    assert len(rows) == 2
-    assert rows[0] == (1,)
-    assert rows[1] == (2,)
+# """Tests specific to the MySql Database implementation."""
+# import pathlib
+#
+# import pandas as pd
+# import pytest
+# import sqlalchemy
+#
+# from astro.constants import Database
+# from astro.databases.mysql import MysqlDatabase
+# from astro.settings import SCHEMA
+# from astro.table import Metadata, Table
+#
+# DEFAULT_CONN_ID = "mysql_default"
+# CUSTOM_CONN_ID = "mysql_conn"
+# SUPPORTED_CONN_IDS = [DEFAULT_CONN_ID, CUSTOM_CONN_ID]
+# CWD = pathlib.Path(__file__).parent
+#
+# TEST_TABLE = Table()
+#
+#
+# @pytest.mark.integration
+# def test_mysql_run_sql():
+#     """Test run_sql against mysql database"""
+#     statement = "SELECT 1 + 1;"
+#     database = MysqlDatabase(conn_id=CUSTOM_CONN_ID)
+#     response = database.run_sql(statement, handler=lambda x: x.first())
+#     assert response[0] == 2
+#
+#
+# @pytest.mark.integration
+# def test_table_exists_raises_exception():
+#     """Test if table exists in mysql database"""
+#     database = MysqlDatabase(conn_id=CUSTOM_CONN_ID)
+#     table = Table(name="non-existing-table", metadata=Metadata(schema=SCHEMA))
+#     assert not database.table_exists(table)
+#
+#
+# @pytest.mark.integration
+# @pytest.mark.parametrize(
+#     "database_table_fixture",
+#     [
+#         {
+#             "database": Database.MYSQL,
+#             "table": Table(
+#                 metadata=Metadata(database=SCHEMA, schema=SCHEMA),
+#                 columns=[
+#                     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+#                     sqlalchemy.Column("name", sqlalchemy.String(60), nullable=False, key="name"),
+#                 ],
+#             ),
+#         }
+#     ],
+#     indirect=True,
+#     ids=["mysql"],
+# )
+# def test_mysql_create_table_with_columns(database_table_fixture):
+#     """Test table creation with columns data"""
+#     database, table = database_table_fixture
+#
+#     statement = (
+#         f"SELECT TABLE_SCHEMA,TABLE_NAME,COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+#         f"WHERE table_name='{table.name}'"
+#     )
+#     response = database.run_sql(statement, handler=lambda x: x.first())
+#     assert response is None
+#
+#     database.create_table(table)
+#     response = database.run_sql(statement, handler=lambda x: x.fetchall())
+#     rows = response
+#     assert len(rows) == 2
+#     assert rows[0][:3] == (
+#         SCHEMA,
+#         f"{table.name}",
+#         "id",
+#     )
+#     assert rows[1][:3] == (
+#         SCHEMA,
+#         f"{table.name}",
+#         "name",
+#     )
+#
+#
+# @pytest.mark.integration
+# @pytest.mark.parametrize(
+#     "database_table_fixture",
+#     [
+#         {"database": Database.MYSQL},
+#     ],
+#     indirect=True,
+#     ids=["mysql"],
+# )
+# def test_load_pandas_dataframe_to_table(database_table_fixture):
+#     """Test load_pandas_dataframe_to_table against mysql"""
+#     database, table = database_table_fixture
+#
+#     pandas_dataframe = pd.DataFrame(data={"id": [1, 2]})
+#     database.load_pandas_dataframe_to_table(pandas_dataframe, table)
+#
+#     statement = f"SELECT id FROM {database.get_table_qualified_name(table)};"
+#     response = database.run_sql(statement, handler=lambda x: x.fetchall())
+#
+#     rows = response
+#     assert len(rows) == 2
+#     assert rows[0] == (1,)
+#     assert rows[1] == (2,)


### PR DESCRIPTION
There is an upstream issue for redshift cluster type - `dc2`
Error:
```
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf0 in position 122: unexpected end of data` Can you please explain why is that the case?
```
ref - https://github.com/astronomer/astro-sdk/actions/runs/5355001227/jobs/9712737921?pr=1974 

Case created with AWS: https://support.console.aws.amazon.com/support/home?region=us-east-2#/case/?displayId=12988936661&language=en

Awaiting response till then we are skipping the tests