### PR TITLE
ci(github-actions): add workflow dispatch for manually deployment

### DIFF
--- a/.github/workflows/ci-astro-deploy.yml
+++ b/.github/workflows/ci-astro-deploy.yml
@@ -2,6 +2,12 @@ name: "Astro Deploy"
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      git_rev:
+        description: 'The git revision to deploy'
+        required: false
+        default: ''
 
 jobs:
   deploy:
@@ -16,5 +22,21 @@ jobs:
       ASTRO_KEY_SECRET_SINGLE_WORKER: ${{ secrets.ASTRO_KEY_SECRET_SINGLE_WORKER }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: cd python-sdk/tests_integration/astro_deploy && bash deploy.sh $ASTRO_DOCKER_REGISTRY $ASTRO_ORGANIZATION_ID $ASTRO_DEPLOYMENT_ID $ASTRO_KEY_ID $ASTRO_KEY_SECRET $ASTRO_DEPLOYMENT_ID_SINGLE_WORKER $ASTRO_KEY_ID_SINGLE_WORKER $ASTRO_KEY_SECRET_SINGLE_WORKER
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git_rev }}
+
+      - name: deploy
+        working-directory: python-sdk/tests_integration/astro_deploy
+        run: |
+          echo "deploying ${{ inputs.git_rev }}"
+          bash deploy.sh \
+            $ASTRO_DOCKER_REGISTRY \
+            $ASTRO_ORGANIZATION_ID \
+            $ASTRO_DEPLOYMENT_ID \
+            $ASTRO_KEY_ID \
+            $ASTRO_KEY_SECRET \
+            $ASTRO_DEPLOYMENT_ID_SINGLE_WORKER \
+            $ASTRO_KEY_ID_SINGLE_WORKER \
+            $ASTRO_KEY_SECRET_SINGLE_WORKER


### PR DESCRIPTION
# Description
## What is the current behavior?
Cannot manually trigger deploy workflow on GitHub


<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add workflow_dispatch to "Astro Deploy" workflow for enabling manually trigger deploying

## Does this introduce a breaking change?


### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
