### PR TITLE
adding only dag allowed states

### DIFF
--- a/python-sdk/tests_integration/astro_deploy/master_dag.py
+++ b/python-sdk/tests_integration/astro_deploy/master_dag.py
@@ -127,7 +127,7 @@ def prepare_dag_dependency(task_info, execution_time):
                 wait_for_completion=True,
                 reset_dag_run=True,
                 execution_date=execution_time,
-                allowed_states=["success", "failed", "skipped"],
+                allowed_states=["success", "failed"],
             )
         )
     return _task_list, _dag_run_ids

--- a/python-sdk/tests_integration/astro_deploy/master_dag_single_worker.py
+++ b/python-sdk/tests_integration/astro_deploy/master_dag_single_worker.py
@@ -76,7 +76,7 @@ def prepare_dag_dependency(task_info, execution_time):
                 wait_for_completion=True,
                 reset_dag_run=True,
                 execution_date=execution_time,
-                allowed_states=["success", "failed", "skipped"],
+                allowed_states=["success", "failed"],
             )
         )
     return _task_list, _dag_run_ids


### PR DESCRIPTION
Recently, we have noticed that our Master DAG is throwing parsing errors due to a new [change](https://github.com/apache/airflow/commit/fd2687d0d51fa444f63aac705d843f30e5922319#diff-800088a475d2b93df93b7b497aba69eeb0485005be1d4dd5b414c46ab1c68023). We can only pass valid DAG [states](https://github.com/apache/airflow/blob/145b16caaa43f0c42bffd97344df916c602cddde/airflow/utils/state.py#L67C7-L67C18) in TriggerDagRunOperator. This PR will address this issue