### PR TITLE
use bot's personal access token for pushing rc testing branch and triggering ci checking workflows

### DIFF
--- a/.github/workflows/ci-rc-test.yaml
+++ b/.github/workflows/ci-rc-test.yaml
@@ -119,6 +119,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.base_git_rev }}
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
 
       - name: Install dev dependency
         run: |
@@ -126,8 +127,8 @@ jobs:
 
       - name: Setup Github Actions git user
         run: |
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Actions"
+          git config --global user.email "airflow-oss-bot@astronomer.io"
+          git config --global user.name "airflow-oss-bot"
 
       - name: Export GitHub RC provider testing url
         id: export-rc-issue-url


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Even if we trigger the rc testing GitHub actions workflows and it creates a testing branch as expected, it won't trigger ci testing workflows due to https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow. Thus, we'll need to use personal access token for it.

<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

automatically trigger other ci testing workflows when rc testing branch is triggered

## Does this introduce a breaking change?
no

### Checklist
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
