### PR TITLE
Format pyproject to fix Test RC Job

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -85,7 +85,9 @@ ftp = [
     "apache-airflow-providers-ftp>=3.0.0",
     "smart-open>=5.2.1",
 ]
-openlineage = ["apache-airflow-providers-openlineage>=1.4.0"]
+openlineage = [
+    "apache-airflow-providers-openlineage>=1.4.0",
+]
 
 databricks = [
     "databricks-cli",


### PR DESCRIPTION
RC job does not replace the square bracket correctly if we have a dependency and square bracket in the same line for example 
`openlineage = ["apache-airflow-providers-openlineage==1.5.0rc1"]`
The workaround is to keep the square bracket and dependency in newline
```
openlineage = [
    "apache-airflow-providers-openlineage==1.5.0rc1",
]
```

This PR, format the pyproject.py to make the Test job green. I faced an issue while testing https://github.com/astronomer/astro-sdk/pull/2112 
