### PR TITLE
Fix gdrive_to_snowflake task in example_load_dag

### DIFF
--- a/.github/workflows/ci-astro-deploy.yml
+++ b/.github/workflows/ci-astro-deploy.yml
@@ -90,6 +90,7 @@ jobs:
       deployment_id:  ${{ secrets.ASTRO_DEPLOYMENT_ID_KE }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       bearer_token: ${{ secrets.BEARER_TOKEN }}
+      GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
 
   wait-for-deployment-to-be-ready-and-trigger-dags-for-astro-sdk-integration-tests-on-KE:
     if: |

--- a/.github/workflows/ci-astro-deploy.yml
+++ b/.github/workflows/ci-astro-deploy.yml
@@ -59,6 +59,7 @@ jobs:
       deployment_id:  ${{ secrets.ASTRO_DEPLOYMENT_ID }}
       bearer_token: ${{ secrets.BEARER_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
 
   wait-for-deployment-to-be-ready-and-trigger-dags-for-astro-sdk-integration-tests:
     if: |

--- a/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
+++ b/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
@@ -51,6 +51,8 @@ jobs:
             ${{ secrets.organization_id }} \
             ${{ secrets.deployment_id }} \
             ${{ secrets.bearer_token }} \
+            ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }} \
+          
 
       - name: send succeeded notification to Slack
         if: success() && github.event_name == 'workflow_dispatch'

--- a/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
+++ b/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
@@ -51,12 +51,12 @@ jobs:
         working-directory: python-sdk/tests_integration/astro_deploy
         run: |
           echo "deploying ${{ inputs.git_rev }} to ${{ inputs.environment_to_deploy }}"
+          echo "${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}" | base64 --decode > service-account-key.json
           bash deploy.sh  ${{ secrets.docker_registry }}\
             ${{ secrets.organization_id }} \
             ${{ secrets.deployment_id }} \
             ${{ secrets.bearer_token }} \
-            ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }} \
-          
+
 
       - name: send succeeded notification to Slack
         if: success() && github.event_name == 'workflow_dispatch'

--- a/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
+++ b/.github/workflows/reuse-wf-deploy-to-astro-cloud.yaml
@@ -29,6 +29,10 @@ on:  # yamllint disable-line rule:truthy
       SLACK_WEBHOOK_URL:
         description: 'slack webhook url for sending notification'
         required: true
+      GCP_SERVICE_ACCOUNT_JSON:
+        description: 'GCP service account json'
+        required: true
+
 
 jobs:
   deploy-to-astro-cloud:

--- a/python-sdk/tests_integration/astro_deploy/Dockerfile
+++ b/python-sdk/tests_integration/astro_deploy/Dockerfile
@@ -22,6 +22,7 @@ RUN pip install astronomer-starship-provider
 
 RUN mkdir -p ${AIRFLOW_HOME}/dags
 RUN mkdir -p ${AIRFLOW_HOME}/tests
+RUN mkdir -p ${AIRFLOW_HOME}/include
 
 COPY example_dags/ ${AIRFLOW_HOME}/dags/
 COPY master_dag.py/ ${AIRFLOW_HOME}/dags/
@@ -30,4 +31,4 @@ COPY astronomer_migration_dag.py/ ${AIRFLOW_HOME}/dags/
 COPY tests/ ${AIRFLOW_HOME}/tests/
 
 RUN ls ${AIRFLOW_HOME}/dags/
-RUN echo $GCP_SERVICE_ACCOUNT_JSON > $AIRFLOW_HOME/include/astro_sdk_gcp_cred.json"
+RUN echo $GCP_SERVICE_ACCOUNT_JSON > $AIRFLOW_HOME/include/astro_sdk_gcp_cred.json

--- a/python-sdk/tests_integration/astro_deploy/Dockerfile
+++ b/python-sdk/tests_integration/astro_deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:9.5.0-base
+FROM quay.io/astronomer/astro-runtime:10.0.0-base
 ARG GCP_SERVICE_ACCOUNT_JSON
 USER root
 RUN apt-get update -y && apt-get install -y git

--- a/python-sdk/tests_integration/astro_deploy/Dockerfile
+++ b/python-sdk/tests_integration/astro_deploy/Dockerfile
@@ -1,5 +1,4 @@
 FROM quay.io/astronomer/astro-runtime:10.0.0-base
