### PR TITLE
Fix regex for var `allowed_deserialization_classes`

### DIFF
--- a/python-sdk/noxfile.py
+++ b/python-sdk/noxfile.py
@@ -25,7 +25,7 @@ def test(session: nox.Session, airflow) -> None:
     """Run both unit and integration tests."""
     env = {
         "AIRFLOW_HOME": f"~/airflow-{airflow}-python-{session.python}",
-        "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": "airflow\\.* astro\\.*",
+        "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": "airflow.* astro.*",
     }
 
     session.install(f"apache-airflow~={airflow}")
@@ -73,7 +73,7 @@ def test_examples_by_dependency(session: nox.Session, extras):
 
     env = {
         "AIRFLOW_HOME": "~/airflow-latest-python-latest",
-        "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": "airflow\\.* astro\\.*",
+        "AIRFLOW__CORE__ALLOWED_DESERIALIZATION_CLASSES": "airflow.* astro.*",
     }
 
     session.install("-e", f".[{pypi_deps}]")


### PR DESCRIPTION
AstroSDK test seem to be failing on below PR
PR: https://github.com/astronomer/astro-sdk/pull/2124
CI Job: https://github.com/astronomer/astro-sdk/actions/runs/8158059156/job/22301955847?pr=2124