### PR TITLE
Disable schedule astro-deploy job and run the RC test scheduled job only once a day

### DIFF
--- a/.github/workflows/ci-astro-deploy.yml
+++ b/.github/workflows/ci-astro-deploy.yml
@@ -1,7 +1,10 @@
 name: "Astro Deploy"
 on:
-  schedule:
-    - cron: '0 19 * * *'
+  # Since we have a job to test upstream RCs, and additionally our CI runs integrations tests on every PR,
+  # we can disable this scheduled job for now. In the future, in case we need to run this on schedule, we
+  # can enable it again by uncommenting the below schedule.
+  # schedule:
+  #   - cron: '0 19 * * *'
   workflow_dispatch:
     inputs:
       git_rev:

--- a/.github/workflows/ci-rc-test.yaml
+++ b/.github/workflows/ci-rc-test.yaml
@@ -3,7 +3,7 @@ name: Test providers RC releases
 
 on: # yamllint disable-line rule:truthy
   schedule:
-    - cron: "0 0,12 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       rc_testing_branch:


### PR DESCRIPTION
Since we have a job to test upstream RCs, and additionally 
our CI runs integrations tests on every PR, we can disable 
the scheduled astro deploy job for now to reduce our cloud costs. 
In the future, in case we need to run this on schedule, we can 
enable it again by uncommenting the schedule.

Additionally, I am changing the RC test scheduled job to run only 
once a day instead of running it twice. We need to further 
optimise that job to trigger a deploy only when actual RCs are out. 
At the moment, we run the deploy and master DAG irrespective of 
RCs being out.