### PR TITLE
Disable the Benchmark schedule job

### DIFF
--- a/.github/workflows/ci-benchmark.yaml
+++ b/.github/workflows/ci-benchmark.yaml
@@ -3,8 +3,6 @@ on:
   pull_request:
     types:
       - labeled
-  schedule:
-    - cron: '0 0 * * 1'
 
 # This allows a subsequently queued workflow run to interrupt and cancel previous runs
 concurrency:
@@ -14,7 +12,6 @@ concurrency:
 jobs:
   Run-Benchmark:
     if: >-
-      (github.event_name == 'schedule' && github.event.schedule != '0 0 * * *') ||
       (
         github.event.label.name == 'run_benchmark' &&
         github.event.name != 'pull_request_target'


### PR DESCRIPTION
I'm thinking of disabling the scheduled benchmark job since we are not monitoring it at the moment. If needed still we will be able to run it on label 