### PR TITLE
Support loading metadata columns from stage into table for Snowflake

### DIFF
--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -388,4 +388,27 @@ with dag:
     )
     # [END load_file_example_28]
 
+    # [START load_file_example_29]
+    aql.load_file(
+        task_id="s3_to_snowflake_native_with_metadata_columns",
+        input_file=File("s3://astro-sdk/python_sdk/example_dags/data/sample.csv", conn_id=AWS_CONN_ID),
+        output_table=Table(
+            conn_id=SNOWFLAKE_CONN_ID,
+        ),
+        load_options=[
+            SnowflakeLoadOptions(
+                file_options={"SKIP_HEADER": 1, "SKIP_BLANK_LINES": True},
+                copy_options={"ON_ERROR": "CONTINUE"},
+                metadata_columns=[
+                    "METADATA$FILENAME",
+                    "METADATA$FILE_ROW_NUMBER",
+                    "METADATA$FILE_CONTENT_KEY",
+                    "METADATA$FILE_LAST_MODIFIED",
+                    "METADATA$START_SCAN_TIME",
+                ],
+            )
+        ],
+    )
+    # [END load_file_example_29]
+
     aql.cleanup()

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -112,7 +112,7 @@ all = [
     "apache-airflow-providers-google>=6.4.0",
     "apache-airflow-providers-ftp",
     "apache-airflow-providers-postgres",
-    "apache-airflow-providers-snowflake",
+    "apache-airflow-providers-snowflake>=3.2.0",
     "apache-airflow-providers-sftp",
     "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -112,7 +112,7 @@ all = [
     "apache-airflow-providers-google>=6.4.0",
     "apache-airflow-providers-ftp",
     "apache-airflow-providers-postgres",
-    "apache-airflow-providers-snowflake>=3.2.0",
+    "apache-airflow-providers-snowflake",
     "apache-airflow-providers-sftp",
     "smart-open[all]>=5.2.1",
     "snowflake-connector-python[pandas]",

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -647,7 +647,7 @@ class SnowflakeDatabase(BaseDatabase):
 
     def _get_copy_into_with_metadata_sql_statement(
         self, file_path: str, target_table: BaseTable, stage: SnowflakeStage
-    ):
+    ) -> str:
         """Return the sql statement for copy into with metadata columns."""
         if self.load_options is None or not self.load_options.metadata_columns:
             raise ValueError("Error: Requires metadata columns to be set in load options")

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -659,7 +659,7 @@ class SnowflakeDatabase(BaseDatabase):
             table_columns_count = self.hook.run(
                 sql_statement, parameters={"table_name": table_name}, handler=lambda cur: cur.fetchone()
             )[0]
