### PR TITLE
Deploy only if RC is  released

### DIFF
--- a/.github/workflows/ci-astro-deploy.yml
+++ b/.github/workflows/ci-astro-deploy.yml
@@ -1,7 +1,7 @@
 name: "Astro Deploy"
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 19 * * *'
   workflow_dispatch:
     inputs:
       git_rev:

--- a/.github/workflows/ci-rc-test.yaml
+++ b/.github/workflows/ci-rc-test.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: check-airflow-provider-rc-release
     if: |
       always() &&
-      needs.check-airflow-provider-rc-release.result == 'success'
+      needs.check-airflow-provider-rc-release.outputs.rc_issue_url != ''
     uses:  ./.github/workflows/ci-astro-deploy.yml
     with:
        environment_to_deploy: "both"

--- a/.github/workflows/ci-rc-test.yaml
+++ b/.github/workflows/ci-rc-test.yaml
@@ -31,7 +31,7 @@ defaults:
 
 jobs:
   check-airflow-provider-rc-release:
-    uses: astronomer/astronomer-providers/.github/workflows/reuse-wf-check-rc-release.yaml@deploy-only-if-rc-released
+    uses: astronomer/astronomer-providers/.github/workflows/reuse-wf-check-rc-release.yaml@main
     with:
       rc_testing_branch: ${{ inputs.rc_testing_branch }}
       issue_url: ${{ inputs.issue_url }}

--- a/.github/workflows/ci-rc-test.yaml
+++ b/.github/workflows/ci-rc-test.yaml
@@ -31,7 +31,7 @@ defaults:
 
 jobs:
   check-airflow-provider-rc-release:
-    uses: astronomer/astronomer-providers/.github/workflows/reuse-wf-check-rc-release.yaml@main
+    uses: astronomer/astronomer-providers/.github/workflows/reuse-wf-check-rc-release.yaml@deploy-only-if-rc-released
     with:
       rc_testing_branch: ${{ inputs.rc_testing_branch }}
       issue_url: ${{ inputs.issue_url }}


### PR DESCRIPTION
Our RC test workflow was updating the deployment and running the master DAG even if there was no RC release. This PR only initiates deployment and DAG triggers when we have an RC release. Additionally, I have updated the cron of the deploy job to avoid both workflows running at the same time.