### PR TITLE
Fix CI issues related to the GitHub action `upload-artifact`

### DIFF
--- a/.github/workflows/ci-python-sdk.yaml
+++ b/.github/workflows/ci-python-sdk.yaml
@@ -1,7 +1,7 @@
 name: Build and test astro Python SDK
 on:
   push:
-    branches: [ 'main', 'release-**' ]
+    branches: [ 'main', 'release-**', 'fix-ci' ]
     paths:
       - 'python-sdk/**'
       - '.github/workflows/ci-python-sdk.yaml'
@@ -193,10 +193,11 @@ jobs:
       - run: pip3 install nox
       - run: nox -s test_examples_by_dependency -- --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage${{ matrix.group }}
           path: ./python-sdk/.coverage
+          include-hidden-files: true
     env:
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
@@ -258,10 +259,11 @@ jobs:
       - run: pip3 install nox
       - run: nox -s "test-${{ matrix.version }}(airflow='2.8')" -- tests/ --cov=src --cov-report=xml --cov-branch
       - name: Upload coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-unit-test
           path: ./python-sdk/.coverage
+          include-hidden-files: true
 
   Run-load-file-Integration-Airflow-2-8:
     if: >-
@@ -339,15 +341,17 @@ jobs:
       - run: nox -s "test-3.10(airflow='2.8')" -- tests_integration/ -k "test_load_file.py and not redshift" --splits 3 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - run: cat /tmp/durations-${{ matrix.group }}
       - name: Upload coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.group }}-integration-tests
           path: ./python-sdk/.coverage
+          include-hidden-files: true
       - name: Collect pytest durations
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pytest_durations_load_file_${{ matrix.group }}
           path: /tmp/durations-${{ matrix.group }}
+          include-hidden-files: true
     env:
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
@@ -440,15 +444,17 @@ jobs:
       - run: nox -s "test-3.10(airflow='2.8')" -- tests_integration/ -k "test_example_dags.py and not redshift" --splits 3 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - run: cat /tmp/durations-${{ matrix.group }}
       - name: Upload coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.group }}-integration-tests
           path: ./python-sdk/.coverage
+          include-hidden-files: true
       - name: Collect pytest durations
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pytest_durations_example_dags_${{ matrix.group }}
           path: /tmp/durations-${{ matrix.group }}
+          include-hidden-files: true
     env:
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
@@ -541,15 +547,16 @@ jobs:
       - run: nox -s "test-3.10(airflow='2.8')" -- tests_integration/ -k "not test_load_file.py and not test_example_dags.py and not redshift" --splits 11 --group ${{ matrix.group }} --store-durations --durations-path /tmp/durations-${{ matrix.group }} --cov=src --cov-report=xml --cov-branch
       - run: cat /tmp/durations-${{ matrix.group }}
       - name: Upload coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.group }}-integration-tests
           path: ./python-sdk/.coverage
       - name: Collect pytest durations
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pytest_durations_integration_tests_${{ matrix.group }}
           path: /tmp/durations-${{ matrix.group }}
+          include-hidden-files: true
     env:
       GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
       GOOGLE_APPLICATION_CREDENTIALS: /tmp/google_credentials.json
@@ -601,6 +608,7 @@ jobs:
           name: constraints-${{ matrix.python }}-${{ matrix.airflow }}
           path: ./python-sdk/constraints-${{ matrix.python }}-${{ matrix.airflow }}
           if-no-files-found: error
+          include-hidden-files: true
 
   Code-Coverage:
     if: github.event.action != 'labeled'


### PR DESCRIPTION
Fix CI issues, as experienced in https://github.com/astronomer/astro-sdk/actions/runs/10957200761/job/30424844404\?pr\=2187
```
Error: This request has automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

This PR also fixes the issue that would come after, similar to what we experienced in the [Ray Provider](https://github.com/astronomer/astro-provider-ray/pull/60) and [Cosmos](https://github.com/astronomer/astronomer-cosmos/pull/1210) projects.
