### PR TITLE
Fix the check for Github issue for manual job run

### DIFF
--- a/.github/workflows/ci-rc-test.yaml
+++ b/.github/workflows/ci-rc-test.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: check-airflow-provider-rc-release
     if: |
       always() &&
-      needs.check-airflow-provider-rc-release.outputs.rc_issue_url != ''
+      ${{ inputs.issue_url }} != ''
     uses:  ./.github/workflows/ci-astro-deploy.yml
     with:
        environment_to_deploy: "both"

--- a/.github/workflows/ci-rc-test.yaml
+++ b/.github/workflows/ci-rc-test.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: check-airflow-provider-rc-release
     if: |
       always() &&
-      ${{ inputs.issue_url }} != ''
+      needs.check-airflow-provider-rc-release.outputs.rc_issue_url != '' || ${{ inputs.issue_url }} != ''
     uses:  ./.github/workflows/ci-astro-deploy.yml
     with:
        environment_to_deploy: "both"


### PR DESCRIPTION
In the case of a manual run the astro-cloud deployment job was getting skipped.

CI job: https://github.com/astronomer/astro-sdk/actions/runs/7307530418