-        except AttributeError:
+        except AttributeError:  # pragma: no cover
             # For apache-airflow-providers-snowflake <3.2.0.
             try:
                 table_columns_count = self.hook.run(sql_statement, parameters={"table_name": table_name})[0][

--- a/python-sdk/src/astro/databases/snowflake.py
+++ b/python-sdk/src/astro/databases/snowflake.py
@@ -652,8 +652,10 @@ class SnowflakeDatabase(BaseDatabase):
         if self.load_options is None or not self.load_options.metadata_columns:
             raise ValueError("Error: Requires metadata columns to be set in load options")
         table_name = target_table.name.upper()
-        sql_statement = f"SELECT count(*) from INFORMATION_SCHEMA.columns where table_name='{table_name}';"
-        table_columns_count = self.hook.run(sql_statement, handler=lambda cur: cur.fetchone())[0]
+        sql_statement = "SELECT count(*) from INFORMATION_SCHEMA.columns where table_name=%(table_name)s;"
+        table_columns_count = self.hook.run(
+            sql_statement, parameters={"table_name": table_name}, handler=lambda cur: cur.fetchone()
+        )[0]
         non_metadata_columns_count = table_columns_count - len(self.load_options.metadata_columns)
         select_non_metadata_columns = [f"${col}" for col in range(1, non_metadata_columns_count + 1)]
         select_columns_list = select_non_metadata_columns + self.load_options.metadata_columns

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from __future__ import annotations
 
 import attr
 
@@ -15,14 +15,14 @@ class LoadOptions:
         return attr.asdict(self)
 
 
-def contains_required_option(load_options: Optional[LoadOptions], option_name: str) -> bool:
+def contains_required_option(load_options: LoadOptions | None, option_name: str) -> bool:
     """
     Check required options in load_option class
     """
     return bool(load_options and getattr(load_options, option_name, None))
 
 
-def list_to_dict(value: Optional[List[LoadOptions]]) -> Optional[Dict[str, LoadOptions]]:
+def list_to_dict(value: list[LoadOptions] | None) -> dict[str, LoadOptions] | None:
     """
     Convert list object to dict
     """
@@ -33,9 +33,9 @@ def list_to_dict(value: Optional[List[LoadOptions]]) -> Optional[Dict[str, LoadO
 
 @attr.define
 class LoadOptionsList:
-    _load_options: Optional[Dict[str, LoadOptions]] = attr.field(converter=list_to_dict)
+    _load_options: dict[str, LoadOptions] | None = attr.field(converter=list_to_dict)
 
-    def get(self, option_class) -> Optional[LoadOptions]:
+    def get(self, option_class) -> LoadOptions | None:
         """
         Check `LOAD_OPTIONS_CLASS_NAME` attribute and select the correct load_options
         :param option_class: FileType | FileLocation | BaseDatabase
@@ -49,7 +49,7 @@ class LoadOptionsList:
                 break
         return cls
 
-    def get_by_class_name(self, option_class_name) -> Optional[LoadOptions]:
+    def get_by_class_name(self, option_class_name) -> LoadOptions | None:
         """
         Get load_option by class name
         :return:

--- a/python-sdk/src/astro/options.py
+++ b/python-sdk/src/astro/options.py
@@ -64,11 +64,14 @@ class SnowflakeLoadOptions(LoadOptions):
     """
     Load options to load file to snowflake using native approach.
 
+    :param copy_options: Specify one or more of the copy option as key-value pair. Read more at:
+        https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
     :param file_options: Depending on the file format type specified, use one or more of the
         format-specific options as key-value pair. Read more at:
         https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#format-type-options-formattypeoptions
-    :param copy_options: Specify one or more of the copy option as key-value pair. Read more at:
-        https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#copy-options-copyoptions
+    :param metadata_columns: Specify one or more metadata columns to be included from Snowflake stage into the target
+        table. Read more at:
+        https://docs.snowflake.com/en/user-guide/querying-metadata#example-3-loading-metadata-columns-into-a-table
     :param storage_integration: Specify the previously created Snowflake storage integration
     :param validation_mode: Defaults to `validation_mode=None`. This instructs the COPY command to validate the data
         files instead of loading them into the specified table; i.e. the COPY command tests the files for errors but
@@ -86,12 +89,18 @@ class SnowflakeLoadOptions(LoadOptions):
           to `CONTINUE` during the load.
 
         Read more at: https://docs.snowflake.com/en/sql-reference/sql/copy-into-table.html#optional-parameters
+
+    .. note::
+        If you specify `validation_mode` and `metadata_columns` together, `metadata_columns` will not be loaded as the
+        transformed `COPY INTO` command fails with SQL compilation error, and the load file operation will fall back to
+        the non-native approach using pandas.
     """
 
-    file_options: dict = attr.field(init=True, factory=dict)
     copy_options: dict = attr.field(init=True, factory=dict)
-    validation_mode: str = attr.field(default=None)
+    file_options: dict = attr.field(init=True, factory=dict)
+    metadata_columns: list[str] = attr.field(default=None)
     storage_integration: str = attr.field(default=None)
+    validation_mode: str = attr.field(default=None)
 
     def empty(self):
         return not self.file_options and not self.copy_options


### PR DESCRIPTION
Adds support to load metadata columns like METADATA$FILENAME, 
METADATA$FILE_ROW_NUMBER, etc. from stage into target table 
while natively loading files into Snowflake tables. Read more at: 
https://docs.snowflake.com/en/user-guide/querying-metadata#example-3-loading-metadata-columns-into-a-table

Note that, you cannot specify both `validation_mode` and 
`metadata_columns` together in the Snowflake load options 
because when we need to load `metadata_columns`, we need 
to explicitly name the metadata columns in the `COPY INTO` 
sql statement and such a transformed SQL statement does not 
allow specifying `VALIDATION_MODE` with it. It's a limitation 
for Snowflake queries.
The transformed SQL appears like in the snippet in the following link: 
https://docs.snowflake.com/en/user-guide/querying-metadata#example-3-loading-metadata-columns-into-a-table

closes: #1982