-ARG GCP_SERVICE_ACCOUNT_JSON
 USER root
 RUN apt-get update -y && apt-get install -y git
 RUN apt-get install -y --no-install-recommends \
@@ -31,4 +30,4 @@ COPY astronomer_migration_dag.py/ ${AIRFLOW_HOME}/dags/
 COPY tests/ ${AIRFLOW_HOME}/tests/
 
 RUN ls ${AIRFLOW_HOME}/dags/
-RUN echo $GCP_SERVICE_ACCOUNT_JSON > $AIRFLOW_HOME/include/astro_sdk_gcp_cred.json
+COPY service-account-key.json  $AIRFLOW_HOME/include/astro_sdk_gcp_cred.json

--- a/python-sdk/tests_integration/astro_deploy/Dockerfile
+++ b/python-sdk/tests_integration/astro_deploy/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/astronomer/astro-runtime:9.5.0-base
-
+ARG GCP_SERVICE_ACCOUNT_JSON
 USER root
 RUN apt-get update -y && apt-get install -y git
 RUN apt-get install -y --no-install-recommends \
@@ -30,3 +30,4 @@ COPY astronomer_migration_dag.py/ ${AIRFLOW_HOME}/dags/
 COPY tests/ ${AIRFLOW_HOME}/tests/
 
 RUN ls ${AIRFLOW_HOME}/dags/
+RUN echo $GCP_SERVICE_ACCOUNT_JSON > $AIRFLOW_HOME/include/astro_sdk_gcp_cred.json"

--- a/python-sdk/tests_integration/astro_deploy/deploy.sh
+++ b/python-sdk/tests_integration/astro_deploy/deploy.sh
@@ -23,8 +23,7 @@ function echo_help() {
     echo "ASTRO_ORGANIZATION_ID         Astro cloud organization Id"
     echo "ASTRO_DEPLOYMENT_ID           Astro cloud Deployment id"
     echo "TOKEN     Astro workspace token"
-    echo "GCP_SERVICE_ACCOUNT_JSON     gcp service account json"
-    echo "bash deploy.sh <ASTRO_DOCKER_REGISTRY> <ASTRO_ORGANIZATION_ID>  <ASTRO_DEPLOYMENT_ID> <TOKEN> <GCP_SERVICE_ACCOUNT_JSON>"
+    echo "bash deploy.sh <ASTRO_DOCKER_REGISTRY> <ASTRO_ORGANIZATION_ID>  <ASTRO_DEPLOYMENT_ID> <TOKEN> "
 }
 
 if [ "$1" == "-h" ]; then
@@ -43,7 +42,6 @@ ASTRO_DOCKER_REGISTRY=$1
 ASTRO_ORGANIZATION_ID=$2
 ASTRO_DEPLOYMENT_ID=$3
 TOKEN=$4
-GCP_SERVICE_ACCOUNT_JSON=$5
 MASTER_DAG_DOCKERFILE="Dockerfile"
 
 
