### PR TITLE
Remove databricks-sql-connector from pyproject.toml

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -92,8 +92,7 @@ openlineage = [
 databricks = [
     "databricks-cli",
     "apache-airflow-providers-databricks",
-    # TODO: Remove this once https://github.com/databricks/databricks-sql-python/pull/191 released
-    "databricks-sql-connector<2.9.0",
+    "databricks-sql-connector",
 ]
 
 mssql = [
@@ -121,8 +120,7 @@ all = [
     "sqlalchemy-bigquery>=1.3.0",
     "databricks-cli",
     "apache-airflow-providers-databricks",
-    # TODO: Remove this once https://github.com/databricks/databricks-sql-python/pull/191 released
-    "databricks-sql-connector<2.9.0",
+    "databricks-sql-connector",
     "s3fs",
     "protobuf",
     "apache-airflow-providers-openlineage>=1.4.0",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -119,7 +119,6 @@ all = [
     "sqlalchemy-bigquery>=1.3.0",
     "databricks-cli",
     "apache-airflow-providers-databricks",
-    "databricks-sql-connector",
     "s3fs",
     "protobuf",
     "apache-airflow-providers-openlineage>=1.4.0",

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -92,7 +92,6 @@ openlineage = [
 databricks = [
     "databricks-cli",
     "apache-airflow-providers-databricks",
-    "databricks-sql-connector",
 ]
 
 mssql = [


### PR DESCRIPTION
 We included the `databricks-sql-connector` dependency due to the reasons stated in the GitHub issue https://github.com/databricks/databricks-sql-python/issues/190. Now that this issue has been fixed, we should remove this dependency.