### PR TITLE
test(snowflake): add missing ORDER in column default

### DIFF
--- a/python-sdk/tests_integration/databases/test_snowflake.py
+++ b/python-sdk/tests_integration/databases/test_snowflake.py
@@ -87,7 +87,7 @@ def test_snowflake_create_table_with_columns(database_table_fixture):
         "NUMBER(38,0)",
         "COLUMN",
         "N",
-        "IDENTITY START 1 INCREMENT 1",
+        "IDENTITY START 1 INCREMENT 1 ORDER",
         "Y",
         "N",
         None,


### PR DESCRIPTION
# Description
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`python-sdk/tests_integration/databases/test_snowflake.py::test_snowflake_create_table_with_columns` fails

During testing on https://github.com/astronomer/astro-sdk/pull/2043, I found out there's this snowflake failure in integration test
<!--
Issues are required for both bug fixes and features.
Reference it using one of the following:

closes: #ISSUE
related: #ISSUE
-->


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `python-sdk/tests_integration/databases/test_snowflake.py::test_snowflake_create_table_with_columns` passes

## Does this introduce a breaking change?
no

### Checklist
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