@@ -54,8 +52,7 @@ function deploy(){
     organization_id=$2
     deployment_id=$3
     TOKEN=$4
-    GCP_SERVICE_ACCOUNT_JSON=$5
-    dockerfile=$6
+    dockerfile=$5
 
     # Build image and deploy
     BUILD_NUMBER=$(awk 'BEGIN {srand(); print srand()}')
@@ -64,7 +61,7 @@ function deploy(){
     organization_id=$(echo $organization_id | tr '[:upper:]' '[:lower:]')
     deployment_id=$(echo $deployment_id | tr '[:upper:]' '[:lower:]')
     IMAGE_NAME=${docker_registry_astro}/${organization_id}/${deployment_id}:ci-${BUILD_NUMBER}
-    docker build --platform=linux/amd64 -t "${IMAGE_NAME}" -f "${SCRIPT_PATH}"/${dockerfile} "${SCRIPT_PATH}" --build-arg GCP_SERVICE_ACCOUNT_JSON="$GCP_SERVICE_ACCOUNT_JSON"
+    docker build --platform=linux/amd64 -t "${IMAGE_NAME}" -f "${SCRIPT_PATH}"/${dockerfile} "${SCRIPT_PATH}"
     docker login "${docker_registry_astro}" -u "cli" -p "$TOKEN"
     docker push "${IMAGE_NAME}"
 
@@ -112,6 +109,6 @@ cp -r "${PROJECT_PATH}"/example_dags "${SCRIPT_PATH}"/example_dags
 cp -r "${PROJECT_PATH}"/tests/data "${SCRIPT_PATH}"/tests/data
 
 
-deploy $ASTRO_DOCKER_REGISTRY $ASTRO_ORGANIZATION_ID $ASTRO_DEPLOYMENT_ID $TOKEN $GCP_SERVICE_ACCOUNT_JSON $MASTER_DAG_DOCKERFILE
+deploy $ASTRO_DOCKER_REGISTRY $ASTRO_ORGANIZATION_ID $ASTRO_DEPLOYMENT_ID $TOKEN $MASTER_DAG_DOCKERFILE
 
 clean

--- a/python-sdk/tests_integration/astro_deploy/deploy.sh
+++ b/python-sdk/tests_integration/astro_deploy/deploy.sh
@@ -23,7 +23,8 @@ function echo_help() {
     echo "ASTRO_ORGANIZATION_ID         Astro cloud organization Id"
     echo "ASTRO_DEPLOYMENT_ID           Astro cloud Deployment id"
     echo "TOKEN     Astro workspace token"
-    echo "bash deploy.sh <ASTRO_DOCKER_REGISTRY> <ASTRO_ORGANIZATION_ID>  <ASTRO_DEPLOYMENT_ID> <TOKEN>"
+    echo "GCP_SERVICE_ACCOUNT_JSON     gcp service account json"
+    echo "bash deploy.sh <ASTRO_DOCKER_REGISTRY> <ASTRO_ORGANIZATION_ID>  <ASTRO_DEPLOYMENT_ID> <TOKEN> <GCP_SERVICE_ACCOUNT_JSON>"
 }
 
 if [ "$1" == "-h" ]; then
@@ -42,6 +43,7 @@ ASTRO_DOCKER_REGISTRY=$1
 ASTRO_ORGANIZATION_ID=$2
 ASTRO_DEPLOYMENT_ID=$3
 TOKEN=$4
+GCP_SERVICE_ACCOUNT_JSON=$5
 MASTER_DAG_DOCKERFILE="Dockerfile"
 
 
@@ -52,7 +54,8 @@ function deploy(){
     organization_id=$2
     deployment_id=$3
     TOKEN=$4
-    dockerfile=$5
+    GCP_SERVICE_ACCOUNT_JSON=$5
+    dockerfile=$6
 
     # Build image and deploy
     BUILD_NUMBER=$(awk 'BEGIN {srand(); print srand()}')
@@ -61,7 +64,7 @@ function deploy(){
     organization_id=$(echo $organization_id | tr '[:upper:]' '[:lower:]')
     deployment_id=$(echo $deployment_id | tr '[:upper:]' '[:lower:]')
     IMAGE_NAME=${docker_registry_astro}/${organization_id}/${deployment_id}:ci-${BUILD_NUMBER}
-    docker build --platform=linux/amd64 -t "${IMAGE_NAME}" -f "${SCRIPT_PATH}"/${dockerfile} "${SCRIPT_PATH}"
+    docker build --platform=linux/amd64 -t "${IMAGE_NAME}" -f "${SCRIPT_PATH}"/${dockerfile} "${SCRIPT_PATH}" --build-arg GCP_SERVICE_ACCOUNT_JSON="$GCP_SERVICE_ACCOUNT_JSON"
     docker login "${docker_registry_astro}" -u "cli" -p "$TOKEN"
     docker push "${IMAGE_NAME}"
 
@@ -109,6 +112,6 @@ cp -r "${PROJECT_PATH}"/example_dags "${SCRIPT_PATH}"/example_dags
 cp -r "${PROJECT_PATH}"/tests/data "${SCRIPT_PATH}"/tests/data
 
 
-deploy $ASTRO_DOCKER_REGISTRY $ASTRO_ORGANIZATION_ID $ASTRO_DEPLOYMENT_ID $TOKEN $MASTER_DAG_DOCKERFILE
+deploy $ASTRO_DOCKER_REGISTRY $ASTRO_ORGANIZATION_ID $ASTRO_DEPLOYMENT_ID $TOKEN $GCP_SERVICE_ACCOUNT_JSON $MASTER_DAG_DOCKERFILE
 
 clean


### PR DESCRIPTION
The `gdrive_to_snowflake` task was failing because we hadn't set the `GOOGLE_APPLICATION_CREDENTIALS` in deployment. This pull request addresses the issue by creating a credential file using the Google Cloud Platform Service Account credentials from secrets, which is essential for the task.