### PR TITLE
Add support for pandas 2.0

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.7"
 dependencies = [
     "apache-airflow>=2.0",
     "attrs>=20.0",
-    "pandas>=1.3.4,<2.0.0", # Pinning it to <2.0.0 to avoid breaking changes
+    "pandas>=1.3.4",
     "pyarrow",
     "pydantic>=1.10.0,<2.0.0", # Airflow & Pydantic issue: https://github.com/apache/airflow/issues/32311
     "python-frontmatter",

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -294,7 +294,7 @@ class BaseDatabase(ABC):
         try:
             return SQLDatabase(engine=self.sqlalchemy_engine)
         except TypeError:
-            return SQLDatabase(con=self.sqlalchemy_engine.url)
+            return SQLDatabase(con=self.hook.get_uri())
 
     def is_native_autodetect_schema_available(  # skipcq: PYL-R0201
         self, file: File  # skipcq: PYL-W0613

--- a/python-sdk/src/astro/databases/base.py
+++ b/python-sdk/src/astro/databases/base.py
@@ -281,7 +281,7 @@ class BaseDatabase(ABC):
         else:
             source_dataframe = file.export_to_dataframe(nrows=LOAD_TABLE_AUTODETECT_ROWS_COUNT)
 
-        db = SQLDatabase(engine=self.sqlalchemy_engine)
+        db = self.get_pandas_sql_database()
         db.prep_table(
             source_dataframe,
             table.name.lower(),
@@ -289,6 +289,12 @@ class BaseDatabase(ABC):
             if_exists="replace",
             index=False,
         )
+
+    def get_pandas_sql_database(self):
+        try:
+            return SQLDatabase(engine=self.sqlalchemy_engine)
+        except TypeError:
+            return SQLDatabase(con=self.sqlalchemy_engine.url)
 
     def is_native_autodetect_schema_available(  # skipcq: PYL-R0201
         self, file: File  # skipcq: PYL-W0613


### PR DESCRIPTION
Since we have not found any breaking changes with pandas 2.0, lets offer 2.0 support for users who wish to use the latest pandas can offer.

In creating this PR, we also tested whether or not we could upgrade the snowflake python connector, but unfortunately we ran into the same versioning issue as before.
