### PR TITLE
Release 1.8.0

### DIFF
--- a/python-sdk/src/astro/__init__.py
+++ b/python-sdk/src/astro/__init__.py
@@ -1,6 +1,6 @@
 """A decorator that allows users to run SQL queries natively in Airflow."""
 
-__version__ = "1.7.0.dev1"
+__version__ = "1.8.0"
 
 
 # This is needed to allow Airflow to pick up specific metadata fields it needs

--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 try:
     from airflow.decorators.base import TaskDecorator
-except ImportError:
+except ImportError:  # pragma: no cover
     from airflow.decorators import _TaskDecorator as TaskDecorator  # type: ignore[attr-defined]
 
 import airflow

--- a/python-sdk/src/astro/sql/operators/transform.py
+++ b/python-sdk/src/astro/sql/operators/transform.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 try:
     from airflow.decorators.base import TaskDecorator
-except ImportError:
+except ImportError:  # pragma: no cover
     from airflow.decorators import _TaskDecorator as TaskDecorator  # type: ignore[attr-defined]
 
 from airflow.decorators.base import get_unique_task_id, task_decorator_factory


### PR DESCRIPTION
- Replace openlineage-airflow with Apache Airflow OSS provider apache-airflow-providers-openlineage #2103
- Bump up minimum version of apache-airflow to 2.7 #2103
- Bump up minimum version of Python to 3.8 #2103
- Limit pandas version to <2.2.0 due to an open issue for the release pandas==2.2.0 #2105 