### PR TITLE
Introduce sleep in tests to avoid bigquery rate limits

### DIFF
--- a/python-sdk/src/astro/sql/operators/raw_sql.py
+++ b/python-sdk/src/astro/sql/operators/raw_sql.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 try:
     from airflow.decorators.base import TaskDecorator
-except ImportError:
+except ImportError:  # pragma: no cover
     from airflow.decorators import _TaskDecorator as TaskDecorator  # type: ignore[attr-defined]
 
 import airflow

--- a/python-sdk/src/astro/sql/operators/transform.py
+++ b/python-sdk/src/astro/sql/operators/transform.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 try:
     from airflow.decorators.base import TaskDecorator
-except ImportError:
+except ImportError:  # pragma: no cover
     from airflow.decorators import _TaskDecorator as TaskDecorator  # type: ignore[attr-defined]
 
 from airflow.decorators.base import get_unique_task_id, task_decorator_factory


### PR DESCRIPTION
We're encountering difficulties achieving success with the 
integration test `test_aql_replace_existing_table` in our CI environment. 
The issue stems from `Google BigQuery` imposing rate limits on table 
operations—specifically, restricting them to `5` per `10` seconds per table. 
As a consequence, our CI pipeline fails, thereby hindering the release of 
version `1.18.0.`
The rate limits are documented here: 
https://cloud.google.com/bigquery/quotas#standard_tables

Initially, I contemplated skipping this test in CI. However, implementing 
a `10s` sleep for the problematic `BigQuery` test appears to 
circumvent the rate limit error, resulting in a fully successful CI build.

I will cherrypick this PR in the release branch.