### PR TITLE
 Ignore type for File _load_options attribute

### DIFF
--- a/python-sdk/src/astro/files/base.py
+++ b/python-sdk/src/astro/files/base.py
@@ -57,7 +57,7 @@ class File(LoggingMixin, Dataset):
         Setter of all the load_options. load_options is a container with for the custom option passed by user for a
          third-party integrations like pandas, azure etc.
         """
-        self._load_options = value
+        self._load_options = value  # type: ignore[misc]
 
     @property
     def location(self) -> BaseFileLocation:


### PR DESCRIPTION
main branch is broken see CI https://github.com/astronomer/astro-sdk/actions/runs/5830707808/job/15812653210
I had added a ignore in https://github.com/astronomer/astro-sdk/pull/1978 but for quick merge creating separate PR