### PR TITLE
Fix Generate-Constraints job

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -626,8 +626,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10' '3.11']
-        airflow: [ '2.6', '2.7', '2.8']
+        python: [ '3.8', '3.9', '3.10' '3.11' ]
+        airflow: [ '2.6', '2.7', '2.8' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -626,7 +626,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.8', '3.9', '3.10' '3.11' ]
+        python: [ '3.8', '3.9', '3.10', '3.11' ]
         airflow: [ '2.6', '2.7', '2.8' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -626,8 +626,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ '3.7', '3.8', '3.9', '3.10' ]
-        airflow: [ '2.2.5', '2.3', '2.4', '2.5', '2.6', '2.7', '2.8']
+        python: [ '3.8', '3.9', '3.10' '3.11']
+        airflow: [ '2.6', '2.7', '2.8']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -150,8 +150,8 @@ def build_docs(session: nox.Session) -> None:
     session.run("make", "html")
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
-@nox.parametrize("airflow", ["2.2.5", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
+@nox.parametrize("airflow", ["2.6", "2.7", "2.8"])
 def generate_constraints(session: nox.Session, airflow) -> None:
     """Generate constraints file"""
     session.install("wheel")


### PR DESCRIPTION
Recently, I upgraded the Airflow version in CI https://github.com/astronomer/astro-sdk/pull/2084 after that the Generate-Constraints job failed. This PR will restrict to generate of the constraints for the min and max versions of Python and Airflow version which OSS support
