### PR TITLE
Set load_secret True in in Databricks S3 load file DAG

### DIFF
--- a/python-sdk/example_dags/example_load_file.py
+++ b/python-sdk/example_dags/example_load_file.py
@@ -339,6 +339,7 @@ with dag:
             DeltaLoadOptions(
                 copy_into_format_options={"header": "true", "inferSchema": "true"},
                 copy_into_copy_options={"mergeSchema": "true"},
+                load_secrets=True,
             )
         ],
     )


### PR DESCRIPTION
closes: https://github.com/astronomer/astro-sdk/issues/2070
closes: https://github.com/astronomer/astro-sdk/issues/2068

The default value for load_secret is false 
and because of that Databricks cluster was 
not able to access the AWS S3 file. 
I have changed that to True in this PR and 
the Airflow task is green now.
but not sure if this is because of some recent changes in Databricks.
